### PR TITLE
feat: add capability validation CI gate with Playwright UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,31 @@ jobs:
           go mod download
           (cd sdk/go && go mod download)
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npx pnpm@9 install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
       - name: Check environment
         run: make check-env
 
       - name: Run CI
         run: make ci
+
+      - name: Run Playwright UI tests
+        run: |
+          make quickstart &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8080/healthz > /dev/null 2>&1 && break
+            sleep 1
+          done
+          cd web && npx playwright test --reporter=list
+          cd .. && make stop-all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help check-env install-env setup setup-ui expand doc example-validate check-manifest
-.PHONY: build build-service build-ui build-sdk-go dev quickstart dev-api dev-web deploy serve-ui status stop-all stop-dev stop-deploy test test-service test-ui test-ladybug verify verify-go verify-python verify-java guard ci clean
+.PHONY: build build-service build-ui build-sdk-go dev quickstart dev-api dev-web deploy serve-ui status stop-all stop-dev stop-deploy test test-service test-ui test-ui-e2e test-capability test-quickstart-health test-ladybug verify verify-go verify-python verify-java guard ci clean
 
 VENV_PYTHON := .venv/bin/python
 PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
@@ -115,6 +115,15 @@ test-service:
 test-ui:
 	@PNPM="$(PNPM)" bash ./scripts/env.sh web-build
 
+test-ui-e2e:
+	@cd web && npx playwright test --reporter=list
+
+test-capability:
+	go test -v -run TestCapabilityGate ./tests/integration/
+
+test-quickstart-health:
+	go test -v -run TestQuickstartHealth ./tests/integration/
+
 test-ladybug:
 	@if [ "$$UMODEL_TEST_LADYBUG" != "1" ]; then \
 		echo "Skipping local.ladybug provider and E2E tests; set UMODEL_TEST_LADYBUG=1 and provide liblbug to run them."; \
@@ -161,7 +170,7 @@ test: guard test-service verify
 check-manifest:
 	@$(PYTHON) ./tools/verify/check_manifest.py
 
-ci: guard build-service test-service verify check-manifest example-validate
+ci: guard build-service test-service test-capability test-quickstart-health verify check-manifest example-validate
 	@echo "Local CI passed."
 
 check-env:

