### PR TITLE
fix(scripts): respect activated python env and run vite from web/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 .PHONY: build build-service build-ui build-sdk-go dev quickstart dev-api dev-web deploy serve-ui status stop-all stop-dev stop-deploy test test-service test-ui test-ladybug verify verify-go verify-python verify-java guard ci clean
 
 VENV_PYTHON := .venv/bin/python
-PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
+CONDA_PYTHON := $(if $(CONDA_PREFIX),$(CONDA_PREFIX)/bin/python)
+VIRTUAL_ENV_PYTHON := $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV)/bin/python)
+PYTHON ?= $(or $(wildcard $(VENV_PYTHON)),$(wildcard $(CONDA_PYTHON)),$(wildcard $(VIRTUAL_ENV_PYTHON)),python3)
 GOCACHE ?= $(CURDIR)/.cache/go-build
 PNPM ?= pnpm
 API_ADDR ?= :8080

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -106,6 +106,7 @@ start_web_server() {
     exit 1
   fi
 
+  cd "${ROOT_DIR}/web"
   exec nohup env UMODEL_API_TARGET="${API_URL}" "${vite_bin}" --host 0.0.0.0 --port "${WEB_PORT}" --strictPort >> "${WEB_LOG}" 2>&1 < /dev/null
 }
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -74,16 +74,37 @@ check_go() {
 }
 
 check_python() {
-  if ! command_exists "${PYTHON_BIN}"; then
-    echo "ERROR: Python 3.10+ is required; ${PYTHON_BIN} was not found." >&2
-    return 1
+  if command_exists "${PYTHON_BIN}" && \
+     "${PYTHON_BIN}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+    echo "OK: $(${PYTHON_BIN} --version 2>&1) ($(command -v ${PYTHON_BIN}))"
+    return 0
   fi
 
-  if ! "${PYTHON_BIN}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
-    echo "ERROR: Python 3.10+ is required; found $(${PYTHON_BIN} --version 2>&1)." >&2
-    return 1
+  local detail
+  if command_exists "${PYTHON_BIN}"; then
+    detail="found $(${PYTHON_BIN} --version 2>&1) at $(command -v ${PYTHON_BIN})"
+  else
+    detail="${PYTHON_BIN} not found"
   fi
-  echo "OK: $(${PYTHON_BIN} --version 2>&1)"
+
+  local candidate
+  for candidate in \
+    "${CONDA_PREFIX:+${CONDA_PREFIX}/bin/python}" \
+    "${VIRTUAL_ENV:+${VIRTUAL_ENV}/bin/python}" \
+    "python"; do
+    [[ -z "${candidate}" ]] && continue
+    if command_exists "${candidate}" && \
+       "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+      echo "ERROR: Python 3.10+ is required; ${detail}." >&2
+      echo "       Compatible Python detected at $(command -v ${candidate}) ($(${candidate} --version 2>&1))." >&2
+      echo "       Retry with: make <target> PYTHON=${candidate}" >&2
+      echo "       Or adjust PATH so '${PYTHON_BIN}' resolves to it (an activated env may be behind /usr/bin in PATH)." >&2
+      return 1
+    fi
+  done
+
+  echo "ERROR: Python 3.10+ is required; ${detail}." >&2
+  return 1
 }
 
 check_node() {


### PR DESCRIPTION
Fixes #2

## Summary

- **Makefile**: `PYTHON` now prefers an activated conda/virtualenv interpreter (`\$CONDA_PREFIX/bin/python`, `\$VIRTUAL_ENV/bin/python`) before falling back to bare `python3`. On macOS, `conda activate` may end up behind `/usr/bin` in PATH, so `python3` was resolving to the system 3.9 even with a 3.12 env active and `make check-env` failed.
- **scripts/env.sh** `check_python`: when the configured interpreter fails the 3.10+ check, probe the same candidate set and print an actionable retry hint (\`make <target> PYTHON=...\`) plus a PATH-ordering tip, instead of just reporting the version error.
- **scripts/dev.sh** `start_web_server`: `cd` into `web/` before exec'ing vite. Without it, vite ran from the repo root, found no `index.html`/`vite.config.ts`, and answered `GET /` with 404. `curl -fsS` in `wait_for_web` therefore never succeeded, the 30s poll window expired, and `cleanup_after_failure` SIGTERM'd the API — producing the confusing \`Terminated: 15 ... exec nohup \"\${API_BIN}\"\` error on \`make quickstart\`.

## Reproduction (before)

\`\`\`
$ conda activate umodel        # python 3.12 env
$ make check-env
ERROR: Python 3.10+ is required; found Python 3.9.6.

$ make quickstart PYTHON=python
... OpenUModel API is healthy.
... OpenUModel Web did not become reachable at http://localhost:5173.
./scripts/dev.sh: line 151:  8678 Terminated: 15  ( ... exec nohup "\${API_BIN}" ... )
make: *** [dev] Error 1
\`\`\`

## Test plan

- [x] \`make check-env\` — picks up the conda interpreter automatically (\`OK: Python 3.12.13 (/.../envs/umodel/bin/python)\`).
- [x] \`make quickstart\` — API healthz 200, vite 200, clean stop via \`make stop-all\`.
- [x] \`make guard\` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
