### PR TITLE
chore: drop "Open" prefix from OpenUModel and fix knowledge_config typo

### DIFF
--- a/cmd/umodel-server/main.go
+++ b/cmd/umodel-server/main.go
@@ -14,7 +14,7 @@ func main() {
 	addr := flag.String("addr", ":8080", "HTTP listen address")
 	dataRoot := flag.String("data", "data", "UModel data root")
 	provider := flag.String("graphstore", graphstore.DefaultProviderType, "GraphStore provider: local.ladybug, memory, or file.memory")
-	uiDir := flag.String("ui-dir", "", "Optional directory containing built OpenUModel web UI assets")
+	uiDir := flag.String("ui-dir", "", "Optional directory containing built UModel web UI assets")
 	quickStart := flag.Bool("quickstart", false, "Create a demo workspace and import bundled quickstart data before serving")
 	quickStartWorkspace := flag.String("quickstart-workspace", bootstrap.DefaultQuickStartWorkspaceID, "Workspace id used by --quickstart")
 	quickStartSample := flag.String("quickstart-sample", bootstrap.DefaultQuickStartSample, "Sample package imported by --quickstart")

--- a/docs/en/guides/web-ui.md
+++ b/docs/en/guides/web-ui.md
@@ -2,7 +2,7 @@
 
 中文：[Web UI 指南](../../zh/guides/web-ui.md)
 
-OpenUModel Web: local console for workspaces, model definitions, runtime data, Query Service behavior, and AgentGateway metadata.
+UModel Web: local console for workspaces, model definitions, runtime data, Query Service behavior, and AgentGateway metadata.
 
 
 ## Start

--- a/docs/en/ui-api.md
+++ b/docs/en/ui-api.md
@@ -1,4 +1,4 @@
-# OpenUModel Web UI API Map
+# UModel Web UI API Map
 
 中文：[Web UI API 对照](../zh/ui-api.md)
 

--- a/docs/en/ui-architecture.md
+++ b/docs/en/ui-architecture.md
@@ -1,12 +1,12 @@
-# OpenUModel Web UI Architecture
+# UModel Web UI Architecture
 
 中文：[Web UI 架构](../zh/ui-architecture.md)
 
 ## Product Shape
 
-OpenUModel Web: workspace-first local console. Flow: workspace chooser, workspace create/select, compact workbench. Workbench views: Explorer, Query, Imports & Writes, Agent, Settings, Data Store, and API Map.
+UModel Web: workspace-first local console. Flow: workspace chooser, workspace create/select, compact workbench. Workbench views: Explorer, Query, Imports & Writes, Agent, Settings, Data Store, and API Map.
 
-UI contract: public OpenUModel REST API only. No Aliyun internal packages, obviz libraries, cloud console SDKs, or Formily. Structured editing stays JSON-first for the open-source distribution.
+UI contract: public UModel REST API only. No Aliyun internal packages, obviz libraries, cloud console SDKs, or Formily. Structured editing stays JSON-first for the open-source distribution.
 
 ## Frontend Modules
 

--- a/docs/html/runbook_set.html
+++ b/docs/html/runbook_set.html
@@ -5241,7 +5241,7 @@ code {
 </div>
 </div>
 <div class="property-description">
-<div class="desc-item"><strong>中文：</strong>内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。</div>
+<div class="desc-item"><strong>中文：</strong>内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。</div>
 <div class="desc-item"><strong>English：</strong>Content type such as markdown, html, url, pdf. UModel built-in supported type is markdown.</div>
 </div>
 <div class="constraints-section">

--- a/docs/html_cn/runbook_set.html
+++ b/docs/html_cn/runbook_set.html
@@ -5069,7 +5069,7 @@ code {
 </div>
 </div>
 <div class="property-description">
-<div class="desc-item">内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。</div>
+<div class="desc-item">内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。</div>
 </div>
 <div class="constraints-section">
 <h6>约束条件：</h6>

--- a/docs/zh/guides/web-ui.md
+++ b/docs/zh/guides/web-ui.md
@@ -2,7 +2,7 @@
 
 English: [Web UI Guide](../../en/guides/web-ui.md)
 
-OpenUModel Web：面向 workspace、模型定义、运行时数据、Query Service 行为和 AgentGateway 元数据的本地控制台。
+UModel Web：面向 workspace、模型定义、运行时数据、Query Service 行为和 AgentGateway 元数据的本地控制台。
 
 
 ## 启动

--- a/docs/zh/ui-api.md
+++ b/docs/zh/ui-api.md
@@ -1,6 +1,6 @@
 # Web UI API 对照
 
-English: [OpenUModel Web UI API Map](../en/ui-api.md)
+English: [UModel Web UI API Map](../en/ui-api.md)
 
 Web UI 的每个界面只对应公开 REST 契约。
 

--- a/docs/zh/ui-architecture.md
+++ b/docs/zh/ui-architecture.md
@@ -1,12 +1,12 @@
 # Web UI 架构
 
-English: [OpenUModel Web UI Architecture](../en/ui-architecture.md)
+English: [UModel Web UI Architecture](../en/ui-architecture.md)
 
 ## 产品形态
 
-OpenUModel Web 是 workspace-first 的本地控制台。流程：workspace chooser，workspace 创建或选择，紧凑工作台。工作台视图包含 Explorer、Query、Imports & Writes、Agent、Settings、Data Store 和 API Map。
+UModel Web 是 workspace-first 的本地控制台。流程：workspace chooser，workspace 创建或选择，紧凑工作台。工作台视图包含 Explorer、Query、Imports & Writes、Agent、Settings、Data Store 和 API Map。
 
-UI 契约：只使用公开 OpenUModel REST API。不导入 Aliyun 内部包、obviz libraries、云控制台 SDK 或 Formily。开源发行版的结构化编辑路径保持 JSON-first。
+UI 契约：只使用公开 UModel REST API。不导入 Aliyun 内部包、obviz libraries、云控制台 SDK 或 Formily。开源发行版的结构化编辑路径保持 JSON-first。
 
 ## 前端模块
 

--- a/expanded_schemas/runbook_set.expanded.yaml
+++ b/expanded_schemas/runbook_set.expanded.yaml
@@ -1266,7 +1266,7 @@ versions:
                                 type: string
                     content_type:
                       description:
-                        zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+                        zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
                         en_us: >-
                           Content type such as markdown, html, url, pdf. UModel built-in supported type is markdown.
                       type: string

--- a/generated/java/src/main/java/com/umodel/shared/KnowledgeConfigV1.java
+++ b/generated/java/src/main/java/com/umodel/shared/KnowledgeConfigV1.java
@@ -79,7 +79,7 @@ public class KnowledgeConfigV1 implements UModelObject {
     }
 
     /**
-     * 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+     * 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
      */
     @JSONField(name = "content_type")
     private String contentType;

--- a/schemas/includes/knowledge_config.schema.yaml
+++ b/schemas/includes/knowledge_config.schema.yaml
@@ -70,7 +70,7 @@ versions:
                     type: string
         content_type:
           description: 
-            zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+            zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
             en_us: Content type such as markdown, html, url, pdf. UModel built-in supported type is markdown.
           type: string
           constraint:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,7 +73,7 @@ assert_pid_file_stale_or_absent() {
   local pid
   pid="$(cat "${DEPLOY_PID_FILE}" 2>/dev/null || true)"
   if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
-    echo "OpenUModel deploy already appears to be running with pid ${pid}." >&2
+    echo "UModel deploy already appears to be running with pid ${pid}." >&2
     echo "Use make status to inspect it or make stop-all before starting again." >&2
     exit 1
   fi
@@ -86,20 +86,20 @@ wait_for_api() {
 
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
     if ! kill -0 "${DEPLOY_PID}" >/dev/null 2>&1; then
-      echo "OpenUModel deploy server exited before becoming healthy." >&2
+      echo "UModel deploy server exited before becoming healthy." >&2
       tail -n 60 "${DEPLOY_LOG}" >&2 || true
       return 1
     fi
 
     if curl -fsS "${API_URL}/healthz" >/dev/null 2>&1; then
-      echo "OpenUModel deploy server is healthy."
+      echo "UModel deploy server is healthy."
       return 0
     fi
 
     sleep 0.5
   done
 
-  echo "OpenUModel deploy server did not become healthy at ${API_URL}/healthz." >&2
+  echo "UModel deploy server did not become healthy at ${API_URL}/healthz." >&2
   tail -n 60 "${DEPLOY_LOG}" >&2 || true
   return 1
 }
@@ -119,9 +119,9 @@ mkdir -p "${PID_DIR}" "${LOG_DIR}"
 assert_pid_file_stale_or_absent
 
 if is_enabled "${QUICKSTART}"; then
-  echo "Starting OpenUModel production server at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT}, quickstart=${QUICKSTART_WORKSPACE}/${QUICKSTART_SAMPLE})"
+  echo "Starting UModel production server at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT}, quickstart=${QUICKSTART_WORKSPACE}/${QUICKSTART_SAMPLE})"
 else
-  echo "Starting OpenUModel production server at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT})"
+  echo "Starting UModel production server at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT})"
 fi
 (
   cd "${ROOT_DIR}"
@@ -145,7 +145,7 @@ if ! wait_for_api; then
 fi
 
 cat <<EOF
-OpenUModel deploy is running in the background.
+UModel deploy is running in the background.
   App: ${API_URL}
   Log: ${DEPLOY_LOG}
 Use make status to monitor it and make stop-all to stop it.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -187,19 +187,19 @@ wait_for_api() {
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
     if ! kill -0 "${API_PID}" >/dev/null 2>&1; then
       wait "${API_PID}" || api_status="$?"
-      echo "OpenUModel API exited before becoming healthy (status ${api_status})." >&2
+      echo "UModel API exited before becoming healthy (status ${api_status})." >&2
       exit "${api_status}"
     fi
 
     if curl -fsS "${API_URL}/healthz" >/dev/null 2>&1; then
-      echo "OpenUModel API is healthy."
+      echo "UModel API is healthy."
       return
     fi
 
     sleep 0.5
   done
 
-  echo "OpenUModel API did not become healthy at ${API_URL}/healthz." >&2
+  echo "UModel API did not become healthy at ${API_URL}/healthz." >&2
   exit 1
 }
 
@@ -209,20 +209,20 @@ wait_for_web() {
 
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
     if ! kill -0 "${WEB_PID}" >/dev/null 2>&1; then
-      echo "OpenUModel Web exited before becoming reachable." >&2
+      echo "UModel Web exited before becoming reachable." >&2
       tail -n 40 "${WEB_LOG}" >&2 || true
       return 1
     fi
 
     if curl -fsS "${web_url}" >/dev/null 2>&1; then
-      echo "OpenUModel Web is reachable."
+      echo "UModel Web is reachable."
       return 0
     fi
 
     sleep 0.5
   done
 
-  echo "OpenUModel Web did not become reachable at ${web_url}." >&2
+  echo "UModel Web did not become reachable at ${web_url}." >&2
   tail -n 40 "${WEB_LOG}" >&2 || true
   return 1
 }
@@ -235,24 +235,24 @@ resolve_web_tooling
 ensure_port_free "API" "${API_PORT}"
 ensure_port_free "Web" "${WEB_PORT}"
 mkdir -p "${PID_DIR}" "${LOG_DIR}"
-assert_pid_file_stale_or_absent "OpenUModel API" "${API_PID_FILE}"
-assert_pid_file_stale_or_absent "OpenUModel Web" "${WEB_PID_FILE}"
+assert_pid_file_stale_or_absent "UModel API" "${API_PID_FILE}"
+assert_pid_file_stale_or_absent "UModel Web" "${WEB_PID_FILE}"
 
-echo "Installing OpenUModel Web dependencies..."
+echo "Installing UModel Web dependencies..."
 if ! (
   install_web_dependencies
 ); then
-  echo "OpenUModel Web dependency install failed. See ${WEB_LOG}." >&2
+  echo "UModel Web dependency install failed. See ${WEB_LOG}." >&2
   tail -n 40 "${WEB_LOG}" >&2 || true
   exit 1
 fi
 
 if is_enabled "${QUICKSTART}"; then
-  echo "Starting OpenUModel API at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT}, quickstart=${QUICKSTART_WORKSPACE}/${QUICKSTART_SAMPLE})"
+  echo "Starting UModel API at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT}, quickstart=${QUICKSTART_WORKSPACE}/${QUICKSTART_SAMPLE})"
 else
-  echo "Starting OpenUModel API at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT})"
+  echo "Starting UModel API at ${API_URL} (graphstore=${GRAPHSTORE}, data=${DATA_ROOT})"
 fi
-echo "Building OpenUModel API binary at ${API_BIN}"
+echo "Building UModel API binary at ${API_BIN}"
 mkdir -p "$(dirname "${API_BIN}")"
 (
   cd "${ROOT_DIR}"
@@ -279,7 +279,7 @@ if ! wait_for_api; then
   exit 1
 fi
 
-echo "Starting OpenUModel Web at http://localhost:${WEB_PORT}"
+echo "Starting UModel Web at http://localhost:${WEB_PORT}"
 (
   start_web_server
 ) &
@@ -292,7 +292,7 @@ if ! wait_for_web; then
 fi
 
 cat <<EOF
-OpenUModel dev is running in the background.
+UModel dev is running in the background.
   API: ${API_URL}
   Web: http://localhost:${WEB_PORT}
   API log: ${API_LOG}

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -101,7 +101,7 @@ if [[ -z "${API_PORT}" ]]; then
 fi
 
 cat <<EOF
-OpenUModel status
+UModel status
   graphstore: ${GRAPHSTORE}
   data root: ${DATA_ROOT}
   pid dir: ${PID_DIR}

--- a/sdk/go/umodel/shared_types.go
+++ b/sdk/go/umodel/shared_types.go
@@ -283,7 +283,7 @@ type KnowledgeConfigV1 struct {
 	Description *SemanticStringV1 `json:"description,omitempty" yaml:"description,omitempty"`
 	// ApplyPolicy 知识如何应用的配置。
 	ApplyPolicy *KnowledgeConfigV1ApplyPolicy `json:"apply_policy" yaml:"apply_policy"`
-	// ContentType 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+	// ContentType 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
 	ContentType string `json:"content_type" yaml:"content_type"`
 	// Content 知识内容，根据content_type可以是文本内容或URL地址。
 	Content string `json:"content,omitempty" yaml:"content,omitempty"`

--- a/sdk/python/umodel/shared_types.py
+++ b/sdk/python/umodel/shared_types.py
@@ -359,7 +359,7 @@ class KnowledgeConfigV1(UModelObject):
     description: Optional['SemanticStringV1'] = None
     # 知识如何应用的配置。
     apply_policy: Optional['KnowledgeConfigV1ApplyPolicy'] = None
-    # 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+    # 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
     content_type: Optional[str] = None
     # 知识内容，根据content_type可以是文本内容或URL地址。
     content: Optional[str] = None

--- a/tests/integration/http_flow_test.go
+++ b/tests/integration/http_flow_test.go
@@ -199,7 +199,7 @@ func TestHTTPSampleImportThenQuery(t *testing.T) {
 
 func TestHTTPServesSPAWhenUIDirConfigured(t *testing.T) {
 	uiDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(uiDir, "index.html"), []byte(`<html><body>OpenUModel UI</body></html>`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(uiDir, "index.html"), []byte(`<html><body>UModel UI</body></html>`), 0o644); err != nil {
 		t.Fatalf("write index: %v", err)
 	}
 	if err := os.Mkdir(filepath.Join(uiDir, "assets"), 0o755); err != nil {

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
-# OpenUModel Web UI
+# UModel Web UI
 
-OpenUModel Web is a small, open-source friendly React/Vite workspace UI for the public UModel REST API.
+UModel Web is a small, open-source friendly React/Vite workspace UI for the public UModel REST API.
 
 ## Development
 

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -1,8 +1,8 @@
-# OpenUModel Web UI
+# UModel Web UI
 
 English version: [README.md](README.md)
 
-OpenUModel Web 是面向公开 UModel REST API 的 React/Vite workspace UI。
+UModel Web 是面向公开 UModel REST API 的 React/Vite workspace UI。
 
 ## 开发
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light" />
-    <title>OpenUModel</title>
+    <title>UModel</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/features/explorer/ExplorerPage.tsx
+++ b/web/src/features/explorer/ExplorerPage.tsx
@@ -1538,7 +1538,7 @@ function DiffDialog({
         <header>
           <div>
             <strong>Submit Preview</strong>
-            <span>Review draft diff before writing to OpenUModel API.</span>
+            <span>Review draft diff before writing to UModel API.</span>
           </div>
           <button className="ume-icon-button subtle" onClick={onClose} type="button">
             <X size={15} />

--- a/web/src/features/settings/ApiMapPage.tsx
+++ b/web/src/features/settings/ApiMapPage.tsx
@@ -32,7 +32,7 @@ export function ApiMapPage() {
       >
         <div className="stack">
           <p className="muted" style={{ marginTop: 0 }}>
-            The UI is implemented entirely on public OpenUModel REST contracts. No internal packages, obviz modules, or cloud console APIs are required.
+            The UI is implemented entirely on public UModel REST contracts. No internal packages, obviz modules, or cloud console APIs are required.
           </p>
           <div style={{ overflow: 'auto' }}>
             <table className="om-table">

--- a/web/src/features/workspaces/WorkspaceLanding.tsx
+++ b/web/src/features/workspaces/WorkspaceLanding.tsx
@@ -162,7 +162,7 @@ export function WorkspaceLanding({
               Build the <span className="landing-gradient-text">world model</span> for digital twins.
             </h1>
             <p>
-              OpenUModel maps assets, systems, metrics, tools, and relationships into a living graph
+              UModel maps assets, systems, metrics, tools, and relationships into a living graph
               that agents can query, simulate, and evolve.
             </p>
           </div>
@@ -335,7 +335,7 @@ export function WorkspaceLanding({
           </div>
         </section>
 
-        <section className="landing-stage flow-stage" aria-label="OpenUModel product preview">
+        <section className="landing-stage flow-stage" aria-label="UModel product preview">
           <div className="flow-product-shell">
             <div className="flow-canvas-wrap">
               <ReactFlow
@@ -883,7 +883,7 @@ function CreateWorkspaceModal({
 }) {
   const [id, setId] = useState('demo')
   const [name, setName] = useState('Demo')
-  const [description, setDescription] = useState('Local OpenUModel workspace')
+  const [description, setDescription] = useState('Local UModel workspace')
   const [labels, setLabels] = useState('{\n  "env": "local"\n}')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')


### PR DESCRIPTION
## Summary

Narrowed per @qiansheng91's review: **UModel** is the project's primary brand name (used externally in docs, UI, CLI, prose), so the only normalization needed is to drop the legacy "Open" prefix from leftover `OpenUModel` mentions. All standalone `UModel` references stay as-is.

This PR therefore only does **OpenUModel → UModel**, plus the typo Copilot flagged on `schemas/includes/knowledge_config.schema.yaml:74`.

## Changes

**OpenUModel → UModel** (17 files):
- `cmd/umodel-server/main.go` — flag help text
- `scripts/dev.sh`, `scripts/status.sh`, `scripts/deploy.sh` — echo / log lines
- `web/index.html` — page `<title>`
- `web/README.md`, `web/README.zh-CN.md`
- `web/src/features/{settings/ApiMapPage,workspaces/WorkspaceLanding,explorer/ExplorerPage}.tsx` — UI strings
- `tests/integration/http_flow_test.go` — synthetic SPA body fixture
- `docs/en/{ui-api,ui-architecture,guides/web-ui}.md`
- `docs/zh/{ui-api,ui-architecture,guides/web-ui}.md`

**Typo fix** on `schemas/includes/knowledge_config.schema.yaml:74` — Chinese description had "UModel buildin 支持的类型为 markdown" while the English line correctly says "built-in supported type". Updated zh_cn to "UModel 内置支持的类型为 markdown". The same string is patched in the six downstream files where it had been carried through (so the diff stays consistent without running a full regen):
- `expanded_schemas/runbook_set.expanded.yaml`
- `sdk/python/umodel/shared_types.py`
- `sdk/go/umodel/shared_types.go`
- `generated/java/src/main/java/com/umodel/shared/KnowledgeConfigV1.java`
- `docs/html/runbook_set.html`, `docs/html_cn/runbook_set.html`

## Explicitly NOT changed

- `CHANGELOG.md`, `CHANGELOG.zh-CN.md` — history preserved.
- Every existing `UModel` mention — UModel is the primary brand and stays.
- All SDK identifiers, package paths, directory names, binary names.

Total diff: 24 files, +52 / -52 lines.

## Test plan

- [x] `make guard` — passes.
- [x] `make build-service` — passes.
- [x] `make test-service` — passes (all packages green).
- [x] `rg -n OpenUModel --glob '!CHANGELOG*'` — no hits.
- [x] `rg -n "buildin "` — no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)