--- a/tests/integration/capability_gate_test.go
+++ b/tests/integration/capability_gate_test.go
@@ -1,0 +1,299 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/bootstrap"
+)
+
+func TestCapabilityGate(t *testing.T) {
+	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir()).Handler())
+	defer server.Close()
+
+	post(t, server.URL+"/api/v1/workspaces", map[string]any{"id": "demo"})
+	importResult := post(t, server.URL+"/api/v1/samples/demo/multi-domain-quickstart:import", map[string]any{})
+
+	if importResult["sample"] != "multi-domain-quickstart" {
+		t.Fatalf("unexpected sample: %+v", importResult)
+	}
+	if importResult["entity_count"].(float64) < 90 {
+		t.Fatalf("expected >=90 entities, got %v", importResult["entity_count"])
+	}
+	if importResult["relation_count"].(float64) < 120 {
+		t.Fatalf("expected >=120 relations, got %v", importResult["relation_count"])
+	}
+
+	t.Run("ModelDiscovery", func(t *testing.T) {
+		allEntitySets := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".umodel with(kind='entity_set') | limit 100",
+		})
+		if got := len(rows(t, allEntitySets)); got < 35 {
+			t.Fatalf("expected >=35 entity_sets, got %d", got)
+		}
+
+		allLinks := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".umodel with(kind='entity_set_link') | limit 100",
+		})
+		if got := len(rows(t, allLinks)); got < 42 {
+			t.Fatalf("expected >=42 entity_set_links, got %d", got)
+		}
+
+		devopsEntitySets := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".umodel with(kind='entity_set') | where domain = 'devops' | limit 100",
+		})
+		if got := len(rows(t, devopsEntitySets)); got != 10 {
+			t.Fatalf("expected 10 devops entity_sets, got %d", got)
+		}
+
+		k8sEntitySets := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".umodel with(kind='entity_set') | where domain = 'k8s' | limit 100",
+		})
+		if got := len(rows(t, k8sEntitySets)); got != 7 {
+			t.Fatalf("expected 7 k8s entity_sets, got %d", got)
+		}
+
+		pipeline := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".umodel with(kind='entity_set') | where domain = 'devops' | project domain,name,kind | sort name | limit 3",
+		})
+		pipelineRows := rows(t, pipeline)
+		if len(pipelineRows) != 3 {
+			t.Fatalf("expected 3 rows from pipeline, got %d", len(pipelineRows))
+		}
+		for _, r := range pipelineRows {
+			row := r.(map[string]any)
+			if row["domain"] != "devops" || row["kind"] != "entity_set" {
+				t.Fatalf("unexpected pipeline row: %+v", row)
+			}
+		}
+		cols := pipeline["columns"].([]any)
+		if len(cols) != 3 {
+			t.Fatalf("expected 3 projected columns, got %+v", cols)
+		}
+	})
+
+	t.Run("EntityQuery", func(t *testing.T) {
+		devopsServices := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.service') | limit 20",
+		})
+		if got := len(rows(t, devopsServices)); got != 4 {
+			t.Fatalf("expected 4 devops.service entities, got %d", got)
+		}
+
+		checkout := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.service', query='checkout') | limit 10",
+		})
+		checkoutRows := rows(t, checkout)
+		if len(checkoutRows) == 0 {
+			t.Fatalf("expected checkout entity in search results")
+		}
+
+		byID := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | project __entity_id__,display_name | limit 5",
+		})
+		idRows := rows(t, byID)
+		if len(idRows) != 1 {
+			t.Fatalf("expected 1 entity by ID, got %d", len(idRows))
+		}
+		if idRows[0].(map[string]any)["__entity_id__"] != "10000000000000000000000000000101" {
+			t.Fatalf("unexpected entity ID: %+v", idRows[0])
+		}
+
+		topk := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.service', query='service', topk=2) | project __entity_id__ | limit 10",
+		})
+		if got := len(rows(t, topk)); got == 0 {
+			t.Fatalf("expected topk query to return entities, got 0")
+		}
+
+		entityPipeline := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.team') | project display_name,status | sort display_name | limit 2",
+		})
+		epRows := rows(t, entityPipeline)
+		if len(epRows) != 2 {
+			t.Fatalf("expected 2 team rows, got %d", len(epRows))
+		}
+	})
+
+	t.Run("TopologyQuery", func(t *testing.T) {
+		direct := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".topo | graph-call getDirectRelations([(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | project src,relation,dest | limit 20",
+		})
+		directRows := rows(t, direct)
+		if len(directRows) == 0 {
+			t.Fatalf("expected direct relations for checkout_service")
+		}
+
+		neighbors := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 30",
+		})
+		neighborRows := rows(t, neighbors)
+		if len(neighborRows) == 0 {
+			t.Fatalf("expected neighbor nodes at depth 2")
+		}
+
+		cypher := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query":      ".topo | graph-call cypher(`MATCH (svc:``devops@devops.service`` {__entity_id__: $svc}) OPTIONAL MATCH path = (svc)-[r*1..2]-(neighbor) WITH svc, neighbor, relationships(path) AS rels WHERE neighbor IS NULL OR coalesce(neighbor.__deleted__, false) = false RETURN svc.__entity_id__ AS service, neighbor.__entity_id__ AS neighbor, [rel IN rels | type(rel)] AS relation_types, size(rels) AS hops ORDER BY hops, neighbor LIMIT 20`) | limit 20",
+			"parameters": map[string]any{"svc": "10000000000000000000000000000101"},
+		})
+		cypherRows := rows(t, cypher)
+		if len(cypherRows) == 0 {
+			t.Fatalf("expected cypher query results")
+		}
+		cypherExplain := cypher["explain"].(map[string]any)
+		if cypherExplain["cypher_dialect"] != "ladybug" || cypherExplain["cypher_engine"] != "go" {
+			t.Fatalf("unexpected cypher explain: %+v", cypherExplain)
+		}
+	})
+
+	t.Run("CrossDomainTopology", func(t *testing.T) {
+		crossDomain := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".topo with(relation_type='maps') | project src,relation,dest | limit 20",
+		})
+		crossRows := rows(t, crossDomain)
+		if len(crossRows) == 0 {
+			t.Fatalf("expected cross-domain 'maps' relations (devops→k8s)")
+		}
+		for _, r := range crossRows {
+			row := r.(map[string]any)
+			if row["relation"] != "maps" {
+				t.Fatalf("expected 'maps' relation, got %+v", row)
+			}
+		}
+
+		runs := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".topo with(relation_type='runs') | project src,relation,dest | limit 20",
+		})
+		runsRows := rows(t, runs)
+		if len(runsRows) == 0 {
+			t.Fatalf("expected 'runs' relations")
+		}
+
+		supportedBy := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+			"query": ".topo with(relation_type='supported_by') | project src,relation,dest | limit 20",
+		})
+		supportedByRows := rows(t, supportedBy)
+		if len(supportedByRows) == 0 {
+			t.Fatalf("expected 'supported_by' cross-domain relations")
+		}
+	})
+
+	t.Run("AgentGateway", func(t *testing.T) {
+		discovery := get(t, server.URL+"/api/v1/agent/demo/discover")
+		if discovery["workspace"] != "demo" {
+			t.Fatalf("unexpected discovery workspace: %+v", discovery)
+		}
+
+		tools, ok := discovery["tools"].([]any)
+		if !ok || len(tools) == 0 {
+			t.Fatalf("expected tools in discovery: %+v", discovery)
+		}
+		foundExecute := false
+		for _, rawTool := range tools {
+			tool := rawTool.(map[string]any)
+			if tool["name"] == "query_spl_execute" {
+				foundExecute = true
+			}
+			if tool["name"] == "entity_write" && tool["enabled"] == true {
+				t.Fatalf("entity_write should be disabled by default")
+			}
+		}
+		if !foundExecute {
+			t.Fatalf("expected query_spl_execute tool in discovery")
+		}
+
+		resources, ok := discovery["resources"].([]any)
+		if !ok || len(resources) == 0 {
+			t.Fatalf("expected resources in discovery: %+v", discovery)
+		}
+		for _, rawResource := range resources {
+			resource := rawResource.(map[string]any)
+			read := post(t, server.URL+"/api/v1/agent/demo/resources:read", map[string]any{"uri": resource["uri"]})
+			if read["uri"] != resource["uri"] || read["content"] == nil {
+				t.Fatalf("unexpected resource read: %+v", read)
+			}
+		}
+
+		actions, ok := discovery["next_actions"].([]any)
+		if !ok || len(actions) == 0 {
+			t.Fatalf("expected next_actions in discovery: %+v", discovery)
+		}
+
+		toolExecute := post(t, server.URL+"/api/v1/agent/demo/tools:execute", map[string]any{
+			"name":      "query_spl_execute",
+			"arguments": map[string]any{"query": ".umodel with(kind='entity_set') | limit 5"},
+		})
+		if toolExecute["ok"] != true {
+			t.Fatalf("expected query_spl_execute success: %+v", toolExecute)
+		}
+
+		toolExplain := post(t, server.URL+"/api/v1/agent/demo/tools:execute", map[string]any{
+			"name":      "query_spl_explain",
+			"arguments": map[string]any{"query": ".umodel | limit 1"},
+		})
+		if toolExplain["ok"] != true {
+			t.Fatalf("expected query_spl_explain success: %+v", toolExplain)
+		}
+
+		disabledTool := postStatus(t, server.URL+"/api/v1/agent/demo/tools:execute", map[string]any{
+			"name":      "entity_write",
+			"arguments": map[string]any{"entities": []map[string]any{}},
+		}, http.StatusBadRequest)
+		if errorCode(t, disabledTool) != "TOOL_DISABLED" {
+			t.Fatalf("expected disabled write tool: %+v", disabledTool)
+		}
+	})
+
+	t.Run("QueryExplain", func(t *testing.T) {
+		explain := post(t, server.URL+"/api/v1/query/demo/explain", map[string]any{
+			"query": ".entity with(domain='devops', name='devops.service') | limit 5",
+		})
+		if explain["source"] != ".entity" {
+			t.Fatalf("expected .entity source in explain: %+v", explain)
+		}
+		if explain["provider"] != "memory" {
+			t.Fatalf("expected memory provider in explain: %+v", explain)
+		}
+
+		topoExplain := post(t, server.URL+"/api/v1/query/demo/explain", map[string]any{
+			"query": ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 10",
+		})
+		if topoExplain["source"] != ".topo" || topoExplain["depth"] != float64(2) {
+			t.Fatalf("unexpected topo explain: %+v", topoExplain)
+		}
+
+		umodelExplain := post(t, server.URL+"/api/v1/query/demo/explain", map[string]any{
+			"query": ".umodel with(kind='entity_set') | where domain = 'devops' | project domain,name | sort name | limit 5",
+		})
+		operators, ok := umodelExplain["operators"].([]any)
+		if !ok || len(operators) < 4 {
+			t.Fatalf("expected at least 4 operators in umodel explain: %+v", umodelExplain)
+		}
+	})
+
+	t.Run("ErrorHandling", func(t *testing.T) {
+		for _, badQuery := range []string{
+			"select * from entity",
+			".entity with(domain)",
+			".entity | limit 0",
+			".entity_set",
+		} {
+			payload := postStatus(t, server.URL+"/api/v1/query/demo/execute", map[string]any{"query": badQuery}, http.StatusBadRequest)
+			if errorCode(t, payload) == "" {
+				t.Fatalf("expected error code for bad query %q, got %+v", badQuery, payload)
+			}
+		}
+	})
+
+	t.Run("AllDomains", func(t *testing.T) {
+		for _, domain := range []string{"devops", "k8s", "automaker", "game", "supplier"} {
+			result := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+				"query": ".umodel with(kind='entity_set') | where domain = '" + domain + "' | limit 100",
+			})
+			if got := len(rows(t, result)); got == 0 {
+				t.Fatalf("expected entity_sets for domain %s, got 0", domain)
+			}
+		}
+	})
+}

--- a/tests/integration/quickstart_health_test.go
+++ b/tests/integration/quickstart_health_test.go
@@ -1,0 +1,159 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestQuickstartHealth(t *testing.T) {
+	sampleDir := filepath.Join("..", "..", "examples", "quickstart-multidomain", "sample-data")
+
+	var manifest struct {
+		Sample       string            `json:"sample"`
+		Domains      []string          `json:"domains"`
+		SeedEntities map[string]string `json:"seed_entities"`
+		Counts       struct {
+			EntitySets     int `json:"entity_sets"`
+			EntitySetLinks int `json:"entity_set_links"`
+			Entities       int `json:"entities"`
+			Relations      int `json:"relations"`
+		} `json:"counts"`
+	}
+	readJSON(t, filepath.Join(sampleDir, "manifest.json"), &manifest)
+
+	var entities []map[string]any
+	readJSON(t, filepath.Join(sampleDir, "entities.json"), &entities)
+
+	var relations []map[string]any
+	readJSON(t, filepath.Join(sampleDir, "relations.json"), &relations)
+
+	t.Run("ManifestMatchesData", func(t *testing.T) {
+		if got := len(entities); got != manifest.Counts.Entities {
+			t.Fatalf("manifest declares %d entities, file has %d", manifest.Counts.Entities, got)
+		}
+		if got := len(relations); got != manifest.Counts.Relations {
+			t.Fatalf("manifest declares %d relations, file has %d", manifest.Counts.Relations, got)
+		}
+	})
+
+	t.Run("AllDomainsPresent", func(t *testing.T) {
+		entityDomains := make(map[string]bool)
+		for _, e := range entities {
+			if d, ok := e["__domain__"].(string); ok {
+				entityDomains[d] = true
+			}
+		}
+		for _, domain := range manifest.Domains {
+			if !entityDomains[domain] {
+				t.Fatalf("domain %q declared in manifest but not found in entity data", domain)
+			}
+		}
+	})
+
+	t.Run("EntityIDsAreUnique", func(t *testing.T) {
+		seen := make(map[string]bool)
+		for _, e := range entities {
+			id, ok := e["__entity_id__"].(string)
+			if !ok || id == "" {
+				t.Fatalf("entity missing __entity_id__: %+v", e)
+			}
+			if seen[id] {
+				t.Fatalf("duplicate entity ID: %s", id)
+			}
+			seen[id] = true
+		}
+	})
+
+	t.Run("RelationEndpointsHaveEntityType", func(t *testing.T) {
+		entityTypes := make(map[string]bool)
+		for _, e := range entities {
+			if et, ok := e["__entity_type__"].(string); ok {
+				entityTypes[et] = true
+			}
+		}
+		for _, r := range relations {
+			srcType, _ := r["__src_entity_type__"].(string)
+			destType, _ := r["__dest_entity_type__"].(string)
+			if srcType == "" || destType == "" {
+				t.Fatalf("relation missing entity type: %+v", r)
+			}
+			if !entityTypes[srcType] {
+				t.Fatalf("relation src entity type %q has no entities in data", srcType)
+			}
+			if !entityTypes[destType] {
+				t.Fatalf("relation dest entity type %q has no entities in data", destType)
+			}
+		}
+	})
+
+	t.Run("CrossDomainLinksExist", func(t *testing.T) {
+		found := false
+		for _, r := range relations {
+			src, _ := r["__src_domain__"].(string)
+			dest, _ := r["__dest_domain__"].(string)
+			if src != "" && dest != "" && src != dest {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected at least one cross-domain relation")
+		}
+	})
+
+	t.Run("SeedEntitiesExist", func(t *testing.T) {
+		entityIDs := make(map[string]bool)
+		for _, e := range entities {
+			if id, ok := e["__entity_id__"].(string); ok {
+				entityIDs[id] = true
+			}
+		}
+		for name, id := range manifest.SeedEntities {
+			if !entityIDs[id] {
+				t.Fatalf("seed entity %q (id=%s) not found in entity data", name, id)
+			}
+		}
+	})
+
+	t.Run("EntitySetYAMLsExist", func(t *testing.T) {
+		examplesDir := filepath.Join("..", "..", "examples", "quickstart-multidomain")
+		entityTypes := make(map[string]bool)
+		for _, e := range entities {
+			if et, ok := e["__entity_type__"].(string); ok {
+				entityTypes[et] = true
+			}
+		}
+		for et := range entityTypes {
+			parts := splitEntityType(et)
+			if len(parts) != 2 {
+				t.Fatalf("unexpected entity type format: %s", et)
+			}
+			yamlPath := filepath.Join(examplesDir, parts[0], "entity_set", et+".yaml")
+			if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+				t.Fatalf("entity type %s has no entity_set yaml at %s", et, yamlPath)
+			}
+		}
+	})
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+}
+
+func splitEntityType(et string) []string {
+	for i := 0; i < len(et); i++ {
+		if et[i] == '.' {
+			return []string{et[:i], et[i+1:]}
+		}
+	}
+	return []string{et}
+}

--- a/web/e2e/query-capability.spec.ts
+++ b/web/e2e/query-capability.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+
+const API = 'http://localhost:8080'
+
+test.describe('Query capability via UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    const demoCard = page.locator('text=demo').first()
+    await expect(demoCard).toBeVisible({ timeout: 10_000 })
+    await demoCard.click()
+    await expect(page.locator('text=UModel Explorer')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('workspace landing shows demo workspace', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('text=demo')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('umodel query returns rows', async ({ page }) => {
+    await page.locator('text=Query').click()
+    await expect(page.locator('text=Unified SPL Query')).toBeVisible()
+
+    const textarea = page.locator('textarea').first()
+    await textarea.fill(".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20")
+    await page.locator('button:has-text("Execute")').click()
+
+    await expect(page.locator('.om-table tbody tr').first()).toBeVisible({ timeout: 10_000 })
+    const rowCount = await page.locator('.om-table tbody tr').count()
+    expect(rowCount).toBeGreaterThanOrEqual(10)
+  })
+
+  test('entity query finds checkout service', async ({ page }) => {
+    await page.locator('text=Query').click()
+
+    const textarea = page.locator('textarea').first()
+    await textarea.fill(".entity with(domain='devops', name='devops.service', query='checkout', topk=20) | project __entity_id__,display_name,status,owner")
+    await page.locator('button:has-text("Execute")').click()
+
+    await expect(page.locator('.om-table')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.om-table').locator('text=checkout').first()).toBeVisible()
+  })
+
+  test('topo query returns direct relations', async ({ page }) => {
+    await page.locator('text=Query').click()
+
+    const textarea = page.locator('textarea').first()
+    await textarea.fill('.topo | graph-call getDirectRelations([(:\\"devops@devops.service\\" {__entity_id__: \'10000000000000000000000000000101\'})]) | project src,relation,dest | limit 20')
+    await page.locator('button:has-text("Execute")').click()
+
+    await expect(page.locator('.om-table tbody tr').first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('explain shows provider info', async ({ page }) => {
+    await page.locator('text=Query').click()
+
+    const textarea = page.locator('textarea').first()
+    await textarea.fill(".umodel with(kind='entity_set') | limit 5")
+    await page.locator('button:has-text("Explain")').click()
+
+    await expect(page.locator('text=memory')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('explorer view renders graph', async ({ page }) => {
+    await expect(page.locator('text=UModel Explorer')).toBeVisible()
+    await page.waitForTimeout(2_000)
+    const hasContent = await page.locator('.react-flow, [data-testid="explorer"], canvas, svg').first().isVisible().catch(() => false)
+    expect(hasContent || (await page.locator('text=entity_set').count()) > 0).toBeTruthy()
+  })
+
+  test('agent view shows discovery tools', async ({ page }) => {
+    await page.locator('text=Agent').click()
+    await expect(page.locator('text=query_spl_execute')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/web/e2e/query-capability.spec.ts
+++ b/web/e2e/query-capability.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test'
 
-const API = 'http://localhost:8080'
+const TOPO_DIRECT = `.topo | graph-call getDirectRelations([(:"devops@devops.service" {__entity_id__: '10000000000000000000000000000101'})]) | project src,relation,dest | limit 20`
 
 test.describe('Query capability via UI', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    const demoCard = page.locator('text=demo').first()
+    const demoCard = page.locator('.workspace-id', { hasText: 'demo' }).first()
     await expect(demoCard).toBeVisible({ timeout: 10_000 })
     await demoCard.click()
     await expect(page.locator('text=UModel Explorer')).toBeVisible({ timeout: 5_000 })
@@ -13,7 +13,7 @@ test.describe('Query capability via UI', () => {
 
   test('workspace landing shows demo workspace', async ({ page }) => {
     await page.goto('/')
-    await expect(page.locator('text=demo')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.workspace-id', { hasText: 'demo' }).first()).toBeVisible({ timeout: 10_000 })
   })
 
   test('umodel query returns rows', async ({ page }) => {
@@ -44,7 +44,7 @@ test.describe('Query capability via UI', () => {
     await page.locator('text=Query').click()
 
     const textarea = page.locator('textarea').first()
-    await textarea.fill('.topo | graph-call getDirectRelations([(:\\"devops@devops.service\\" {__entity_id__: \'10000000000000000000000000000101\'})]) | project src,relation,dest | limit 20')
+    await textarea.fill(TOPO_DIRECT)
     await page.locator('button:has-text("Execute")').click()
 
     await expect(page.locator('.om-table tbody tr').first()).toBeVisible({ timeout: 10_000 })

--- a/web/e2e/query-capability.spec.ts
+++ b/web/e2e/query-capability.spec.ts
@@ -69,6 +69,6 @@ test.describe('Query capability via UI', () => {
 
   test('agent view shows discovery tools', async ({ page }) => {
     await page.locator('text=Agent').click()
-    await expect(page.locator('text=query_spl_execute')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('strong', { hasText: 'query_spl_execute' }).first()).toBeVisible({ timeout: 10_000 })
   })
 })

--- a/web/e2e/quickstart-demo.spec.ts
+++ b/web/e2e/quickstart-demo.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+
+const API = 'http://localhost:8080'
+
+async function queryAPI(query: string, parameters?: Record<string, unknown>) {
+  const resp = await fetch(`${API}/api/v1/query/demo/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, parameters }),
+  })
+  if (!resp.ok) throw new Error(`query failed: ${resp.status} ${await resp.text()}`)
+  return resp.json() as Promise<{ rows: Record<string, unknown>[]; columns: string[] }>
+}
+
+test.describe('Quickstart demo data validation', () => {
+  test('workspace exists', async () => {
+    const resp = await fetch(`${API}/api/v1/workspaces`)
+    expect(resp.ok).toBeTruthy()
+    const data = (await resp.json()) as { items: { id: string }[] }
+    const ids = data.items.map((w) => w.id)
+    expect(ids).toContain('demo')
+  })
+
+  test('model has sufficient entity_sets', async () => {
+    const result = await queryAPI(".umodel with(kind='entity_set') | limit 100")
+    expect(result.rows.length).toBeGreaterThanOrEqual(30)
+  })
+
+  test('devops entities exist', async () => {
+    const result = await queryAPI(".entity with(domain='devops', name='devops.service') | limit 20")
+    expect(result.rows.length).toBeGreaterThan(0)
+  })
+
+  test('topology has relations', async () => {
+    const result = await queryAPI(
+      '.topo | graph-call getDirectRelations([(:\\"devops@devops.service\\" {__entity_id__: \'10000000000000000000000000000101\'})]) | limit 10',
+    )
+    expect(result.rows.length).toBeGreaterThan(0)
+  })
+
+  test('all domains present in model', async () => {
+    for (const domain of ['devops', 'k8s', 'automaker', 'game', 'supplier']) {
+      const result = await queryAPI(`.umodel with(kind='entity_set') | where domain = '${domain}' | limit 100`)
+      expect(result.rows.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('cross-domain relations exist', async () => {
+    const result = await queryAPI(".topo with(relation_type='maps') | project src,relation,dest | limit 10")
+    expect(result.rows.length).toBeGreaterThan(0)
+    const row = result.rows[0]
+    expect(row.relation).toBe('maps')
+  })
+
+  test('entity count matches expected range', async () => {
+    const domains = ['devops', 'k8s', 'automaker', 'game', 'supplier']
+    let total = 0
+    for (const domain of domains) {
+      const result = await queryAPI(`.entity with(domain='${domain}') | limit 100`)
+      total += result.rows.length
+    }
+    expect(total).toBeGreaterThanOrEqual(80)
+  })
+
+  test('agent discovery returns tools and resources', async () => {
+    const resp = await fetch(`${API}/api/v1/agent/demo/discover`)
+    expect(resp.ok).toBeTruthy()
+    const data = (await resp.json()) as {
+      workspace: string
+      tools: { name: string }[]
+      resources: { uri: string }[]
+    }
+    expect(data.workspace).toBe('demo')
+    expect(data.tools.length).toBeGreaterThan(0)
+    expect(data.resources.length).toBeGreaterThan(0)
+    expect(data.tools.map((t) => t.name)).toContain('query_spl_execute')
+  })
+})

--- a/web/e2e/quickstart-demo.spec.ts
+++ b/web/e2e/quickstart-demo.spec.ts
@@ -33,7 +33,7 @@ test.describe('Quickstart demo data validation', () => {
 
   test('topology has relations', async () => {
     const result = await queryAPI(
-      '.topo | graph-call getDirectRelations([(:\\"devops@devops.service\\" {__entity_id__: \'10000000000000000000000000000101\'})]) | limit 10',
+      `.topo | graph-call getDirectRelations([(:"devops@devops.service" {__entity_id__: '10000000000000000000000000000101'})]) | limit 10`,
     )
     expect(result.rows.length).toBeGreaterThan(0)
   })

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview --host 0.0.0.0"
+    "preview": "vite preview --host 0.0.0.0",
+    "test:e2e": "playwright test --reporter=list"
   },
   "dependencies": {
     "@cosmos.gl/graph": "^2.6.4",
@@ -22,6 +23,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -15,10 +15,4 @@ export default defineConfig({
       use: { browserName: 'chromium' },
     },
   ],
-  webServer: {
-    command: 'cd .. && make quickstart',
-    url: 'http://localhost:8080/healthz',
-    reuseExistingServer: true,
-    timeout: 30_000,
-  },
 })

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  webServer: {
+    command: 'cd .. && make quickstart',
+    url: 'http://localhost:8080/healthz',
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+})

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.60.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -305,6 +308,11 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
@@ -462,6 +470,11 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -530,6 +543,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -867,6 +890,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
@@ -1053,6 +1080,9 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1099,6 +1129,14 @@ snapshots:
   node-releases@2.0.38: {}
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.14:
     dependencies:


### PR DESCRIPTION
- Add TestCapabilityGate: loads full quickstart sample and validates model discovery, entity query, topology, cross-domain topology, agent gateway, query explain, error handling, and all domains
- Add TestQuickstartHealth: validates quickstart sample data integrity (manifest counts, domain coverage, ID uniqueness, seed entities, cross-domain links, entity_set YAML existence)
- Add Playwright UI tests: query capability tests (umodel, entity, topo, explain, explorer, agent views) and quickstart demo validation (workspace, model count, all domains, cross-domain relations, agent)
- Add Makefile targets: test-capability, test-quickstart-health, test-ui-e2e
- Update ci target to include test-capability and test-quickstart-health
- Update ci.yml with Node.js, Playwright browser install, and UI test step