### PR TITLE
feat(umodel): enforce schema-driven validation on every write path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,19 @@ expand:
 	@$(PYTHON) ./tools/generators/schema_python_generator_v2.py
 	@echo "Generating Java model SDK..."
 	@$(PYTHON) ./tools/generators/schema_java_generator_v2.py
+	@$(MAKE) schemas-embed
+
+schemas-embed:
+	@echo "Mirroring expanded schemas into internal/umodel/schemaspec/data/..."
+	@mkdir -p internal/umodel/schemaspec/data
+	@cp expanded_schemas/*.expanded.yaml internal/umodel/schemaspec/data/
+
+schemas-embed-check:
+	@if ! diff -r expanded_schemas/ internal/umodel/schemaspec/data/ --exclude='*.md' >/dev/null 2>&1; then \
+		echo "Embedded schemas under internal/umodel/schemaspec/data/ differ from expanded_schemas/. Run 'make schemas-embed' and commit."; \
+		diff -r expanded_schemas/ internal/umodel/schemaspec/data/ --exclude='*.md' | head -40; \
+		exit 1; \
+	fi
 
 doc:
 	@bash ./tools/converters/batch_convert_html.sh
@@ -172,7 +185,7 @@ test: guard test-service verify
 check-manifest:
 	@$(PYTHON) ./tools/verify/check_manifest.py
 
-ci: guard build-service test-service test-capability test-quickstart-health verify check-manifest example-validate
+ci: guard schemas-embed-check build-service test-service test-capability test-quickstart-health verify check-manifest example-validate
 	@echo "Local CI passed."
 
 check-env:

--- a/internal/agentgateway/service_test.go
+++ b/internal/agentgateway/service_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	"github.com/alibaba/UnifiedModel/internal/umodel"
 	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
 )
@@ -133,6 +135,50 @@ func TestReadResourcesDoNotLeakRuntimeResults(t *testing.T) {
 				t.Fatalf("resource leaked runtime result marker %q in %s: %s", leaked, resource.URI, text)
 			}
 		}
+	}
+}
+
+func TestUModelValidateSurfacesSchemaErrorsAndWarnings(t *testing.T) {
+	graph := graphstore.NewMemoryStore()
+	umodelSvc := umodel.NewService(graph)
+	svc := NewService(fakeQuery{}, WithWriteServices(umodelSvc, &fakeEntityStore{}))
+
+	// entity_set_link with bad shape: wrong field names + missing required entity_link_type.
+	result, err := svc.ExecuteTool(context.Background(), "demo", model.AgentToolCallRequest{
+		Name: "umodel_validate",
+		Arguments: map[string]any{"elements": []map[string]any{{
+			"kind":   "entity_set_link",
+			"domain": "demo",
+			"name":   "demo.bad",
+			"spec": map[string]any{
+				"source":        map[string]any{"domain": "demo", "name": "a"},
+				"destination":   map[string]any{"domain": "demo", "name": "b"},
+				"relation_type": "depends_on",
+			},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("umodel_validate: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected ok envelope, got %+v", result)
+	}
+	body, err := json.Marshal(result.Output)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	var validation model.ValidationResult
+	if err := json.Unmarshal(body, &validation); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if validation.Valid {
+		t.Fatalf("expected invalid, got %+v", validation)
+	}
+	if len(validation.Errors) == 0 || !strings.Contains(validation.Errors[0].Reason, "required") {
+		t.Fatalf("expected required-missing error, got %+v", validation.Errors)
+	}
+	if len(validation.Warnings) < 3 {
+		t.Fatalf("expected at least 3 warnings for unknown fields, got %+v", validation.Warnings)
 	}
 }
 

--- a/internal/umodel/import_test.go
+++ b/internal/umodel/import_test.go
@@ -28,7 +28,7 @@ func TestValidateAcceptsValidUModelElements(t *testing.T) {
 		Kind:   "entity_set",
 		Domain: "devops",
 		Name:   "devops.service",
-		Spec:   map[string]any{"fields": []any{map[string]any{"name": "service_id"}}},
+		Spec:   map[string]any{"fields": []any{map[string]any{"name": "service_id", "type": "string"}}},
 	}})
 	if err != nil {
 		t.Fatalf("validate: %v", err)

--- a/internal/umodel/schemaspec/data/aliyun_prometheus.expanded.yaml
+++ b/internal/umodel/schemaspec/data/aliyun_prometheus.expanded.yaml
@@ -1,0 +1,219 @@
+description:
+  zh_cn: 阿里云 Prometheus 实例的定义，用于描述阿里云 Prometheus 实例的配置和连接信息。
+  en_us: The aliyun_prometheus is used to define the aliyun prometheus instance.
+name: aliyun_prometheus
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - aliyun_prometheus
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        description:
+          zh_cn: 阿里云 Prometheus 的核心配置部分，定义监控实例的连接和采集参数。
+          en_us: The specification section containing Aliyun Prometheus configuration.
+        properties:
+          region:
+            description:
+              zh_cn: 阿里云 Prometheus 实例所属区域。
+              en_us: The region of the Aliyun Prometheus instance.
+            type: string
+            constraint:
+              required: true
+          instance_id:
+            description:
+              zh_cn: 阿里云 Prometheus 的实例ID。
+              en_us: The instance ID of Aliyun Prometheus.
+            type: string
+            constraint:
+              required: true
+          sls_project:
+            description:
+              zh_cn: 阿里云 Prometheus 数据存储所在的 SLS 项目名称。
+              en_us: The SLS project name where the Aliyun Prometheus data is stored.
+            type: string
+          sls_metricstore:
+            description:
+              zh_cn: 阿里云 Prometheus 数据存储所在的 SLS 时序库名称。
+              en_us: The SLS metricstore name where the Aliyun Prometheus data is stored.
+            type: string

--- a/internal/umodel/schemaspec/data/data_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/data_link.expanded.yaml
@@ -1,0 +1,321 @@
+description:
+  zh_cn: >-
+    DataLink 用于定义 EntitySet/Link 和 DataSet 之间的关系，同时也可以描述两个 DataSet 之间的关系。DataLink 必须包含源 DataSet 、目标 DataSet 和链接类型。
+  en_us: >-
+    DataLink is used to define the relationship between EntitySet/Link and DataSet, and also describe the relationship between
+    two DataSet. DataLink must contain the source DataSet, destination DataSet and link type.
+name: data_link
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - data_link
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identify of source Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: >
+                    The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+              filter:
+                description:
+                  zh_cn: >-
+                    对于源 Set 的过滤器，用于部分 Link 的场景，例如 EntitySet 中只有"region=cn-beijing"的实体存在此关联。该方式已废弃，请使用 filter_by_entity 替代。
+                  en_us: >-
+                    The filter of the source Set. It is used for some Link scenarios, such as only entities with "region=cn-beijing"
+                    in the EntitySet have this association. This method is deprecated, please use filter_by_entity instead.
+                type: string
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identify of the destination Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+          fields_mapping:
+            type: map
+            description:
+              zh_cn: 源 DataSet/EntitySet 和目标 DataSet 字段之间的映射关系。
+              en_us: >-
+                The mapping relationship between the fields of the source DataSet and the destination DataSet.
+            constraint:
+              map:
+                key:
+                  description:
+                    zh_cn: 源 DataSet/EntitySet 的字段名称。
+                    en_us: The field name of the source DataSet.
+                  type: string
+                value:
+                  description:
+                    zh_cn: 目标 DataSet 的字段名称。
+                    en_us: The field name of the destination DataSet.
+                  type: string
+          data_link_type:
+            description:
+              zh_cn: DataLink 的类型。值不能为空。值必须是以下之一：produce（产生）、related_to（有关联，即弱连接）。
+              en_us: >-
+                The type of the DataLink. The value cannot be empty. The value must be one of the following: produce, related_to.
+            type: enum
+            constraint:
+              enum:
+                values:
+                - produce
+                - related_to
+          data_filter:
+            description:
+              zh_cn: >
+                关联目标数据的过滤器，即目标 DataSet 中只有部分数据和源数据有关联。例如存在一个通用的MetricSet，包含各种调用类型的指标，而源实体可能是DBClient，则可通过 data_fiter = "type='db'"
+                过滤出所有 db 类型的指标。注意：data_filter 需要使用query类型的filter语法。此方式过于复杂，不建议使用。
+              en_us: >
+                The data filter, used to filter data. For example, there is a general MetricSet that contains various types
+                of metrics, and the source entity may be DBClient, then the metrics of all db types can be filtered out through
+                data_fiter = "type='db'". Note: data_filter needs to use query type filter syntax. This method is too complex
+                and is not recommended.
+            type: string
+        constraint:
+          required: true
+        description:
+          zh_cn: DataLink 的核心配置部分，定义 EntitySet、DataSet 之间的映射和关联规则。
+          en_us: >-
+            The specification section containing DataLink configuration, which defines the mapping and association rules between
+            EntitySet and DataSet.

--- a/internal/umodel/schemaspec/data/entity_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/entity_set.expanded.yaml
@@ -1,0 +1,736 @@
+name: entity_set
+description:
+  zh_cn: >-
+    EntitySet 用于定义实体，实体集是具有相同属性的实体的集合，类似于数据库中的表、编程中的类概念。在建模场景中，可根据需要定义关心的实体，例如IT可观测场景中，需要定义主机、容器、进程、应用、Code Repo、运维人员等。
+  en_us: >-
+    EntitySet is used to define the entity, which is a collection of entities that share the same properties. In the modeling
+    scenario, entities can be defined according to needs, such as in the IT observable scenario, it is necessary to define
+    entities such as hosts, containers, processes, applications, Code Repo, and operation and maintenance personnel.
+versions:
+- name: v1.0.0
+  description:
+    zh_cn: EntitySet 的核心配置部分，定义实体数据的结构和生命周期管理规则。
+    en_us: The specification section containing EntitySet configuration.
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - entity_set
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的字段列表。
+              en_us: The fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          time_field:
+            type: string
+            description:
+              zh_cn: 可观测数据的时间字段。一般要求时间字段为时间戳类型，支持秒、毫秒、微秒、纳秒。
+              en_us: >-
+                The time field of the TelemetryData. It is generally required to be a timestamp type, supporting seconds,
+                milliseconds, microseconds, and nanoseconds.
+            constraint:
+              required: false
+          display_field:
+            type: string
+            description:
+              zh_cn: 注意：定位和 `name_fields` 有一定重叠，字段已废弃，请使用 `name_fields` 字段第一个值替代。可观测数据的显示字段。即默认展示的字段。
+              en_us: >
+                Note: This field is deprecated. Please use the `name_fields` field instead. The display field of the TelemetryData.
+                It is the default displayed field.
+            release_stage: experimental
+          name_fields:
+            type: array
+            description:
+              zh_cn: >
+                可观测数据的显示字段。建议按照显示重要性配置先后顺序，前端、算法等在各类场景会根据特点自由选择，例如极窄/引用场景下只取name_fields的第一个值。 例如：服务操作实体，建议取值为 ["operation_name",
+                "service_name"]；
+                     K8s Pod 实体，建议取值为 ["pod_name", "namespace", "cluster"]。
+              en_us: >
+                The name fields of the TelemetryData. It is recommended to configure the display fields in order of importance.
+                Front-end, algorithms, etc. will freely choose according to the characteristics in various scenarios. For
+                example, for service operation entities, it is recommended to take ["operation_name", "service_name"]; For K8s
+                Pod entities, it is recommended to take ["pod_name", "namespace", "cluster"].
+            constraint:
+              array:
+                item:
+                  type: string
+          hidden_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的隐藏字段。即不用作展示的字段。
+              en_us: The hidden fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: string
+          tag_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的标签字段。标签字段默认聚合在一起显示和分析。
+              en_us: >-
+                The tag fields of the TelemetryData. The tag fields are aggregated by default for display and analysis.
+            constraint:
+              array:
+                item:
+                  type: string
+          ordered_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的排序字段。即当前数据集的排序字段。
+              en_us: >-
+                The ordered fields of the TelemetryData. It is the ordered field of the current data set.
+            constraint:
+              array:
+                item:
+                  type: string
+          default_order:
+            type: enum
+            description:
+              zh_cn: 可观测数据的默认排序。默认值为 asc。
+              en_us: The default order of the TelemetryData. The default value is asc.
+            constraint:
+              enum:
+                values:
+                - asc
+                - desc
+                default_value: asc
+          first_observed_time_field:
+            description:
+              zh_cn: >-
+                Entity 的首次被观测时间所在字段。参考：https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+              en_us: >-
+                The field containing the first observed time of the Entity. See: https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+            type: string
+          last_observed_time_field:
+            description:
+              zh_cn: >-
+                Entity 最近被观测时间所在字段。参考：https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+              en_us: >-
+                The field containing the last observed time of the Entity. See: https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+            type: string
+          primary_key_fields:
+            description:
+              zh_cn: Entity 的主键字段。值格式为唯一标识实体的字段名称列表。
+              en_us: >-
+                The primary key fields of the Entity. The value format is a list of field names that uniquely identify an
+                entity.
+            type: array
+            constraint:
+              array:
+                item:
+                  type: string
+          id_generator:
+            description:
+              zh_cn: >
+                Entity 的 ID 生成器。表示该 EntitySet 的ID如何通过PrimaryKeyFields 生成。该字段类型为 string，需要符合 SPL 的表达式语法，执行返回为 string。如果为空，则使用默认的生成方式：
+                lower(to_hex(md5(cast(join(primaryKeys, '#$#') as varbinary)))) ，即将 PrimaryKeyFields 拼接成字符串，然后进行 MD5 计算，再转换为小写字符串。
+              en_us: ''
+              ? >-
+                The ID generator of the Entity. The ID generator is used to generate the ID of the EntitySet based on the
+                PrimaryKeyFields. The type of the field is string, and it needs to conform to the expression syntax of SPL,
+                and the execution returns a string. If it is empty, the default generation method is used
+              : >-
+                lower(to_hex(md5(cast(join(primaryKeys, '#$#') as varbinary)))), which is to join the PrimaryKeyFields into
+                a string, then perform MD5 calculation, and then convert it to a lowercase string.
+            type: string
+            constraint:
+              required: false
+          keep_alive_seconds:
+            description:
+              zh_cn: >-
+                保持活跃的持续时间，在最后观测时间加上保活秒数后，Entity 将被视为消失。默认为3600秒（1小时）。参考：https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+              en_us: >
+                The duration to keep active is, after the last observed time plus the keep-alive seconds, the Entity  will
+                be considered as disappeared. Default is 3600 seconds (1 hour). See: https://alidocs.dingtalk.com/i/nodes/XPwkYGxZV347LdvpHaABmZXgJAgozOKL
+            type: number
+            constraint:
+              default_value: 3600
+          dynamic:
+            description:
+              zh_cn: >-
+                是否为动态生成，默认为false。为true时表示该实体为动态实体，会绑定 Storage，每次实体的内容由Storage 处获取，而非存储在 EntityStore 中。
+              en_us: >-
+                Whether the Entity is dynamically generated, default is false. If true, the Entity is a dynamic entity, which
+                will be bound to a Storage, and the content of the Entity will be obtained from the Storage, rather than being
+                stored in the EntityStore.
+            type: bool
+            constraint:
+              default_value: false
+        constraint:
+          required: true
+        description:
+          zh_cn: EntitySet 的核心配置部分，定义实体数据的结构和生命周期管理规则。
+          en_us: The specification section containing EntitySet configuration.

--- a/internal/umodel/schemaspec/data/entity_set_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/entity_set_link.expanded.yaml
@@ -1,0 +1,331 @@
+description:
+  zh_cn: >-
+    EntitySetLink 用于定义两个 EntitySet 之间的关系。EntitySetLink 必须包含源 EntitySet 、目标 EntitySet 和链接类型。
+  en_us: >-
+    EntitySetLink is used to define the relationship between two EntitySet. EntitySetLink must contain the source EntitySet,
+    destination EntitySet and link type.
+name: entity_set_link
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - entity_set_link
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identify of source Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: >
+                    The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+              filter:
+                description:
+                  zh_cn: >-
+                    对于源 Set 的过滤器，用于部分 Link 的场景，例如 EntitySet 中只有"region=cn-beijing"的实体存在此关联。该方式已废弃，请使用 filter_by_entity 替代。
+                  en_us: >-
+                    The filter of the source Set. It is used for some Link scenarios, such as only entities with "region=cn-beijing"
+                    in the EntitySet have this association. This method is deprecated, please use filter_by_entity instead.
+                type: string
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identify of the destination Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+          fields_mapping:
+            description:
+              zh_cn: EntitySetLink 的目标 EntitySet 字段映射。
+              en_us: The destination EntitySet fields mapping of the EntitySetLink.
+            type: map
+            constraint:
+              map:
+                key:
+                  description:
+                    zh_cn: 源 EntitySet 的字段名称。
+                    en_us: The field name of the source EntitySet.
+                  type: string
+                value:
+                  description:
+                    zh_cn: 目标 EntitySet 的字段名称。
+                    en_us: The field name of the destination EntitySet.
+                  type: string
+          constructor:
+            type: object
+            description:
+              zh_cn: EntitySetLink 的自动化生成配置。若配置了此字段，则后台会自动创建并维护任务，自动生成 EntitySetLink。
+              en_us: >-
+                The constructor configuration for EntitySetLink. If this field is configured, the background will automatically
+                create and maintain tasks to automatically generate EntitySetLink.
+          entity_link_type:
+            description:
+              zh_cn: >
+                EntityLinkSet 的链接类型。值不能为空。建议的取值有： - calls (调用) - runs (运行) - instance_of (实例) - parent_of (父级) - contains
+                (包含) - balances (平衡) - can_access (可访问) - clustered_by (集群化) - manages (管理) - monitors (监控) - sends_to (发送到)
+                - affects (影响) - related_to (关联到) - same_as (相同) - propagates_to (传播到) - indirectly_sends_to (间接发送到) - groups
+                (分组) - consists_of (组成) - serves (服务) - hosted_by (托管于) - use (使用) - exec (执行) - access (访问) - login (登录)
+              en_us: >
+                The type of the EntityLinkSet. The value cannot be empty. The recommended values are: - calls - runs - instance_of
+                - parent_of - contains - balances - can_access - clustered_by - manages - monitors - sends_to - affects -
+                related_to - same_as - propagates_to - indirectly_sends_to - groups - consists_of - serves - hosted_by - use
+                - exec - access - login
+            type: string
+            constraint:
+              required: true
+          dynamic:
+            description:
+              zh_cn: >-
+                是否为动态生成，默认为false。为true时表示该 EntitySetLink 为动态 Link，会绑定 Storage，每次 Link 的内容由Storage 处获取，而非存储在 EntityStore 中。
+              en_us: >-
+                Whether the EntitySetLink is dynamically generated, default is false. If true, the EntitySetLink is a dynamic
+                Link, which will be bound to a Storage, and the content of the Link will be obtained from the Storage, rather
+                than being stored in the EntityStore.
+            type: bool
+            constraint:
+              default_value: false
+        constraint:
+          required: true
+        description:
+          zh_cn: EntitySetLink 的核心配置部分，定义 EntitySet 之间的映射和关联规则。
+          en_us: >-
+            The specification section containing EntitySetLink configuration, which defines the mapping and association rules
+            between EntitySet.

--- a/internal/umodel/schemaspec/data/entity_source.expanded.yaml
+++ b/internal/umodel/schemaspec/data/entity_source.expanded.yaml
@@ -1,0 +1,225 @@
+description:
+  zh_cn: EntitySource 用于定义特定 Entity 数据的导入任务以及其源数据存储（如 SLS LogStore / MetricStore）。
+  en_us: >-
+    EntitySource defines the import job for a specific entity and its source storage (e.g. SLS LogStore / MetricStore).
+name: entity_source
+versions:
+- name: v1.0.0
+  description:
+    zh_cn: EntitySource 的核心配置部分，定义导入任务的调度方式以及源数据存储配置。
+    en_us: >-
+      The specification section containing EntitySource configuration, including scheduling and source storage.
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - entity_source
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        description:
+          zh_cn: EntitySource 的核心配置部分，定义导入任务的调度方式以及源数据存储。
+          en_us: >-
+            The specification section containing EntitySource configuration, including scheduling and source storage.
+        properties:
+          constructor:
+            type: map
+            description:
+              zh_cn: 导入任务的构造/调度配置，支持灵活扩展键值对。
+              en_us: >-
+                Constructor/scheduling configuration of the import job, supports flexible key-value pairs.
+            constraint:
+              required: true
+              map:
+                key:
+                  type: string
+                value:
+                  type: any
+          storages:
+            description:
+              zh_cn: 源数据存储配置列表，每个元素为一个 map，支持灵活扩展字段。
+              en_us: >-
+                List of source storage configurations, each element is a map supporting flexible fields.
+            type: array
+            constraint:
+              required: true
+              array:
+                item:
+                  type: map

--- a/internal/umodel/schemaspec/data/entity_source_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/entity_source_link.expanded.yaml
@@ -1,0 +1,283 @@
+description:
+  zh_cn: EntitySourceLink 用于定义 EntitySource 与 EntitySet 之间的关联关系。
+  en_us: >-
+    EntitySourceLink is used to define the relationship between EntitySource and EntitySet.
+name: entity_source_link
+versions:
+- name: v1.0.0
+  description:
+    zh_cn: EntitySourceLink 的初始版本，定义 EntitySource 与 EntitySet 之间的关联。
+    en_us: >-
+      Initial version of EntitySourceLink, defining the association between EntitySource and EntitySet.
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - entity_source_link
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identifier of the source Set. The value cannot be empty.
+            type: object
+            constraint:
+              required: true
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  enum:
+                    values:
+                    - entity_source
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 1
+                  max_len: 127
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identifier of the destination Set. The value cannot be empty.
+            type: object
+            constraint:
+              required: true
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  enum:
+                    values:
+                    - entity_set
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 1
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+        constraint:
+          required: true
+        description:
+          zh_cn: EntitySourceLink 的核心配置部分，连接 EntitySource 与 EntitySet。
+          en_us: >-
+            The specification section containing EntitySourceLink configuration, linking EntitySource and EntitySet.

--- a/internal/umodel/schemaspec/data/event_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/event_set.expanded.yaml
@@ -1,0 +1,695 @@
+description:
+  zh_cn: EventSet 用于定义事件，事件集是具有相同属性的事件的集合。
+  en_us: >-
+    EventSet is a collection of related events that share certain common attributes or characteristics.
+name: event_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - event_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的字段列表。
+              en_us: The fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          time_field:
+            type: string
+            description:
+              zh_cn: 可观测数据的时间字段。一般要求时间字段为时间戳类型，支持秒、毫秒、微秒、纳秒。
+              en_us: >-
+                The time field of the TelemetryData. It is generally required to be a timestamp type, supporting seconds,
+                milliseconds, microseconds, and nanoseconds.
+            constraint:
+              required: false
+          display_field:
+            type: string
+            description:
+              zh_cn: 注意：定位和 `name_fields` 有一定重叠，字段已废弃，请使用 `name_fields` 字段第一个值替代。可观测数据的显示字段。即默认展示的字段。
+              en_us: >
+                Note: This field is deprecated. Please use the `name_fields` field instead. The display field of the TelemetryData.
+                It is the default displayed field.
+            release_stage: experimental
+          name_fields:
+            type: array
+            description:
+              zh_cn: >
+                可观测数据的显示字段。建议按照显示重要性配置先后顺序，前端、算法等在各类场景会根据特点自由选择，例如极窄/引用场景下只取name_fields的第一个值。 例如：服务操作实体，建议取值为 ["operation_name",
+                "service_name"]；
+                     K8s Pod 实体，建议取值为 ["pod_name", "namespace", "cluster"]。
+              en_us: >
+                The name fields of the TelemetryData. It is recommended to configure the display fields in order of importance.
+                Front-end, algorithms, etc. will freely choose according to the characteristics in various scenarios. For
+                example, for service operation entities, it is recommended to take ["operation_name", "service_name"]; For K8s
+                Pod entities, it is recommended to take ["pod_name", "namespace", "cluster"].
+            constraint:
+              array:
+                item:
+                  type: string
+          hidden_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的隐藏字段。即不用作展示的字段。
+              en_us: The hidden fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: string
+          tag_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的标签字段。标签字段默认聚合在一起显示和分析。
+              en_us: >-
+                The tag fields of the TelemetryData. The tag fields are aggregated by default for display and analysis.
+            constraint:
+              array:
+                item:
+                  type: string
+          ordered_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的排序字段。即当前数据集的排序字段。
+              en_us: >-
+                The ordered fields of the TelemetryData. It is the ordered field of the current data set.
+            constraint:
+              array:
+                item:
+                  type: string
+          default_order:
+            type: enum
+            description:
+              zh_cn: 可观测数据的默认排序。默认值为 asc。
+              en_us: The default order of the TelemetryData. The default value is asc.
+            constraint:
+              enum:
+                values:
+                - asc
+                - desc
+                default_value: asc
+          entity_fields:
+            description:
+              zh_cn: 实体字段，用于标识实体的 ID、域和类型
+              en_us: Entity fields, used to identify the ID, domain and type of entity
+            type: object
+            properties:
+              entity_id:
+                description:
+                  zh_cn: 实体 ID 字段
+                  en_us: Entity ID field, used to identify the ID of entity
+                type: string
+                constraint:
+                  default_value: __entity_id__
+              domain:
+                description:
+                  zh_cn: 实体所属的域字段
+                  en_us: Domain field which entity belongs to
+                type: string
+                constraint:
+                  default_value: __domain__
+              entity_type:
+                description:
+                  zh_cn: 实体类型字段，用于标识实体的类型
+                  en_us: Entity type field, used to identify the type of entity
+                type: string
+                constraint:
+                  default_value: __entity_type__
+        constraint:
+          required: true
+        description:
+          zh_cn: EventSet 的核心配置部分，定义事件数据的结构和处理方式。
+          en_us: The specification section containing EventSet configuration.

--- a/internal/umodel/schemaspec/data/explorer.expanded.yaml
+++ b/internal/umodel/schemaspec/data/explorer.expanded.yaml
@@ -1,0 +1,216 @@
+description: >
+  en_us: The Explorer module is used to define the explorer. zh_cn: Explorer 模块用于定义 Explorer。
+name: explorer
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - explorer
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        properties:
+          type:
+            type: string
+            description:
+              zh_cn: Explorer 的类型。
+              en_us: The kind of explorer.
+            constraint:
+              required: true
+          query:
+            type: string
+            description:
+              zh_cn: Explorer 的默认查询。
+              en_us: The default query of explorer.
+            constraint:
+              required: false
+          config:
+            type: map
+            description:
+              zh_cn: Explorer 的配置动态。
+              en_us: The config dynamic of explorer.
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: any

--- a/internal/umodel/schemaspec/data/explorer_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/explorer_link.expanded.yaml
@@ -1,0 +1,302 @@
+description: >
+  zh_cn: Explorer 链接模块用于存储 Dataset 和 Explorer 之间的链接信息。 en_us: The Explorer Link module is used to store the link information
+  between dataset and Explorer.
+name: explorer_link
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - explorer_link
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identify of source Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: >
+                    The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+              filter:
+                description:
+                  zh_cn: >-
+                    对于源 Set 的过滤器，用于部分 Link 的场景，例如 EntitySet 中只有"region=cn-beijing"的实体存在此关联。该方式已废弃，请使用 filter_by_entity 替代。
+                  en_us: >-
+                    The filter of the source Set. It is used for some Link scenarios, such as only entities with "region=cn-beijing"
+                    in the EntitySet have this association. This method is deprecated, please use filter_by_entity instead.
+                type: string
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identify of the destination Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+          token_mapping:
+            type: map
+            description:
+              zh_cn: 源 Dataset 和目标 Explorer 之间的字段映射关系。
+              en_us: >-
+                The mapping relationship between the fields of the source dataset set and the destination explorer
+          token_replace:
+            type: map
+            description:
+              zh_cn: 源 Dataset 和目标 Explorer 之间的字段替换关系。
+              en_us: >-
+                The replace relationship between the fields of the source dataset set and the destination explorer
+            constraint:
+              map:
+                key:
+                  type: string
+                  description:
+                    zh_cn: 替换 Dashboard 中的字段名称。
+                    en_us: Replace key name in dashboard
+                value:
+                  type: string
+                  description:
+                    zh_cn: EntitySet 字段名称。
+                    en_us: Entity set filed name
+          config:
+            type: map
+            description:
+              zh_cn: Explorer 的配置动态。
+              en_us: The config dynamic of explorer.
+        constraint:
+          required: true

--- a/internal/umodel/schemaspec/data/external_storage.expanded.yaml
+++ b/internal/umodel/schemaspec/data/external_storage.expanded.yaml
@@ -1,0 +1,228 @@
+description:
+  zh_cn: 外部存储，用于存放自定义存储的详细信息。
+  en_us: External storage, used to store details of custom storage.
+name: external_storage
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - external_storage
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        properties:
+          type:
+            description:
+              zh_cn: 外部存储的类型。
+              en_us: The type of the external storage.
+            type: string
+            constraint:
+              required: true
+          name:
+            description:
+              zh_cn: 外部存储的名称。
+              en_us: The name of the external storage.
+            type: string
+            constraint:
+              required: true
+          properties:
+            description:
+              zh_cn: 外部存储的详细信息，以键值对形式存储。
+              en_us: Details of the external storage, stored as key-value pairs.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
+          tags:
+            description:
+              zh_cn: 用于表示该外部存储的标签。
+              en_us: This field is used to represent the tags of the external storage.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string

--- a/internal/umodel/schemaspec/data/log_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/log_set.expanded.yaml
@@ -1,0 +1,668 @@
+description:
+  zh_cn: LogSet 用于定义日志，日志集是具有相同属性的日志的集合。
+  en_us: >-
+    LogSet is a collection of related log entries that share certain common attributes or characteristics.
+name: log_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - log_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的字段列表。
+              en_us: The fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          time_field:
+            type: string
+            description:
+              zh_cn: 可观测数据的时间字段。一般要求时间字段为时间戳类型，支持秒、毫秒、微秒、纳秒。
+              en_us: >-
+                The time field of the TelemetryData. It is generally required to be a timestamp type, supporting seconds,
+                milliseconds, microseconds, and nanoseconds.
+            constraint:
+              required: false
+          display_field:
+            type: string
+            description:
+              zh_cn: 注意：定位和 `name_fields` 有一定重叠，字段已废弃，请使用 `name_fields` 字段第一个值替代。可观测数据的显示字段。即默认展示的字段。
+              en_us: >
+                Note: This field is deprecated. Please use the `name_fields` field instead. The display field of the TelemetryData.
+                It is the default displayed field.
+            release_stage: experimental
+          name_fields:
+            type: array
+            description:
+              zh_cn: >
+                可观测数据的显示字段。建议按照显示重要性配置先后顺序，前端、算法等在各类场景会根据特点自由选择，例如极窄/引用场景下只取name_fields的第一个值。 例如：服务操作实体，建议取值为 ["operation_name",
+                "service_name"]；
+                     K8s Pod 实体，建议取值为 ["pod_name", "namespace", "cluster"]。
+              en_us: >
+                The name fields of the TelemetryData. It is recommended to configure the display fields in order of importance.
+                Front-end, algorithms, etc. will freely choose according to the characteristics in various scenarios. For
+                example, for service operation entities, it is recommended to take ["operation_name", "service_name"]; For K8s
+                Pod entities, it is recommended to take ["pod_name", "namespace", "cluster"].
+            constraint:
+              array:
+                item:
+                  type: string
+          hidden_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的隐藏字段。即不用作展示的字段。
+              en_us: The hidden fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: string
+          tag_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的标签字段。标签字段默认聚合在一起显示和分析。
+              en_us: >-
+                The tag fields of the TelemetryData. The tag fields are aggregated by default for display and analysis.
+            constraint:
+              array:
+                item:
+                  type: string
+          ordered_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的排序字段。即当前数据集的排序字段。
+              en_us: >-
+                The ordered fields of the TelemetryData. It is the ordered field of the current data set.
+            constraint:
+              array:
+                item:
+                  type: string
+          default_order:
+            type: enum
+            description:
+              zh_cn: 可观测数据的默认排序。默认值为 asc。
+              en_us: The default order of the TelemetryData. The default value is asc.
+            constraint:
+              enum:
+                values:
+                - asc
+                - desc
+                default_value: asc
+        constraint:
+          required: true
+        description:
+          zh_cn: LogSet 的核心配置部分，定义日志数据的结构和处理方式。
+          en_us: The specification section containing LogSet configuration.

--- a/internal/umodel/schemaspec/data/metric_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/metric_set.expanded.yaml
@@ -1,0 +1,1803 @@
+description:
+  zh_cn: MetricSet 用于定义指标，指标集是具有相同属性的指标的集合，一般用于描述某类可观测实体的一类指标，例如主机的CPU、内存、磁盘等指标。
+  en_us: >-
+    MetricSet is used to define metrics. A metric set is a collection of metrics with the same attributes, generally used
+    to describe a class of metrics for a certain type of observable entity, such as CPU, memory, disk and other metrics of
+    a host.
+name: metric_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - metric_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        description:
+          zh_cn: MetricSet 的核心配置部分，定义监控指标的数据结构和采集规则。
+          en_us: The specification section containing MetricSet configuration.
+        properties:
+          labels:
+            description:
+              zh_cn: >-
+                指标集的标签列表，建议标签通过 dynamic 方式自动生成。注意：此处的标签是 MetricSet 的通用标签，一般建议 MetricSet 只定义通用标签，不在 Metric 下定义额外的标签。
+              en_us: >-
+                The list of labels for the MetricSet. It is recommended to use dynamic to automatically generate labels. Note:
+                The labels here are the general labels of the MetricSet. It is generally recommended that the MetricSet only
+                define general labels, and not define additional labels under the Metric.
+            type: object
+            properties:
+              keys:
+                description:
+                  zh_cn: 标签列表，值格式参考 field 定义。
+                  en_us: The list of labels. The value format is reference to the field definition.
+                type: array
+                constraint:
+                  array:
+                    item:
+                      type: object
+                      properties:
+                        name:
+                          description:
+                            zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                            en_us: >
+                              The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                              alphanumeric characters.
+                          type: string
+                          constraint:
+                            pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                            required: true
+                            min_len: 0
+                            max_len: 127
+                        display_name:
+                          description:
+                            zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                            en_us: The display name of the Element in UModel System. The value cannot be empty.
+                          type: object
+                          properties:
+                            zh_cn:
+                              description:
+                                zh_cn: 中文描述
+                                en_us: Chinese description
+                              type: string
+                            en_us:
+                              description:
+                                zh_cn: 英文描述
+                                en_us: English description
+                              type: string
+                        description:
+                          description:
+                            zh_cn: Field 在 UModel 系统中的描述。
+                            en_us: The description of the Element in UModel System.
+                          type: object
+                          properties:
+                            zh_cn:
+                              description:
+                                zh_cn: 中文描述
+                                en_us: Chinese description
+                              type: string
+                            en_us:
+                              description:
+                                zh_cn: 英文描述
+                                en_us: English description
+                              type: string
+                        short_description:
+                          description:
+                            zh_cn: Field 在 UModel 系统中的简短描述。
+                            en_us: The short description of the Element in UModel System.
+                          type: object
+                          properties:
+                            zh_cn:
+                              description:
+                                zh_cn: 中文描述
+                                en_us: Chinese description
+                              type: string
+                            en_us:
+                              description:
+                                zh_cn: 英文描述
+                                en_us: English description
+                              type: string
+                        launch_stage:
+                          description:
+                            zh_cn: 元素的发布阶段。默认值为 preview。
+                            en_us: The launch stage of the Element. The default value is preview.
+                          type: string
+                          constraint:
+                            enum:
+                              values:
+                              - preview
+                              - beta
+                              - ga
+                              - deprecated
+                            default_value: preview
+                        type:
+                          description:
+                            zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                            en_us: >
+                              The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                              time, json_object, json_array.  The value cannot be empty.
+                          type: enum
+                          constraint:
+                            enum:
+                              values:
+                              - string
+                              - integer
+                              - float
+                              - boolean
+                              - time
+                              - json_object
+                              - json_array
+                            required: true
+                        value_mapping:
+                          description:
+                            zh_cn: >-
+                              对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                              ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                            en_us: >
+                              For the mapping and interpretation of enumeration values, in order to better display the meaning
+                              of the mapping value, the value field of the mapping is defined separately. The value contains
+                              4 fields: "name", "display_name", "description", and "short_description". For example, the value
+                              of the "status" field is "1", the mapping is: name is "running", display_name is "running",
+                              description is "running...", and short_description is "running...".
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                              value:
+                                type: object
+                                properties:
+                                  name:
+                                    description:
+                                      zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                      en_us: >
+                                        The name of the Element in UModel System. The value cannot be empty.The value format
+                                        is lowercase alphanumeric characters.
+                                    type: string
+                                    constraint:
+                                      pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                      required: true
+                                      min_len: 0
+                                      max_len: 127
+                                  display_name:
+                                    description:
+                                      zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                      en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  description:
+                                    description:
+                                      zh_cn: 在 UModel 系统中的描述。
+                                      en_us: The description of the Element in UModel System.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  short_description:
+                                    description:
+                                      zh_cn: 在 UModel 系统中的简短描述。
+                                      en_us: The short description of the Element in UModel System.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                        unit:
+                          description:
+                            zh_cn: >
+                              指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                              即可满足需求，unit 填写为空即可。
+                                      若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                              为 °C。
+                            en_us: >
+                              The unit of the Metric. The value format is a string. Note: The unit is only used for display
+                              and will not be converted, such as ms will not be automatically converted to s. Best practice:
+                              First configure data_format, in most observable scenarios, data_format can meet the needs, and
+                              unit can be filled in as empty. If it does not meet the needs, it is generally recommended to
+                              configure data_format to a common KMB, and configure unit to a specific type. For example, for
+                              temperature, you can configure data_format to KMB and configure unit to °C.
+                          type: string
+                        data_format:
+                          description:
+                            zh_cn: >
+                              指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                              数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                              存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                              速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per
+                              second）格式化，样例：bps/Kbps/Mbps - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                              百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                              时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式
+                              - localtimens: 纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                              持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                              - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                            en_us: >
+                              The formatting method for metrics, value format is string. Supported formatting options:
+
+                              Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                              Process as millisecond format, example: 1,000,000
+
+                              Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                              example: b/Kb/Mb
+
+                              Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                              Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second
+                              formatting, example: io/s - reqps: Requests per second formatting, example: req/s
+
+                              Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10%
+                              - percent_decimal: Percentage formatting, value range is 0-1, example: 10%
+
+                              Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert
+                              millisecond time to local time format - localtimeus: Convert microsecond time to local time
+                              format - localtimens: Convert nanosecond time to local time format - UTC±n: Convert timestamp
+                              to specific timezone time
+
+                              Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d
+                              hh:mm:ss - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format
+                              time by days - h: Format time by hours - m: Format time by minutes - s: Format time by seconds
+                              - ms: Format time by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                          type: string
+                          constraint:
+                            enum:
+                              values:
+                              - KMB
+                              - milli
+                              - byte
+                              - bit
+                              - byte_ies_sec
+                              - bit_ies_sec
+                              - iops
+                              - reqps
+                              - percent
+                              - percent_decimal
+                              - localtime
+                              - localtimems
+                              - localtimeus
+                              - localtimens
+                              - UTC-11
+                              - UTC-10
+                              - UTC-9
+                              - UTC-8
+                              - UTC-7
+                              - UTC-6
+                              - UTC-5
+                              - UTC-4
+                              - UTC-3
+                              - UTC-2
+                              - UTC-1
+                              - UTC+0
+                              - UTC+1
+                              - UTC+2
+                              - UTC+3
+                              - UTC+4
+                              - UTC+5
+                              - UTC+6
+                              - UTC+7
+                              - UTC+8
+                              - UTC+9
+                              - UTC+10
+                              - UTC+11
+                              - UTC+12
+                              - dtdhms
+                              - dthms
+                              - d
+                              - h
+                              - m
+                              - s
+                              - ms
+                              - us
+                              - ns
+                            default_value: KMB
+                        analysable:
+                          description:
+                            zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                            en_us: >-
+                              Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                              value is false.
+                          type: bool
+                          constraint:
+                            default_value: false
+                        filterable:
+                          description:
+                            zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                            en_us: >-
+                              Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                              default value is false.
+                          type: bool
+                          constraint:
+                            default_value: false
+                        orderable:
+                          description:
+                            zh_cn: 用于表示字段是否可排序。默认值为false。
+                            en_us: Used to indicate whether the field is sortable. default value is false.
+                          type: bool
+                          constraint:
+                            default_value: false
+                        default_order:
+                          description:
+                            zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                            en_us: >
+                              Used to indicate the default sorting order of the field. The value must be one of the following:
+                              asc, desc. default value is asc.
+                          type: enum
+                          constraint:
+                            enum:
+                              values:
+                              - asc
+                              - desc
+                              default_value: asc
+                        pattern:
+                          description:
+                            zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                            en_us: Regular expression, used to define the range of values for this field (String).
+                          type: string
+                        max_length:
+                          description:
+                            zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                            en_us: The max length of string value. Only valid for string type.
+                          type: integer
+                        example:
+                          description:
+                            zh_cn: 字段值的示例。值可以为空。
+                            en_us: examples of the field value. The value can be empty.
+                          type: any
+                        max_value:
+                          description:
+                            zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                            en_us: >-
+                              The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                          type: number
+                        min_value:
+                          description:
+                            zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                            en_us: >-
+                              The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                          type: number
+                        default_value:
+                          description:
+                            zh_cn: 字段的默认值。值可以为空。
+                            en_us: The default value of the field. The value can be empty.
+                          type: any
+                        icon:
+                          description:
+                            zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                            en_us: The icon of the Element in UModel System. The value format is 'url'.
+                          type: string
+                          release_stage: experimental
+                          constraint: null
+                        uri:
+                          description:
+                            zh_cn: 用于表示该字段唯一标识。
+                            en_us: This field is used to represent the unique identifier of the field.
+                          type: string
+                          release_stage: experimental
+                          constraint: null
+                        tags:
+                          description:
+                            zh_cn: 用于表示该 Field 的标签。
+                            en_us: This field is used to represent the tags of the Field.
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                                constraint: null
+                              value:
+                                type: string
+                        properties:
+                          description:
+                            zh_cn: 用于表示该 Field 的附加属性。
+                            en_us: This field is used to represent the additional properties of the Field.
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                                constraint: null
+                              value:
+                                type: string
+              dynamic:
+                description:
+                  zh_cn: 是否动态生成，一般建议设置为 true。
+                  en_us: Whether the key is dynamic. It is generally recommended to set it to true.
+                type: boolean
+                constraint:
+                  default_value: false
+              filter:
+                description:
+                  zh_cn: 标签的过滤器，在 dynamic 为 true 时，会根据此过滤器进行过滤。
+                  en_us: >-
+                    The filter of the label. When dynamic is true, it will be filtered according to this filter.
+                type: string
+          label_keys:
+            description:
+              zh_cn: 指标集的标签键。当前已废弃，待删除，请使用 labels 字段代替。
+              en_us: >-
+                The label keys of the MetricSet. It is currently deprecated and will be deleted. Please use the labels field
+                instead.
+            type: array
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+            release_stage: deprecated
+          metrics:
+            description:
+              zh_cn: 详细的指标列表。
+              en_us: The detailed list of metrics.
+            type: array
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 指标的名称。值不能为空。
+                        en_us: The name of the Metric. The value cannot be empty.
+                      type: string
+                      constraint:
+                        required: true
+                        min_len: 1
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: 指标的显示名称。
+                        en_us: The display name of the Metric. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 指标的描述。值格式为语义字符串。
+                        en_us: The description of the Metric.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 指标的简短描述。值格式为语义字符串。
+                        en_us: The short description of the Metric.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: 用于表示该指标的图标。
+                        en_us: This field is used to represent the icon of the Metric.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    labels:
+                      description:
+                        zh_cn: 用于表示该指标自身额外的标签。即在 MetricSet 的标签基础上，该指标还具有的额外标签。
+                        en_us: >-
+                          This field is used to represent the labels of the Metric. It is the additional labels of the Metric
+                          on top of the labels in the MetricSet.
+                      type: array
+                      constraint:
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Field in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: Field 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: Field 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              launch_stage:
+                                description:
+                                  zh_cn: 元素的发布阶段。默认值为 preview。
+                                  en_us: The launch stage of the Element. The default value is preview.
+                                type: string
+                                constraint:
+                                  enum:
+                                    values:
+                                    - preview
+                                    - beta
+                                    - ga
+                                    - deprecated
+                                  default_value: preview
+                              type:
+                                description:
+                                  zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                                  en_us: >
+                                    The type of the Field. The value must be one of the following: string, integer, float,
+                                    boolean, time, json_object, json_array.  The value cannot be empty.
+                                type: enum
+                                constraint:
+                                  enum:
+                                    values:
+                                    - string
+                                    - integer
+                                    - float
+                                    - boolean
+                                    - time
+                                    - json_object
+                                    - json_array
+                                  required: true
+                              value_mapping:
+                                description:
+                                  zh_cn: >-
+                                    对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                                    ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                                  en_us: >
+                                    For the mapping and interpretation of enumeration values, in order to better display the
+                                    meaning of the mapping value, the value field of the mapping is defined separately. The
+                                    value contains 4 fields: "name", "display_name", "description", and "short_description".
+                                    For example, the value of the "status" field is "1", the mapping is: name is "running",
+                                    display_name is "running", description is "running...", and short_description is "running...".
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description:
+                                            zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                            en_us: >
+                                              The name of the Element in UModel System. The value cannot be empty.The value
+                                              format is lowercase alphanumeric characters.
+                                          type: string
+                                          constraint:
+                                            pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                            required: true
+                                            min_len: 0
+                                            max_len: 127
+                                        display_name:
+                                          description:
+                                            zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                            en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                          type: object
+                                          properties:
+                                            zh_cn:
+                                              description:
+                                                zh_cn: 中文描述
+                                                en_us: Chinese description
+                                              type: string
+                                            en_us:
+                                              description:
+                                                zh_cn: 英文描述
+                                                en_us: English description
+                                              type: string
+                                        description:
+                                          description:
+                                            zh_cn: 在 UModel 系统中的描述。
+                                            en_us: The description of the Element in UModel System.
+                                          type: object
+                                          properties:
+                                            zh_cn:
+                                              description:
+                                                zh_cn: 中文描述
+                                                en_us: Chinese description
+                                              type: string
+                                            en_us:
+                                              description:
+                                                zh_cn: 英文描述
+                                                en_us: English description
+                                              type: string
+                                        short_description:
+                                          description:
+                                            zh_cn: 在 UModel 系统中的简短描述。
+                                            en_us: The short description of the Element in UModel System.
+                                          type: object
+                                          properties:
+                                            zh_cn:
+                                              description:
+                                                zh_cn: 中文描述
+                                                en_us: Chinese description
+                                              type: string
+                                            en_us:
+                                              description:
+                                                zh_cn: 英文描述
+                                                en_us: English description
+                                              type: string
+                              unit:
+                                description:
+                                  zh_cn: >
+                                    指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                                    即可满足需求，unit 填写为空即可。
+                                            若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB，
+                                    并配置 unit 为 °C。
+                                  en_us: >
+                                    The unit of the Metric. The value format is a string. Note: The unit is only used for
+                                    display and will not be converted, such as ms will not be automatically converted to s.
+                                    Best practice: First configure data_format, in most observable scenarios, data_format
+                                    can meet the needs, and unit can be filled in as empty. If it does not meet the needs,
+                                    it is generally recommended to configure data_format to a common KMB, and configure unit
+                                    to a specific type. For example, for temperature, you can configure data_format to KMB
+                                    and configure unit to °C.
+                                type: string
+                              data_format:
+                                description:
+                                  zh_cn: >
+                                    指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                                    数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                                    存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                                    速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit
+                                    per second）格式化，样例：bps/Kbps/Mbps - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                                    百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                                    时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式
+                                    - localtimens: 纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                                    持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                                    - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 -
+                                    ns: 按纳秒格式化时间
+                                  en_us: >
+                                    The formatting method for metrics, value format is string. Supported formatting options:
+
+                                    Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil
+                                    - milli: Process as millisecond format, example: 1,000,000
+
+                                    Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as
+                                    bit format, example: b/Kb/Mb
+
+                                    Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s -
+                                    bit_ies_sec: Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations
+                                    per second formatting, example: io/s - reqps: Requests per second formatting, example:
+                                    req/s
+
+                                    Percentage formatting: - percent: Percentage formatting, value range is 1-100, example:
+                                    10% - percent_decimal: Percentage formatting, value range is 0-1, example: 10%
+
+                                    Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert
+                                    millisecond time to local time format - localtimeus: Convert microsecond time to local
+                                    time format - localtimens: Convert nanosecond time to local time format - UTC±n: Convert
+                                    timestamp to specific timezone time
+
+                                    Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example:
+                                    d hh:mm:ss - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d:
+                                    Format time by days - h: Format time by hours - m: Format time by minutes - s: Format
+                                    time by seconds - ms: Format time by milliseconds - us: Format time by microseconds -
+                                    ns: Format time by nanoseconds
+                                type: string
+                                constraint:
+                                  enum:
+                                    values:
+                                    - KMB
+                                    - milli
+                                    - byte
+                                    - bit
+                                    - byte_ies_sec
+                                    - bit_ies_sec
+                                    - iops
+                                    - reqps
+                                    - percent
+                                    - percent_decimal
+                                    - localtime
+                                    - localtimems
+                                    - localtimeus
+                                    - localtimens
+                                    - UTC-11
+                                    - UTC-10
+                                    - UTC-9
+                                    - UTC-8
+                                    - UTC-7
+                                    - UTC-6
+                                    - UTC-5
+                                    - UTC-4
+                                    - UTC-3
+                                    - UTC-2
+                                    - UTC-1
+                                    - UTC+0
+                                    - UTC+1
+                                    - UTC+2
+                                    - UTC+3
+                                    - UTC+4
+                                    - UTC+5
+                                    - UTC+6
+                                    - UTC+7
+                                    - UTC+8
+                                    - UTC+9
+                                    - UTC+10
+                                    - UTC+11
+                                    - UTC+12
+                                    - dtdhms
+                                    - dthms
+                                    - d
+                                    - h
+                                    - m
+                                    - s
+                                    - ms
+                                    - us
+                                    - ns
+                                  default_value: KMB
+                              analysable:
+                                description:
+                                  zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                                  en_us: >-
+                                    Used to denote whether the field is analyzable, i.e., serving as a column for Group By.
+                                    default value is false.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              filterable:
+                                description:
+                                  zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                                  en_us: >-
+                                    Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                                    default value is false.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              orderable:
+                                description:
+                                  zh_cn: 用于表示字段是否可排序。默认值为false。
+                                  en_us: Used to indicate whether the field is sortable. default value is false.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              default_order:
+                                description:
+                                  zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                                  en_us: >
+                                    Used to indicate the default sorting order of the field. The value must be one of the
+                                    following: asc, desc. default value is asc.
+                                type: enum
+                                constraint:
+                                  enum:
+                                    values:
+                                    - asc
+                                    - desc
+                                    default_value: asc
+                              pattern:
+                                description:
+                                  zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                                  en_us: Regular expression, used to define the range of values for this field (String).
+                                type: string
+                              max_length:
+                                description:
+                                  zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                                  en_us: The max length of string value. Only valid for string type.
+                                type: integer
+                              example:
+                                description:
+                                  zh_cn: 字段值的示例。值可以为空。
+                                  en_us: examples of the field value. The value can be empty.
+                                type: any
+                              max_value:
+                                description:
+                                  zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                                  en_us: >-
+                                    The maximum value of the field. The value can be empty. Only valid for integer and float
+                                    types.
+                                type: number
+                              min_value:
+                                description:
+                                  zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                                  en_us: >-
+                                    The minimum value of the field. The value can be empty. Only valid for integer and float
+                                    types.
+                                type: number
+                              default_value:
+                                description:
+                                  zh_cn: 字段的默认值。值可以为空。
+                                  en_us: The default value of the field. The value can be empty.
+                                type: any
+                              icon:
+                                description:
+                                  zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                                  en_us: The icon of the Element in UModel System. The value format is 'url'.
+                                type: string
+                                release_stage: experimental
+                                constraint: null
+                              uri:
+                                description:
+                                  zh_cn: 用于表示该字段唯一标识。
+                                  en_us: This field is used to represent the unique identifier of the field.
+                                type: string
+                                release_stage: experimental
+                                constraint: null
+                              tags:
+                                description:
+                                  zh_cn: 用于表示该 Field 的标签。
+                                  en_us: This field is used to represent the tags of the Field.
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                      constraint: null
+                                    value:
+                                      type: string
+                              properties:
+                                description:
+                                  zh_cn: 用于表示该 Field 的附加属性。
+                                  en_us: This field is used to represent the additional properties of the Field.
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                      constraint: null
+                                    value:
+                                      type: string
+                    golden_metric:
+                      type: boolean
+                      constraint:
+                        default_value: false
+                      description:
+                        zh_cn: 是否为黄金指标。
+                        en_us: Whether the metric is a golden metric.
+                    generator:
+                      type: string
+                      description:
+                        zh_cn: >
+                          指标的生成方式，如果是 PromMode，该字段为 PromQL语句，能够执行并得到一个可直接使用的 Measure 类型指标。 例如：rate(request_count{}[1m])，在一些场景下结合
+                          aggregator 字段，能够计算出聚合维度的指标，例如 sum(rate(request_count{}[1m])) by (label1, label2) 如果是 SQL/SPLMode，该字段为
+                          SQL/SPL语句的计算方式，能够组合并最终生成执行的语句。例如：count(1)，最终生成的SQL为 select label1, label2, count(1) as request_count
+                          from (${StorageQuery}) group by label1, label2
+                        en_us: >
+                          This field represents the generator of the Metric. If the mode is PromMode, this field is a PromQL
+                          statement that can be executed to get a Measure type metric directly. For example: rate(request_count{}[1m]).
+                          If the mode is SQL/SPLMode, this field is the calculation method of the SQL/SPL statement, which
+                          can be combined and finally generate the execution statement. For example: count(1), the final generated
+                          SQL is select label1, label2, count(1) as request_count from (${StorageQuery}) group by label1,
+                          label2
+                    aggregator:
+                      type: string
+                      description:
+                        zh_cn: >
+                          指标的聚合方式。如果指标本身是聚合的，且聚合方式在多种维度组合下均一致，则不需要配置次字段，其他情况需要配置。一些示例场景如下： 1. Prometheus指标和Metric从时间线维度相同
+                            1.1 rate(cpu_usage_seconds_total{}[1m]) 即可计算出单机指标，cpu_usage_seconds_total 代表主机级别的统计值，这时需要配置 Aggregator
+                          为 avg
+                            1.2 avg(rate(cpu_core_usage_seconds_total{}[1m]))， cpu_core_usage_seconds_total 代表主机上每个CPU的统计值，主机指标本身需要聚合计算，则不需要配置
+                          Aggregator
+                          2. 基础云监控场景全是聚合指标，一定需要配置 3. 基于日志聚合的指标，一般不需要配置
+                        en_us: >
+                          The aggregation method of the metric. If the metric is already aggregated, and the aggregation method
+                          is consistent in multiple dimension combinations, this field does not need to be configured, otherwise
+                          it needs to be configured. Some examples of scenarios that need to be configured are as follows:
+                          1. Prometheus metrics and Metric have the same time line dimension
+                            1.1 rate(cpu_usage_seconds_total{}[1m]) can calculate the single machine metric, cpu_usage_seconds_total
+                          represents the statistical value of the host level, then Aggregator needs to be configured as avg
+                            1.2 avg(rate(cpu_core_usage_seconds_total{}[1m])), cpu_core_usage_seconds_total represents the
+                          statistical value of each CPU on the host, the host metric itself needs to be aggregated, then Aggregator
+                          does not need to be configured
+                          2. All metrics in the cloud monitor scenario are aggregated metrics, so this field must be configured
+                          3. Based on log aggregation metrics, it is generally not required to configure
+                    interval_us:
+                      description:
+                        zh_cn: >
+                          指标的间隔，值格式为整数或整数数组，单位为微秒。 - 当为单个整数时：表示固定的采集间隔 - 当为整数数组时：表示多个采集间隔，用于支持不同精度的数据采集
+                        en_us: >
+                          The interval of the metric, value format is integer or array of integers, in microseconds. - When
+                          single integer: represents a fixed collection interval - When array of integers: represents multiple
+                          collection intervals for supporting different precision data collection
+                      constraint:
+                        oneOf:
+                        - type: integer
+                          description:
+                            zh_cn: 单个采集间隔，单位为微秒
+                            en_us: Single collection interval in microseconds
+                        - type: array
+                          description:
+                            zh_cn: 多个采集间隔的数组，单位为微秒
+                            en_us: Array of collection intervals in microseconds
+                          constraint:
+                            array:
+                              item:
+                                type: integer
+                              min_size: 1
+                    type:
+                      type: string
+                      description:
+                        zh_cn: 指标的类型。对于无需二次处理的指标，该字段应固定为 gauge。
+                        en_us: >-
+                          This field indicates the metric type. For metrics that do not need to be processed again, this field
+                          should be fixed to gauge.
+                      constraint:
+                        default_value: gauge
+                    query_mode:
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - range
+                          - instant
+                          - both
+                          default_value: instant
+                      description:
+                        zh_cn: 指标期望的查询模式。值必须是以下之一：range, instant, both。
+                        en_us: >
+                          This metric query mode. The value must be one of the following: range, instant, both.
+                      release_stage: experimental
+                    display_type:
+                      type: string
+                      description:
+                        zh_cn: 指标的显示类型。当前未使用。
+                        en_us: This metric display type.
+                      release_stage: experimental
+                    statistics:
+                      type: array
+                      description:
+                        zh_cn: 生成该指标时的统计方式，即该指标有多种生成方式。当前仅在基础云监控场景下使用。
+                        en_us: >-
+                          The statistics method when generating this metric, that is, the metric has multiple generation methods.
+                          It is currently only used in the cloud monitor service scenario.
+                      constraint:
+                        array:
+                          item:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 用于表示该指标的标签。
+                        en_us: This field is used to represent the tags of the Metric.
+                      type: map
+                      constraint:
+                        map:
+                          min_size: 1
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该指标的附加属性。
+                        en_us: This field is used to represent the additional properties of the Metric.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    default_fill_policy:
+                      type: string
+                      description:
+                        zh_cn: 指标的默认填充策略。 值可以是 null, 0, last, next。
+                        en_us: The default fill policy of the Metric. The value can be null, 0, last, next.
+                min_size: 1
+          query_type:
+            description:
+              zh_cn: 指标的查询语法，取值包括：prom、spl、cms 。
+              en_us: The query type of the metric. The value can be prom, spl or cms.
+            type: string
+            constraint:
+              enum:
+                values:
+                - prom
+                - spl
+                - cms
+          needs_processing:
+            type: boolean
+            description:
+              zh_cn: >-
+                是否需要二次处理，即该 MetricSet 中指标是否需要二次处理才能被使用。例如 Prometheus 中的 counter/summary/histogram 等指标需要二次处理才能被使用。
+              en_us: >-
+                Whether the MetricSet needs to be processed again. That is, whether the metrics in the MetricSet need to be
+                processed again to be used. For example, the counter/summary/histogram metrics in Prometheus need to be processed
+                again to be used.
+            constraint:
+              default_value: false

--- a/internal/umodel/schemaspec/data/profile_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/profile_set.expanded.yaml
@@ -1,0 +1,679 @@
+description:
+  zh_cn: >-
+    ProfileSet 用于定义 Profile 数据集，Profile 数据集是具有相同属性的 Profile 数据的集合，一般用于描述某类可观测实体的一类 Profile 数据，例如主机的 CPU、内存、磁盘等 Profile 数据。
+  en_us: >-
+    ProfileSet is used to define Profile data sets. A Profile data set is a collection of Profile data with the same attributes,
+    generally used to describe a class of Profile data for a certain type of observable entity, such as CPU, memory, disk
+    and other Profile data of a host.
+name: profile_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - profile_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的字段列表。
+              en_us: The fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          time_field:
+            type: string
+            description:
+              zh_cn: 可观测数据的时间字段。一般要求时间字段为时间戳类型，支持秒、毫秒、微秒、纳秒。
+              en_us: >-
+                The time field of the TelemetryData. It is generally required to be a timestamp type, supporting seconds,
+                milliseconds, microseconds, and nanoseconds.
+            constraint:
+              required: false
+          display_field:
+            type: string
+            description:
+              zh_cn: 注意：定位和 `name_fields` 有一定重叠，字段已废弃，请使用 `name_fields` 字段第一个值替代。可观测数据的显示字段。即默认展示的字段。
+              en_us: >
+                Note: This field is deprecated. Please use the `name_fields` field instead. The display field of the TelemetryData.
+                It is the default displayed field.
+            release_stage: experimental
+          name_fields:
+            type: array
+            description:
+              zh_cn: >
+                可观测数据的显示字段。建议按照显示重要性配置先后顺序，前端、算法等在各类场景会根据特点自由选择，例如极窄/引用场景下只取name_fields的第一个值。 例如：服务操作实体，建议取值为 ["operation_name",
+                "service_name"]；
+                     K8s Pod 实体，建议取值为 ["pod_name", "namespace", "cluster"]。
+              en_us: >
+                The name fields of the TelemetryData. It is recommended to configure the display fields in order of importance.
+                Front-end, algorithms, etc. will freely choose according to the characteristics in various scenarios. For
+                example, for service operation entities, it is recommended to take ["operation_name", "service_name"]; For K8s
+                Pod entities, it is recommended to take ["pod_name", "namespace", "cluster"].
+            constraint:
+              array:
+                item:
+                  type: string
+          hidden_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的隐藏字段。即不用作展示的字段。
+              en_us: The hidden fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: string
+          tag_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的标签字段。标签字段默认聚合在一起显示和分析。
+              en_us: >-
+                The tag fields of the TelemetryData. The tag fields are aggregated by default for display and analysis.
+            constraint:
+              array:
+                item:
+                  type: string
+          ordered_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的排序字段。即当前数据集的排序字段。
+              en_us: >-
+                The ordered fields of the TelemetryData. It is the ordered field of the current data set.
+            constraint:
+              array:
+                item:
+                  type: string
+          default_order:
+            type: enum
+            description:
+              zh_cn: 可观测数据的默认排序。默认值为 asc。
+              en_us: The default order of the TelemetryData. The default value is asc.
+            constraint:
+              enum:
+                values:
+                - asc
+                - desc
+                default_value: asc
+          protocol:
+            description:
+              zh_cn: 使用的 Profile 协议。指定 Profile 数据的格式和标准。
+              en_us: >-
+                The profiling protocol used. Specifies the format and standard for profiling data.
+            type: string
+            constraint:
+              default_value: pprof
+        constraint:
+          required: true
+        description:
+          zh_cn: ProfileSet 的核心配置部分，定义 Profile 数据的数据结构和处理方式。
+          en_us: The specification section containing ProfileSet configuration.

--- a/internal/umodel/schemaspec/data/runbook_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/runbook_link.expanded.yaml
@@ -1,0 +1,303 @@
+description:
+  zh_cn: RunbookLink 用于定义实体集合与操作手册集合之间的关联关系。
+  en_us: >-
+    RunbookLink is used to define the relationship between entity sets and runbook sets.
+name: runbook_link
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - runbook_link
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identify of source Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: >
+                    The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+              filter:
+                description:
+                  zh_cn: >-
+                    对于源 Set 的过滤器，用于部分 Link 的场景，例如 EntitySet 中只有"region=cn-beijing"的实体存在此关联。该方式已废弃，请使用 filter_by_entity 替代。
+                  en_us: >-
+                    The filter of the source Set. It is used for some Link scenarios, such as only entities with "region=cn-beijing"
+                    in the EntitySet have this association. This method is deprecated, please use filter_by_entity instead.
+                type: string
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identify of the destination Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+          token_replace:
+            type: map
+            description:
+              zh_cn: 上下文变量的映射关系，用于在执行 Runbook 时提供动态上下文变量。
+              en_us: >-
+                The mapping relationship of context variables, used to provide dynamic context variables when executing the
+                Runbook.
+          fields_mapping:
+            description:
+              zh_cn: 源数据集字段到目标 Runbook 字段的映射关系，用于将数据集中的字段值传递给 Runbook 的输入参数。
+              en_us: >-
+                The field mapping from source dataset fields to destination Runbook fields, used to pass field values from
+                the dataset to Runbook input parameters.
+            type: map
+            constraint:
+              map:
+                key:
+                  description:
+                    zh_cn: 源数据集（EntitySet 或 DataSet）的字段名称。
+                    en_us: The field name of the source dataset (EntitySet or DataSet).
+                  type: string
+                value:
+                  description:
+                    zh_cn: 目标 Runbook 的输入参数名称。
+                    en_us: The input parameter name of the destination Runbook.
+                  type: string
+        constraint:
+          required: true
+        description:
+          zh_cn: RunbookLink 的核心配置部分，定义关联关系。
+          en_us: The specification section containing RunbookLink configuration.

--- a/internal/umodel/schemaspec/data/runbook_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/runbook_set.expanded.yaml
@@ -1,0 +1,1606 @@
+description:
+  zh_cn: RunbookSet 用于定义实体、数据的操作手册集合，包含分析工具、操作指南和最佳实践。
+  en_us: >-
+    RunbookSet is used to define a collection of operational runbooks for entities and data, including analysis tools, operation
+    guides and best practices.
+name: runbook_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    release_stage: experimental
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - runbook_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        description:
+          zh_cn: RunbookSet 的核心配置部分，定义各类操作手册。
+          en_us: The specification section containing RunbookSet configuration.
+        properties:
+          observations:
+            type: array
+            description:
+              zh_cn: 观察配置列表
+              en_us: List of observation configurations
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 观察名称，在同一个RunbookSet中必须唯一。
+                        en_us: Observation name, must be unique within the same RunbookSet.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                        min_len: 1
+                        max_len: 128
+                    display_name:
+                      description:
+                        zh_cn: 观察显示名称。
+                        en_us: Observation display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 观察简短描述。
+                        en_us: Observation short description.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 观察详细描述信息。
+                        en_us: Observation detailed description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    phenomenon:
+                      description:
+                        zh_cn: 现象定义，描述要观察什么以及如何观察。
+                        en_us: Phenomenon definition, describing what to observe and how.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        phenomenon_type:
+                          description:
+                            zh_cn: 现象类型，如query（查询）、action（动作）、dashboard（大盘）、event（事件）等。
+                            en_us: Phenomenon type such as query, action, dashboard, event.
+                          type: string
+                          constraint:
+                            required: true
+                        inputs:
+                          description:
+                            zh_cn: 现象相关输入配置，用于指引上层如何选择默认的参数进行填入。包括 Dashboard 变量、Query 输入参数等
+                            en_us: >-
+                              Phenomenon related input configurations, used to guide the upper layer to select default parameters
+                              for filling in. Including Dashboard variables, Query input parameters, etc.
+                          type: array
+                          constraint:
+                            array:
+                              item:
+                                type: object
+                                properties:
+                                  name:
+                                    description:
+                                      zh_cn: 参数名称。
+                                      en_us: Parameter name.
+                                    type: string
+                                    constraint:
+                                      required: true
+                                      pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,63}$
+                                      min_len: 1
+                                      max_len: 63
+                                  display_name:
+                                    description:
+                                      zh_cn: 参数显示名称。
+                                      en_us: Parameter display name.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  description:
+                                    description:
+                                      zh_cn: 参数描述信息。
+                                      en_us: Parameter description.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  type:
+                                    description:
+                                      zh_cn: 参数类型。
+                                      en_us: Parameter type.
+                                    type: string
+                                    constraint:
+                                      required: true
+                                      enum:
+                                        values:
+                                        - string
+                                        - integer
+                                        - float
+                                        - boolean
+                                        - json
+                                  required:
+                                    description:
+                                      zh_cn: 是否为必填参数。
+                                      en_us: Whether the parameter is required.
+                                    type: bool
+                                    constraint:
+                                      default_value: false
+                                  default:
+                                    description:
+                                      zh_cn: 参数默认值。
+                                      en_us: Default value for the parameter.
+                                    type: string
+                        outputs:
+                          description:
+                            zh_cn: 可选，现象相关输出配置，用于指引上层如何解析查询结果。
+                            en_us: >-
+                              Optional, phenomenon related output configurations, used to guide the upper layer to parse the
+                              query results.
+                          type: array
+                          constraint:
+                            array:
+                              item:
+                                type: object
+                                properties:
+                                  name:
+                                    description:
+                                      zh_cn: 参数名称。
+                                      en_us: Parameter name.
+                                    type: string
+                                    constraint:
+                                      required: true
+                                      pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,63}$
+                                      min_len: 1
+                                      max_len: 63
+                                  display_name:
+                                    description:
+                                      zh_cn: 参数显示名称。
+                                      en_us: Parameter display name.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  description:
+                                    description:
+                                      zh_cn: 参数描述信息。
+                                      en_us: Parameter description.
+                                    type: object
+                                    properties:
+                                      zh_cn:
+                                        description:
+                                          zh_cn: 中文描述
+                                          en_us: Chinese description
+                                        type: string
+                                      en_us:
+                                        description:
+                                          zh_cn: 英文描述
+                                          en_us: English description
+                                        type: string
+                                  type:
+                                    description:
+                                      zh_cn: 参数类型。
+                                      en_us: Parameter type.
+                                    type: string
+                                    constraint:
+                                      required: true
+                                      enum:
+                                        values:
+                                        - string
+                                        - integer
+                                        - float
+                                        - boolean
+                                        - json
+                                  required:
+                                    description:
+                                      zh_cn: 是否为必填参数。
+                                      en_us: Whether the parameter is required.
+                                    type: bool
+                                    constraint:
+                                      default_value: false
+                                  default:
+                                    description:
+                                      zh_cn: 参数默认值。
+                                      en_us: Default value for the parameter.
+                                    type: string
+                        properties:
+                          description:
+                            zh_cn: 现象相关属性配置，根据 type 类型自由扩展。
+                            en_us: Phenomenon related properties, freely extensible based on type.
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                    conclusions:
+                      description:
+                        zh_cn: 结论配置列表，根据现象观察结果进行判断。
+                        en_us: List of conclusion configurations based on phenomenon observation results.
+                      type: array
+                      constraint:
+                        required: true
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              condition_type:
+                                description:
+                                  zh_cn: >-
+                                    结论生效条件类型，根据现象类型，条件执行方式不同。可以是 query/action 执行结果后的 bool 表达式计算，也可以是由 LLM 进行判断的 prompts。
+                                  en_us: >-
+                                    Condition type for conclusion activation. Can be bool expression calculated after query/action
+                                    execution, or prompts for LLM to judge.
+                                type: string
+                                constraint:
+                                  required: true
+                              condition:
+                                description:
+                                  zh_cn: 结论生效条件，根据现象类型，条件执行方式不同。
+                                  en_us: Condition for conclusion activation.
+                                type: string
+                                constraint:
+                                  required: true
+                              severity:
+                                description:
+                                  zh_cn: 结论严重程度。
+                                  en_us: Conclusion severity level.
+                                type: string
+                                constraint:
+                                  required: true
+                                  enum:
+                                    values:
+                                    - info
+                                    - warning
+                                    - error
+                                    - fatal
+                                    default_value: warning
+                              display_name:
+                                description:
+                                  zh_cn: 结论显示名称。
+                                  en_us: Conclusion display name.
+                                type: object
+                                constraint:
+                                  required: true
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 结论简短描述。
+                                  en_us: Conclusion short description.
+                                type: object
+                                constraint:
+                                  required: true
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 结论详细描述。
+                                  en_us: Conclusion detailed description.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              group:
+                                description:
+                                  zh_cn: 结论分组。在同一个结论分组下，只返回最高等级的结论。
+                                  en_us: >-
+                                    Conclusion group. In the same conclusion group, only the highest level of conclusion is
+                                    returned.
+                                type: string
+                                constraint:
+                                  required: true
+                              properties:
+                                description:
+                                  zh_cn: 结论相关属性配置。
+                                  en_us: Conclusion related properties.
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                    properties:
+                      description:
+                        zh_cn: 观察属性配置。
+                        en_us: Observation property configurations.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 观察标签。
+                        en_us: Observation tags.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+            release_stage: experimental
+          actions:
+            type: array
+            description:
+              zh_cn: 操作能力配置列表
+              en_us: List of action configurations
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 操作名称，在同一个RunbookSet中必须唯一。
+                        en_us: Action name, must be unique within the same RunbookSet.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                        min_len: 1
+                        max_len: 128
+                    display_name:
+                      description:
+                        zh_cn: 操作显示名称。
+                        en_us: Action display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 操作简短描述。
+                        en_us: Action short description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 操作详细描述信息。
+                        en_us: Action detailed description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    action_type:
+                      description:
+                        zh_cn: 操作类型，例如pop_api、mcp、api_call、script、webhook等。
+                        en_us: Action type such as pop_api, mcp, api_call, script, webhook.
+                      type: string
+                      constraint:
+                        required: true
+                    inputs:
+                      description:
+                        zh_cn: 操作参数配置列表。
+                        en_us: List of action parameter configurations.
+                      type: array
+                      constraint:
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 参数名称。
+                                  en_us: Parameter name.
+                                type: string
+                                constraint:
+                                  required: true
+                                  pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,63}$
+                                  min_len: 1
+                                  max_len: 63
+                              display_name:
+                                description:
+                                  zh_cn: 参数显示名称。
+                                  en_us: Parameter display name.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 参数描述信息。
+                                  en_us: Parameter description.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              type:
+                                description:
+                                  zh_cn: 参数类型。
+                                  en_us: Parameter type.
+                                type: string
+                                constraint:
+                                  required: true
+                                  enum:
+                                    values:
+                                    - string
+                                    - integer
+                                    - float
+                                    - boolean
+                                    - json
+                              required:
+                                description:
+                                  zh_cn: 是否为必填参数。
+                                  en_us: Whether the parameter is required.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              default:
+                                description:
+                                  zh_cn: 参数默认值。
+                                  en_us: Default value for the parameter.
+                                type: string
+                    outputs:
+                      description:
+                        zh_cn: 操作输出配置列表。
+                        en_us: List of action output configurations.
+                      type: array
+                      constraint:
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 参数名称。
+                                  en_us: Parameter name.
+                                type: string
+                                constraint:
+                                  required: true
+                                  pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,63}$
+                                  min_len: 1
+                                  max_len: 63
+                              display_name:
+                                description:
+                                  zh_cn: 参数显示名称。
+                                  en_us: Parameter display name.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 参数描述信息。
+                                  en_us: Parameter description.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              type:
+                                description:
+                                  zh_cn: 参数类型。
+                                  en_us: Parameter type.
+                                type: string
+                                constraint:
+                                  required: true
+                                  enum:
+                                    values:
+                                    - string
+                                    - integer
+                                    - float
+                                    - boolean
+                                    - json
+                              required:
+                                description:
+                                  zh_cn: 是否为必填参数。
+                                  en_us: Whether the parameter is required.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              default:
+                                description:
+                                  zh_cn: 参数默认值。
+                                  en_us: Default value for the parameter.
+                                type: string
+                    confirmation_required:
+                      description:
+                        zh_cn: 是否需要确认才能执行操作。
+                        en_us: Whether confirmation is required before executing the action.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    risk_level:
+                      description:
+                        zh_cn: 操作的风险等级。
+                        en_us: Risk level of the operation.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - low
+                          - medium
+                          - high
+                          - critical
+                        default_value: low
+                    properties:
+                      description:
+                        zh_cn: 详细配置信息，用于配置不同类型操作的详细信息
+                        en_us: >-
+                          Detailed configuration information, used to configure detailed information for different types of
+                          operations.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 操作标签。
+                        en_us: Action tags.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+            release_stage: deprecated
+          toolkits:
+            type: array
+            description:
+              zh_cn: 工具箱配置列表，每个工具箱包含共享配置和一组工具
+              en_us: >-
+                List of toolkit configurations, each toolkit contains shared config and a set of tools
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 工具箱名称，在同一个 RunbookSet 内必须唯一。
+                        en_us: Toolkit name, must be unique within the same RunbookSet.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                        min_len: 1
+                        max_len: 128
+                    display_name:
+                      description:
+                        zh_cn: 工具箱显示名称。
+                        en_us: Toolkit display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 工具箱简短描述。
+                        en_us: Toolkit short description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 工具箱详细描述信息。
+                        en_us: Toolkit detailed description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    toolkit_type:
+                      description:
+                        zh_cn: 工具箱类型，如 mcp、pop_api、api_call、script、webhook 等。
+                        en_us: Toolkit type such as mcp, pop_api, api_call, script, webhook.
+                      type: string
+                      constraint:
+                        required: true
+                    configs:
+                      description:
+                        zh_cn: 运行时配置，如连接信息、认证、超时等，Toolkit 内所有 Tool 继承使用。
+                        en_us: >-
+                          Runtime configuration such as connection, auth, timeout; inherited by all tools in this toolkit.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: any
+                    properties:
+                      description:
+                        zh_cn: 扩展元数据，描述性属性，自由扩展的 k-v。
+                        en_us: Extended metadata, descriptive properties, free-form key-value.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 共享标签。
+                        en_us: Shared tags.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tools:
+                      description:
+                        zh_cn: 工具列表。
+                        en_us: List of tools.
+                      type: array
+                      constraint:
+                        required: true
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 工具名称，在同一个 Toolkit 内必须唯一。
+                                  en_us: Tool name, must be unique within the same Toolkit.
+                                type: string
+                                constraint:
+                                  required: true
+                                  pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                                  min_len: 1
+                                  max_len: 128
+                              display_name:
+                                description:
+                                  zh_cn: 工具显示名称。
+                                  en_us: Tool display name.
+                                type: object
+                                constraint:
+                                  required: true
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 工具简短描述，LLM 用来决定是否调用此工具的关键信息。
+                                  en_us: >-
+                                    Tool short description, key information for LLM to decide whether to invoke this tool.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 工具详细描述信息。
+                                  en_us: Tool detailed description.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              input_schema:
+                                type: object
+                                properties:
+                                  properties:
+                                    description:
+                                      zh_cn: 参数属性定义，键为参数名称，值为参数定义对象。
+                                      en_us: >-
+                                        Parameter property definitions, key is parameter name, value is parameter definition
+                                        object.
+                                    type: map
+                                    constraint:
+                                      map:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: any
+                                  required:
+                                    description:
+                                      zh_cn: 必填参数名称列表。
+                                      en_us: List of required parameter names.
+                                    type: array
+                                    constraint:
+                                      array:
+                                        item:
+                                          type: string
+                                description:
+                                  zh_cn: 工具输入参数定义，JSON Schema 风格。
+                                  en_us: Tool input parameter definition, JSON Schema style.
+                              output_schema:
+                                type: object
+                                properties:
+                                  properties:
+                                    description:
+                                      zh_cn: 参数属性定义，键为参数名称，值为参数定义对象。
+                                      en_us: >-
+                                        Parameter property definitions, key is parameter name, value is parameter definition
+                                        object.
+                                    type: map
+                                    constraint:
+                                      map:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: any
+                                  required:
+                                    description:
+                                      zh_cn: 必填参数名称列表。
+                                      en_us: List of required parameter names.
+                                    type: array
+                                    constraint:
+                                      array:
+                                        item:
+                                          type: string
+                                description:
+                                  zh_cn: 工具输出参数定义，JSON Schema 风格。
+                                  en_us: Tool output parameter definition, JSON Schema style.
+                              risk_level:
+                                description:
+                                  zh_cn: 操作的风险等级。
+                                  en_us: Risk level of the operation.
+                                type: string
+                                constraint:
+                                  enum:
+                                    values:
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                  default_value: low
+                              idempotent:
+                                description:
+                                  zh_cn: 操作是否幂等/可重入，重复执行结果一致。
+                                  en_us: >-
+                                    Whether the operation is idempotent/reentrant; repeated execution yields the same result.
+                                type: bool
+                                constraint:
+                                  default_value: true
+                              confirmation_required:
+                                description:
+                                  zh_cn: 是否需要确认才能执行操作。
+                                  en_us: Whether confirmation is required before executing the tool.
+                                type: bool
+                                constraint:
+                                  default_value: false
+                              properties:
+                                description:
+                                  zh_cn: 工具级别的额外配置，可覆盖或补充 Toolkit 的 properties。
+                                  en_us: Tool-level extra configuration, may override or supplement Toolkit properties.
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                              tags:
+                                description:
+                                  zh_cn: 工具标签。
+                                  en_us: Tool tags.
+                                type: map
+                                constraint:
+                                  map:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+            release_stage: experimental
+          knowledge:
+            type: array
+            description:
+              zh_cn: 知识库配置列表
+              en_us: List of knowledge base configurations
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 知识项名称，在同一个RunbookSet中必须唯一。
+                        en_us: Knowledge item name, must be unique within the same RunbookSet.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                        min_len: 1
+                        max_len: 128
+                    display_name:
+                      description:
+                        zh_cn: 知识项显示名称。
+                        en_us: Knowledge item display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 知识项简短描述。
+                        en_us: Knowledge item short description.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 知识项详细描述信息。
+                        en_us: Knowledge item detailed description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    apply_policy:
+                      description:
+                        zh_cn: 知识如何应用的配置。
+                        en_us: Configuration for how the knowledge is applied.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        apply_type:
+                          description:
+                            zh_cn: 应用策略，如auto（自动）、manual（手动）、always（总是）、custom（自定义）等。
+                            en_us: Apply type such as auto, manual, always, custom.
+                          type: enum
+                          constraint:
+                            required: true
+                            enum:
+                              values:
+                              - auto
+                              - manual
+                              - always
+                              - custom
+                        properties:
+                          description:
+                            zh_cn: 应用相关属性配置，根据 custom 类型自由扩展。
+                            en_us: Apply related properties, freely extensible when type is custom.
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                    content_type:
+                      description:
+                        zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+                        en_us: >-
+                          Content type such as markdown, html, url, pdf. UModel built-in supported type is markdown.
+                      type: string
+                      constraint:
+                        required: true
+                    content:
+                      description:
+                        zh_cn: 知识内容，根据content_type可以是文本内容或URL地址。
+                        en_us: Knowledge content, can be text content or URL based on content_type.
+                      type: string
+                      constraint:
+                        max_len: 65536
+                    content_url:
+                      description:
+                        zh_cn: 知识内容的外部URL地址。
+                        en_us: External URL for knowledge content.
+                      type: string
+                      constraint:
+                        max_len: 512
+                    priority:
+                      description:
+                        zh_cn: 知识项优先级，用于排序显示以及模型推理时选择。
+                        en_us: Knowledge item priority for sorting display and model inference selection.
+                      type: integer
+                      constraint:
+                        min_value: 1
+                        max_value: 10
+                        default_value: 5
+                    last_updated:
+                      description:
+                        zh_cn: 最后更新时间。
+                        en_us: Last update time.
+                      type: time
+                    tags:
+                      description:
+                        zh_cn: 知识项标签。
+                        en_us: Knowledge item tags.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+            release_stage: deprecated
+          automations:
+            type: array
+            description:
+              zh_cn: 自动化配置列表
+              en_us: List of automation configurations
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 自动化项名称，在同一个RunbookSet中必须唯一。
+                        en_us: Automation item name, must be unique within the same RunbookSet.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.]{0,127}$
+                        min_len: 1
+                        max_len: 128
+                    display_name:
+                      description:
+                        zh_cn: 自动化项显示名称。
+                        en_us: Automation item display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: 自动化项简短描述。
+                        en_us: Automation item short description.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 自动化项详细描述信息。
+                        en_us: Automation item detailed description.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    automation_type:
+                      description:
+                        zh_cn: 自动化类型，如action、script、webhook等。
+                        en_us: Automation type such as action, script, webhook.
+                      type: string
+                      constraint:
+                        required: true
+                    trigger:
+                      description:
+                        zh_cn: 触发条件配置。
+                        en_us: Trigger condition configuration.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        trigger_type:
+                          description:
+                            zh_cn: 触发条件类型，如 scheduled（定期触发）、event（事件触发）、custom（自定义触发）等。
+                            en_us: Trigger condition type such as scheduled, event, custom.
+                          type: string
+                          constraint:
+                            required: true
+                            enum:
+                              values:
+                              - scheduled
+                              - event
+                              - custom
+                        properties:
+                          description:
+                            zh_cn: 触发条件相关属性配置，根据type类型自由扩展。
+                            en_us: Trigger condition related properties, freely extensible based on type.
+                          type: map
+                          constraint:
+                            map:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                    properties:
+                      description:
+                        zh_cn: 自动化项属性配置。
+                        en_us: Automation item property configuration.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 自动化项标签。
+                        en_us: Automation item tags.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+            release_stage: experimental
+          skills:
+            type: array
+            description:
+              zh_cn: 技能配置列表，遵循 Agent Skills 规范
+              en_us: List of skill configurations following Agent Skills specification
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: 技能名称（唯一标识），仅支持小写字母、数字和连字符，不能以连字符开头或结尾，不能包含连续连字符。
+                        en_us: >-
+                          Skill name (unique identifier), only lowercase letters, numbers and hyphens allowed, cannot start
+                          or end with hyphen, no consecutive hyphens.
+                      type: string
+                      constraint:
+                        required: true
+                        pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+                        min_len: 1
+                        max_len: 64
+                    display_name:
+                      description:
+                        zh_cn: 技能显示名称。
+                        en_us: Skill display name.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: 技能描述，说明技能的功能和使用场景，帮助 Agent 识别何时使用该技能。
+                        en_us: >-
+                          Skill description explaining what the skill does and when to use it, helping agents identify relevant
+                          tasks.
+                      type: object
+                      constraint:
+                        required: true
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    license:
+                      description:
+                        zh_cn: 技能的许可证信息。
+                        en_us: License applied to the skill.
+                      type: string
+                      constraint:
+                        max_len: 256
+                    compatibility:
+                      description:
+                        zh_cn: 技能的环境兼容性要求，如依赖的系统包、网络访问需求等。
+                        en_us: >-
+                          Environment requirements such as required system packages, network access needs, etc.
+                      type: string
+                      constraint:
+                        max_len: 500
+                    allowed_tools:
+                      description:
+                        zh_cn: 预授权工具列表，空格分隔的工具标识符。
+                        en_us: Space-delimited list of pre-approved tools the skill may use.
+                      type: string
+                      constraint:
+                        max_len: 1024
+                    metadata:
+                      description:
+                        zh_cn: 技能的额外元数据，如作者、版本等。
+                        en_us: Additional metadata for the skill, such as author, version, etc.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    tags:
+                      description:
+                        zh_cn: 技能标签，用于分类和检索。
+                        en_us: Skill tags for categorization and retrieval.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                    files:
+                      description:
+                        zh_cn: 技能文件列表，包含 SKILL.md 及其他辅助文件（如 scripts/、references/、assets/ 下的文件）。
+                        en_us: >-
+                          List of skill files including SKILL.md and other supporting files (such as files under scripts/,
+                          references/, assets/).
+                      type: array
+                      constraint:
+                        array:
+                          item:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 文件名称，包含相对路径（如 SKILL.md、scripts/extract.py、references/REFERENCE.md）。
+                                  en_us: >-
+                                    File name including relative path (e.g., SKILL.md, scripts/extract.py, references/REFERENCE.md).
+                                type: string
+                                constraint:
+                                  required: true
+                                  pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\./]*$
+                                  min_len: 1
+                                  max_len: 256
+                              content:
+                                description:
+                                  zh_cn: 文件内容。
+                                  en_us: File content.
+                                type: string
+                                constraint:
+                                  required: true
+                                  max_len: 131072
+                    skill_url:
+                      description:
+                        zh_cn: 技能包的外部URL地址（如OSS地址），与files字段二选一。当使用URL时，技能文件从该地址加载。
+                        en_us: >-
+                          External URL for skill package (e.g., OSS URL), mutually exclusive with files field. When using
+                          URL, skill files are loaded from this address.
+                      type: string
+                      constraint:
+                        max_len: 512
+                    priority:
+                      description:
+                        zh_cn: 技能优先级，用于排序和选择。值越小优先级越高。
+                        en_us: Skill priority for sorting and selection. Lower value means higher priority.
+                      type: integer
+                      constraint:
+                        min_value: 1
+                        max_value: 10
+                        default_value: 5
+                    last_updated:
+                      description:
+                        zh_cn: 最后更新时间。
+                        en_us: Last update time.
+                      type: time
+            release_stage: experimental

--- a/internal/umodel/schemaspec/data/sls_entitystore.expanded.yaml
+++ b/internal/umodel/schemaspec/data/sls_entitystore.expanded.yaml
@@ -1,0 +1,214 @@
+description:
+  zh_cn: SLS EntityStore 存储，一般用于存储可观测实体以及关系数据。
+  en_us: >-
+    SLS EntityStore storage, usually used to store observable entities and relationship data.
+name: sls_entitystore
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - sls_entitystore
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        properties:
+          region:
+            description:
+              zh_cn: SLS EntityStore 的区域。
+              en_us: The region of the SLS EntityStore.
+            type: string
+            constraint:
+              required: true
+          project:
+            description:
+              zh_cn: SLS EntityStore 的项目。
+              en_us: The project of the SLS EntityStore.
+            type: string
+            constraint:
+              required: true
+          workspace:
+            description:
+              zh_cn: SLS EntityStore 的工作空间。
+              en_us: The workspace of the SLS EntityStore.
+            type: string
+            constraint:
+              required: true

--- a/internal/umodel/schemaspec/data/sls_logstore.expanded.yaml
+++ b/internal/umodel/schemaspec/data/sls_logstore.expanded.yaml
@@ -1,0 +1,261 @@
+description:
+  zh_cn: SLS LogStore 存储，一般用于存储日志数据。
+  en_us: SLS LogStore storage, usually used to store log data.
+name: sls_logstore
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - sls_logstore
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        properties:
+          region:
+            description:
+              zh_cn: SLS LogStore 的区域。
+              en_us: The region of the SLS LogStore.
+            type: string
+            constraint:
+              required: true
+          project:
+            description:
+              zh_cn: SLS LogStore 的项目。
+              en_us: The project of the SLS LogStore.
+            type: string
+            constraint:
+              required: true
+          store:
+            description:
+              zh_cn: SLS LogStore 的名称。
+              en_us: The name of the SLS LogStore.
+            type: string
+            constraint:
+              required: true
+          search_filter:
+            type: string
+            description:
+              zh_cn: 日志库的过滤条件，如果日志库中存储了多种类型的数据，可使用此字段过滤目标数据。
+              en_us: >-
+                The filter condition of the logstore, if the logstore contains multiple types of data, you can use this field
+                to filter the target data.
+            constraint:
+              default_value: '*'
+          spl_filter:
+            type: string
+            release_stage: experimental
+            description:
+              zh_cn: 日志库的 SPL 过滤条件，相比 search_filter 字段，SPL 过滤条件更加灵活，支持更复杂的过滤条件，但性能相对较差。
+              en_us: >-
+                The SPL filter condition of the logstore, compared to the search_filter field, SPL filter conditions are more
+                flexible and support more complex filter conditions, but the performance is relatively poor.
+          spl_view:
+            type: string
+            description:
+              zh_cn: 基于 SPL 生成的视图，一般用于动态生成实体列表、连接等场景。注意：此场景每次需要重新生成视图，性能较差。
+              en_us: >
+                The SPL view of the logstore, usually used to dynamically generate entity lists, connections, etc. Note: This
+                scenario requires re-generating the view each time, and the performance is very poor.
+          spl_notebook:
+            type: string
+            description:
+              zh_cn: >-
+                基于 SPL Notebook 计算出的结果，相比 spl_view 字段，相对更加独立，可直接执行且能 Join 多种数据源。注意：此场景每次需要重新计算生成，性能较差。
+              en_us: >-
+                The result calculated by the SPL Notebook, compared to the spl_view field, it is relatively independent, can
+                be executed directly and can join multiple data sources. Note: This scenario requires re-calculating and generating
+                each time, and the performance is relatively poor.
+          sql_filter:
+            type: string
+            release_stage: experimental
+            description:
+              zh_cn: 日志库的 SQL 过滤条件，相比 search_filter 字段，SQL 过滤条件更加灵活，支持更复杂的过滤条件，但性能相对较差。
+              en_us: >-
+                The SQL filter condition of the logstore, compared to the search_filter field, SQL filter conditions are more
+                flexible and support more complex filter conditions, but the performance is relatively poor.
+          sql_view:
+            type: string
+            description:
+              zh_cn: 基于 SQL 生成的视图，一般用于动态生成实体列表、连接等场景。注意：此场景每次需要重新生成视图，性能较差。
+              en_us: >-
+                The SQL view of the logstore, usually used to dynamically generate entity lists, connections, etc. Note: This
+                scenario requires re-generating the view each time, and the performance is very poor.

--- a/internal/umodel/schemaspec/data/sls_metricstore.expanded.yaml
+++ b/internal/umodel/schemaspec/data/sls_metricstore.expanded.yaml
@@ -1,0 +1,213 @@
+description:
+  zh_cn: SLS MetricStore 存储，一般用于存储指标数据。
+  en_us: SLS MetricStore storage, usually used to store metric data.
+name: sls_metricstore
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - sls_metricstore
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        constraint:
+          required: true
+        properties:
+          region:
+            description:
+              zh_cn: SLS MetricStore 的区域。
+              en_us: The region of the SLS MetricStore.
+            type: string
+            constraint:
+              required: true
+          project:
+            description:
+              zh_cn: SLS MetricStore 的项目。
+              en_us: The project of the SLS MetricStore.
+            type: string
+            constraint:
+              required: true
+          store:
+            description:
+              zh_cn: SLS MetricStore 的名称。
+              en_us: The name of the SLS MetricStore.
+            type: string
+            constraint:
+              required: true

--- a/internal/umodel/schemaspec/data/storage_link.expanded.yaml
+++ b/internal/umodel/schemaspec/data/storage_link.expanded.yaml
@@ -1,0 +1,294 @@
+description:
+  zh_cn: >-
+    StorageLink 用于定义 EntitySet/DataSet 和 Storage 之间的关系。StorageLink 必须包含源 Set 、目标 Storage。
+  en_us: >-
+    StorageLink is used to define the relationship between EntitySet/DataSet and Storage. StorageLink must contain the source
+    Set, destination Storage.
+name: storage_link
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - storage_link
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          src:
+            description:
+              zh_cn: 源 Set 的标识。值不能为空。
+              en_us: The identify of source Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 源 Set 的域。
+                  en_us: >
+                    The domain of the source Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 源 Set 的类型。值不能为空。
+                  en_us: The type of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 源 Set 的名称。值不能为空。
+                  en_us: The name of the source Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+              filter:
+                description:
+                  zh_cn: >-
+                    对于源 Set 的过滤器，用于部分 Link 的场景，例如 EntitySet 中只有"region=cn-beijing"的实体存在此关联。该方式已废弃，请使用 filter_by_entity 替代。
+                  en_us: >-
+                    The filter of the source Set. It is used for some Link scenarios, such as only entities with "region=cn-beijing"
+                    in the EntitySet have this association. This method is deprecated, please use filter_by_entity instead.
+                type: string
+          dest:
+            description:
+              zh_cn: 目标 Set 的标识。值不能为空。
+              en_us: The identify of the destination Set. The value cannot be empty.
+            type: object
+            properties:
+              domain:
+                description:
+                  zh_cn: 目标 Set 的域。
+                  en_us: The domain of the destination Set.
+                type: string
+                constraint:
+                  required: true
+              kind:
+                description:
+                  zh_cn: 目标 Set 的类型。值不能为空。
+                  en_us: The type of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+              name:
+                description:
+                  zh_cn: 目标 Set 的名称。值不能为空。
+                  en_us: The name of the destination Set. The value cannot be empty.
+                type: string
+                constraint:
+                  required: true
+                  min_len: 0
+                  max_len: 127
+          filter_by_entity:
+            description:
+              zh_cn: 在部分Entity具备的Link中，用于标识这部分Entity的过滤条件。
+              en_us: >-
+                In the Link that is only for some entities, used to identify the filtering conditions for these entities.
+            type: string
+          priority:
+            description:
+              zh_cn: Link 的优先级。值可以为空。默认值为5。
+              en_us: The priority of the Link. The value can be empty. The default value is 5.
+            type: integer
+            constraint:
+              default_value: 5
+            release_stage: experimental
+          fields_mapping:
+            type: map
+            description:
+              zh_cn: 用于定义简单的字段映射关系，例如 DataSet 中 Field 的名称与 Storage 中字段名称的映射关系。
+              en_us: >-
+                Used to define simple field mapping relationships, such as the mapping relationship between the name of Field
+                in DataSet and the name of Field in Storage.
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
+        constraint:
+          required: true
+        description:
+          zh_cn: StorageLink 的核心配置部分，定义 EntitySet/DataSet 和 Storage 之间的映射和关联规则。
+          en_us: >-
+            The specification section containing StorageLink configuration, which defines the mapping and association rules
+            between EntitySet/DataSet and Storage.

--- a/internal/umodel/schemaspec/data/trace_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/trace_set.expanded.yaml
@@ -1,0 +1,1102 @@
+description:
+  zh_cn: >-
+    TraceSet 是具有某些共同属性或特征的相关追踪记录的集合。TraceSet 必须包含以下字段：trace_id_field、span_id_field、parent_span_id_field 和 protocol（默认值为opentelemetry）。
+  en_us: >
+    TraceSet is a collection of related trace records that share certain common attributes or characteristics. Each TraceSet
+    must include the following fields: trace_id_field, span_id_field, parent_span_id_field, and protocol (with a default value
+    of opentelemetry).
+name: trace_set
+versions:
+- name: v1.0.0
+  spec:
+    type: object
+    properties:
+      kind:
+        type: string
+        constraint:
+          required: true
+          enum:
+            values:
+            - trace_set
+      schema:
+        type: object
+        properties:
+          url:
+            description:
+              zh_cn: Schema 的 URL。Core 部分都为 "umodel.aliyun.com"
+              en_us: The url of the schema. The Core part is "umodel.aliyun.com"
+            type: string
+            constraint:
+              required: true
+          version:
+            description:
+              zh_cn: Schema 的版本。命名格式为 "v1.2.3"。
+              en_us: The version of the schema. The format is "v1.2.3".
+            type: string
+            constraint:
+              required: true
+        constraint:
+          required: true
+      metadata:
+        type: object
+        properties:
+          name:
+            description:
+              zh_cn: 元素在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+              en_us: >-
+                The name of the Element in UModel System. The value cannot be empty.The value format is lowercase alphanumeric
+                characters.
+            type: string
+            constraint:
+              pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+              required: true
+              min_len: 0
+              max_len: 128
+          display_name:
+            description:
+              zh_cn: 元素在 UModel 系统中的显示名称。值不能为空。
+              en_us: The display name of the Element in UModel System. The value cannot be empty.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          description:
+            description:
+              zh_cn: 元素在 UModel 系统中的描述。
+              en_us: The description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          short_description:
+            description:
+              zh_cn: 元素在 UModel系统中的简短描述。
+              en_us: The short description of the Element in UModel System.
+            type: object
+            properties:
+              zh_cn:
+                description:
+                  zh_cn: 中文描述
+                  en_us: Chinese description
+                type: string
+              en_us:
+                description:
+                  zh_cn: 英文描述
+                  en_us: English description
+                type: string
+          domain:
+            description:
+              zh_cn: 域。值格式为'domain.domain'。可以以点连接。
+              en_us: >-
+                The domain of the Field. The value format is 'domain.domain'. it can be connected in the form of a dot.
+            type: string
+            constraint:
+              pattern: ^[A-Za-z][a-zA-Z0-9-_\\.]*$
+              required: true
+              min_len: 0
+              max_len: 128
+          launch_stage:
+            description:
+              zh_cn: 元素的发布阶段。默认值为 preview。
+              en_us: The launch stage of the Element. The default value is preview.
+            type: string
+            constraint:
+              enum:
+                values:
+                - preview
+                - beta
+                - ga
+                - deprecated
+              default_value: preview
+          icon:
+            description:
+              zh_cn: 元素在UModel系统中的图标。值格式为'url'。
+              en_us: The icon of the Element in UModel System. The value format is 'url'.
+            type: string
+            release_stage: experimental
+            constraint: null
+          uri:
+            description:
+              zh_cn: 用于表示该元素唯一标识。
+              en_us: This field is used to represent the unique identifier of the Element.
+            type: string
+            release_stage: experimental
+            constraint: null
+          tags:
+            description:
+              zh_cn: 用于表示该元素的标签。
+              en_us: This field is used to represent the tags of the Element.
+            type: map
+            constraint:
+              map:
+                min_size: 1
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          properties:
+            description:
+              zh_cn: 用于表示该元素的附加属性。
+              en_us: This field is used to represent the additional properties of the Element.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                  constraint: null
+                value:
+                  type: string
+          common_schema_info:
+            type: object
+            description:
+              zh_cn: >
+                背景：在阿里云可观测业务使用中，内置的UModel数据会作为公共UModel（CommonSchema）默认存在，公共UModel数据以引用方式（CommonSchemaRef）配置在UModel，在查询时动态生成UModel实例并附加该字段作为额外说明。
+                使用方式：该字段不需要手动配置，仅供查看。若存在该字段，则说明对应的UModel实例只可查看，不支持编辑或删除；若不存在该字段，则可根据业务需求按需编辑。
+              en_us: >
+                Background: In the use of Alibaba Cloud Observability business, the built-in UModel data will be defaulted
+                as a common UModel (CommonSchema), and the common UModel data will be configured as a reference (CommonSchemaRef)
+                in the UModel. When querying, a UModel instance will be dynamically generated and the field will be added
+                as an additional description.  Usage: This field does not need to be manually configured, and is only for
+                viewing. If this field exists, it means that the corresponding UModel instance can only be viewed, and editing
+                or deletion is not supported; if this field does not exist, it can be edited according to business needs.
+            properties:
+              group:
+                type: string
+                description:
+                  zh_cn: CommonSchema的Group信息
+                  en_us: The group of the common schema
+              version:
+                type: string
+                description:
+                  zh_cn: CommonSchema的版本号
+                  en_us: The version of the common schema
+        constraint:
+          required: true
+      spec:
+        type: object
+        properties:
+          fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的字段列表。
+              en_us: The fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          time_field:
+            type: string
+            description:
+              zh_cn: 可观测数据的时间字段。一般要求时间字段为时间戳类型，支持秒、毫秒、微秒、纳秒。
+              en_us: >-
+                The time field of the TelemetryData. It is generally required to be a timestamp type, supporting seconds,
+                milliseconds, microseconds, and nanoseconds.
+            constraint:
+              required: false
+          display_field:
+            type: string
+            description:
+              zh_cn: 注意：定位和 `name_fields` 有一定重叠，字段已废弃，请使用 `name_fields` 字段第一个值替代。可观测数据的显示字段。即默认展示的字段。
+              en_us: >
+                Note: This field is deprecated. Please use the `name_fields` field instead. The display field of the TelemetryData.
+                It is the default displayed field.
+            release_stage: experimental
+          name_fields:
+            type: array
+            description:
+              zh_cn: >
+                可观测数据的显示字段。建议按照显示重要性配置先后顺序，前端、算法等在各类场景会根据特点自由选择，例如极窄/引用场景下只取name_fields的第一个值。 例如：服务操作实体，建议取值为 ["operation_name",
+                "service_name"]；
+                     K8s Pod 实体，建议取值为 ["pod_name", "namespace", "cluster"]。
+              en_us: >
+                The name fields of the TelemetryData. It is recommended to configure the display fields in order of importance.
+                Front-end, algorithms, etc. will freely choose according to the characteristics in various scenarios. For
+                example, for service operation entities, it is recommended to take ["operation_name", "service_name"]; For K8s
+                Pod entities, it is recommended to take ["pod_name", "namespace", "cluster"].
+            constraint:
+              array:
+                item:
+                  type: string
+          hidden_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的隐藏字段。即不用作展示的字段。
+              en_us: The hidden fields of the TelemetryData.
+            constraint:
+              array:
+                item:
+                  type: string
+          tag_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的标签字段。标签字段默认聚合在一起显示和分析。
+              en_us: >-
+                The tag fields of the TelemetryData. The tag fields are aggregated by default for display and analysis.
+            constraint:
+              array:
+                item:
+                  type: string
+          ordered_fields:
+            type: array
+            description:
+              zh_cn: 可观测数据的排序字段。即当前数据集的排序字段。
+              en_us: >-
+                The ordered fields of the TelemetryData. It is the ordered field of the current data set.
+            constraint:
+              array:
+                item:
+                  type: string
+          default_order:
+            type: enum
+            description:
+              zh_cn: 可观测数据的默认排序。默认值为 asc。
+              en_us: The default order of the TelemetryData. The default value is asc.
+            constraint:
+              enum:
+                values:
+                - asc
+                - desc
+                default_value: asc
+          attribute_fields:
+            description:
+              zh_cn: TraceSet 的属性列表，值格式为定义追踪属性的字段规格列表。当前未使用。
+              en_us: >-
+                The attributes of the TraceSet. The value format is a list of field specifications that define the trace attributes.
+                It is currently not used.
+            type: array
+            constraint:
+              array:
+                item:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                        en_us: >
+                          The name of the Field in UModel System. The value cannot be empty.The value format is lowercase
+                          alphanumeric characters.
+                      type: string
+                      constraint:
+                        pattern: ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+                        required: true
+                        min_len: 0
+                        max_len: 127
+                    display_name:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的显示名称。值不能为空。
+                        en_us: The display name of the Element in UModel System. The value cannot be empty.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的描述。
+                        en_us: The description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    short_description:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的简短描述。
+                        en_us: The short description of the Element in UModel System.
+                      type: object
+                      properties:
+                        zh_cn:
+                          description:
+                            zh_cn: 中文描述
+                            en_us: Chinese description
+                          type: string
+                        en_us:
+                          description:
+                            zh_cn: 英文描述
+                            en_us: English description
+                          type: string
+                    launch_stage:
+                      description:
+                        zh_cn: 元素的发布阶段。默认值为 preview。
+                        en_us: The launch stage of the Element. The default value is preview.
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - preview
+                          - beta
+                          - ga
+                          - deprecated
+                        default_value: preview
+                    type:
+                      description:
+                        zh_cn: 字段的类型。值必须是以下之一：string、integer、float、boolean、time、json_object、json_array。值不能为空。
+                        en_us: >
+                          The type of the Field. The value must be one of the following: string, integer, float, boolean,
+                          time, json_object, json_array.  The value cannot be empty.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - string
+                          - integer
+                          - float
+                          - boolean
+                          - time
+                          - json_object
+                          - json_array
+                        required: true
+                    value_mapping:
+                      description:
+                        zh_cn: >-
+                          对于枚举值的映射和解释，为了更好的展示映射值含义，对于 mapping 的 value 字段单独定义，value 包含4个字段："name"、"display_name"、"description"和"short_description"。例如，"status"字段的值是"1"，映射为
+                          ：name 为 "running" ，display_name 为"运行中"，description 为"运行中......"，short_description 为"运行中..."。
+                        en_us: >
+                          For the mapping and interpretation of enumeration values, in order to better display the meaning
+                          of the mapping value, the value field of the mapping is defined separately. The value contains 4
+                          fields: "name", "display_name", "description", and "short_description". For example, the value of
+                          the "status" field is "1", the mapping is: name is "running", display_name is "running", description
+                          is "running...", and short_description is "running...".
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                          value:
+                            type: object
+                            properties:
+                              name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的名称。值不能为空。值格式为小写字母数字字符。
+                                  en_us: >
+                                    The name of the Element in UModel System. The value cannot be empty.The value format is
+                                    lowercase alphanumeric characters.
+                                type: string
+                                constraint:
+                                  pattern: ^[a-zA-Z][a-zA-Z0-9-_\.]{0,127}$
+                                  required: true
+                                  min_len: 0
+                                  max_len: 127
+                              display_name:
+                                description:
+                                  zh_cn: 在 UModel 系统中的显示名称。值不能为空。
+                                  en_us: The display name of the Element in UModel System. The value cannot be empty.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的描述。
+                                  en_us: The description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                              short_description:
+                                description:
+                                  zh_cn: 在 UModel 系统中的简短描述。
+                                  en_us: The short description of the Element in UModel System.
+                                type: object
+                                properties:
+                                  zh_cn:
+                                    description:
+                                      zh_cn: 中文描述
+                                      en_us: Chinese description
+                                    type: string
+                                  en_us:
+                                    description:
+                                      zh_cn: 英文描述
+                                      en_us: English description
+                                    type: string
+                    unit:
+                      description:
+                        zh_cn: >
+                          指标的单位，值格式为字符串。 注意：单位仅用于展示，不会进行格式转换，例如 ms 不会自动根据大小转换为 s。 最佳实践：首先配置 data_format ，在大部分可观测场景下，data_format
+                          即可满足需求，unit 填写为空即可。
+                                  若不满足需求，一般建议 data_format 配置通用的 KMB， 并配置 unit 为特定类型。比如温度，可以配置 data_format 为 KMB， 并配置 unit
+                          为 °C。
+                        en_us: >
+                          The unit of the Metric. The value format is a string. Note: The unit is only used for display and
+                          will not be converted, such as ms will not be automatically converted to s. Best practice: First
+                          configure data_format, in most observable scenarios, data_format can meet the needs, and unit can
+                          be filled in as empty. If it does not meet the needs, it is generally recommended to configure data_format
+                          to a common KMB, and configure unit to a specific type. For example, for temperature, you can configure
+                          data_format to KMB and configure unit to °C.
+                      type: string
+                    data_format:
+                      description:
+                        zh_cn: >
+                          指标的格式化方式，值格式为字符串。支持的格式化选项：
+
+                          数值格式化： - KMB: 千、百万、十亿格式化，样例：K,Mil,Bil - milli: 处理为毫秒格式，样例：1,000,000
+
+                          存储格式化： - byte: 处理为字节格式，样例：B/KB/MB - bit: 处理为位格式，样例：b/Kb/Mb
+
+                          速率格式化： - byte_ies_sec: 每秒字节（byte per second）格式化，样例：B/s/KB/s/MB/s - bit_ies_sec: 每秒位（bit per second）格式化，样例：bps/Kbps/Mbps
+                          - iops: 输入输出操作每秒格式化，样例：io/s - reqps: 请求每秒格式化，样例：req/s
+
+                          百分比格式化： - percent: 百分比格式化，取值为1-100，样例：10% - percent_decimal: 百分比格式化，取值为0-1，样例：10%
+
+                          时间格式化： - localtime: 将时间戳转换为本地时间格式 - localtimems: 毫秒时间转换为本地时间格式 - localtimeus: 微秒时间转换为本地时间格式 - localtimens:
+                          纳秒时间转换为本地时间格式 - UTC±n: 将时间戳转换为特定时区的时间
+
+                          持续时间（Duration）格式化： - dtdhms: 持续时间格式化为天、小时、分、秒，样例：d hh:mm:ss - dthms: 持续时间格式化为小时、分、秒，样例：hh:mm:ss
+                          - d: 按天格式化时间 - h: 按小时格式化时间 - m: 按分钟格式化时间 - s: 按秒格式化时间 - ms: 按毫秒格式化时间 - us: 按微秒格式化时间 - ns: 按纳秒格式化时间
+                        en_us: >
+                          The formatting method for metrics, value format is string. Supported formatting options:
+
+                          Numeric formatting: - KMB: Thousands, millions, billions formatting, example: K,Mil,Bil - milli:
+                          Process as millisecond format, example: 1,000,000
+
+                          Storage formatting: - byte: Process as byte format, example: B/KB/MB - bit: Process as bit format,
+                          example: b/Kb/Mb
+
+                          Rate formatting: - byte_ies_sec: Bytes per second formatting, example: B/s/KB/s/MB/s - bit_ies_sec:
+                          Bits per second formatting, example: bps/Kbps/Mbps - iops: Input/output operations per second formatting,
+                          example: io/s - reqps: Requests per second formatting, example: req/s
+
+                          Percentage formatting: - percent: Percentage formatting, value range is 1-100, example: 10% - percent_decimal:
+                          Percentage formatting, value range is 0-1, example: 10%
+
+                          Time formatting: - localtime: Convert timestamp to local time format - localtimems: Convert millisecond
+                          time to local time format - localtimeus: Convert microsecond time to local time format - localtimens:
+                          Convert nanosecond time to local time format - UTC±n: Convert timestamp to specific timezone time
+
+                          Duration formatting: - dtdhms: Format duration as days, hours, minutes, seconds, example: d hh:mm:ss
+                          - dthms: Format duration as hours, minutes, seconds, example: hh:mm:ss - d: Format time by days
+                          - h: Format time by hours - m: Format time by minutes - s: Format time by seconds - ms: Format time
+                          by milliseconds - us: Format time by microseconds - ns: Format time by nanoseconds
+                      type: string
+                      constraint:
+                        enum:
+                          values:
+                          - KMB
+                          - milli
+                          - byte
+                          - bit
+                          - byte_ies_sec
+                          - bit_ies_sec
+                          - iops
+                          - reqps
+                          - percent
+                          - percent_decimal
+                          - localtime
+                          - localtimems
+                          - localtimeus
+                          - localtimens
+                          - UTC-11
+                          - UTC-10
+                          - UTC-9
+                          - UTC-8
+                          - UTC-7
+                          - UTC-6
+                          - UTC-5
+                          - UTC-4
+                          - UTC-3
+                          - UTC-2
+                          - UTC-1
+                          - UTC+0
+                          - UTC+1
+                          - UTC+2
+                          - UTC+3
+                          - UTC+4
+                          - UTC+5
+                          - UTC+6
+                          - UTC+7
+                          - UTC+8
+                          - UTC+9
+                          - UTC+10
+                          - UTC+11
+                          - UTC+12
+                          - dtdhms
+                          - dthms
+                          - d
+                          - h
+                          - m
+                          - s
+                          - ms
+                          - us
+                          - ns
+                        default_value: KMB
+                    analysable:
+                      description:
+                        zh_cn: 用于表示字段是否可分析，即作为Group By的列。默认值为false。
+                        en_us: >-
+                          Used to denote whether the field is analyzable, i.e., serving as a column for Group By. default
+                          value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    filterable:
+                      description:
+                        zh_cn: 用于表示字段是否可过滤，即支持索引过滤。默认值为false。
+                        en_us: >-
+                          Used to indicate whether this field can support filtering, i.e., it supports indexed filtering.
+                          default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    orderable:
+                      description:
+                        zh_cn: 用于表示字段是否可排序。默认值为false。
+                        en_us: Used to indicate whether the field is sortable. default value is false.
+                      type: bool
+                      constraint:
+                        default_value: false
+                    default_order:
+                      description:
+                        zh_cn: 用于表示字段的默认排序顺序。值必须是以下之一：asc、desc。默认值为asc。
+                        en_us: >
+                          Used to indicate the default sorting order of the field. The value must be one of the following:
+                          asc, desc. default value is asc.
+                      type: enum
+                      constraint:
+                        enum:
+                          values:
+                          - asc
+                          - desc
+                          default_value: asc
+                    pattern:
+                      description:
+                        zh_cn: 正则表达式，用于定义字段的值范围（字符串）。
+                        en_us: Regular expression, used to define the range of values for this field (String).
+                      type: string
+                    max_length:
+                      description:
+                        zh_cn: 字符串值的最大长度。仅适用于字符串类型。
+                        en_us: The max length of string value. Only valid for string type.
+                      type: integer
+                    example:
+                      description:
+                        zh_cn: 字段值的示例。值可以为空。
+                        en_us: examples of the field value. The value can be empty.
+                      type: any
+                    max_value:
+                      description:
+                        zh_cn: 字段的最大值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The maximum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    min_value:
+                      description:
+                        zh_cn: 字段的最小值。值可以为空。仅适用于整数和浮点类型。
+                        en_us: >-
+                          The minimum value of the field. The value can be empty. Only valid for integer and float types.
+                      type: number
+                    default_value:
+                      description:
+                        zh_cn: 字段的默认值。值可以为空。
+                        en_us: The default value of the field. The value can be empty.
+                      type: any
+                    icon:
+                      description:
+                        zh_cn: Field 在 UModel 系统中的图标。值格式为'url'。
+                        en_us: The icon of the Element in UModel System. The value format is 'url'.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    uri:
+                      description:
+                        zh_cn: 用于表示该字段唯一标识。
+                        en_us: This field is used to represent the unique identifier of the field.
+                      type: string
+                      release_stage: experimental
+                      constraint: null
+                    tags:
+                      description:
+                        zh_cn: 用于表示该 Field 的标签。
+                        en_us: This field is used to represent the tags of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                    properties:
+                      description:
+                        zh_cn: 用于表示该 Field 的附加属性。
+                        en_us: This field is used to represent the additional properties of the Field.
+                      type: map
+                      constraint:
+                        map:
+                          key:
+                            type: string
+                            constraint: null
+                          value:
+                            type: string
+                min_size: 1
+          trace_id_field:
+            description:
+              zh_cn: TraceSet 的 trace_id 字段名称。
+              en_us: The field name of trace_id of the TraceSet.
+            type: string
+            constraint:
+              required: true
+              default_value: traceId
+          span_id_field:
+            description:
+              zh_cn: TraceSet 的 span_id 字段名称。
+              en_us: The field name of span_id of the TraceSet.
+            type: string
+            constraint:
+              required: true
+              default_value: spanId
+          parent_span_id_field:
+            description:
+              zh_cn: TraceSet 的 parent_span_id 字段名称。
+              en_us: The field name of parent_span_id of the TraceSet.
+            type: string
+            constraint:
+              default_value: parentSpanId
+          protocol:
+            description:
+              zh_cn: 使用的追踪协议。指定追踪数据的格式和标准。
+              en_us: The tracing protocol used. Specifies the format and standard for trace data.
+            type: string
+            constraint:
+              default_value: opentelemetry
+        constraint:
+          required: true
+        description:
+          zh_cn: TraceSet 的核心配置部分，定义追踪数据的结构和处理方式。
+          en_us: The specification section containing TraceSet configuration.

--- a/internal/umodel/schemaspec/embed.go
+++ b/internal/umodel/schemaspec/embed.go
@@ -1,0 +1,8 @@
+package schemaspec
+
+import "embed"
+
+//go:embed data/*.expanded.yaml
+var embeddedFS embed.FS
+
+const embeddedDir = "data"

--- a/internal/umodel/schemaspec/registry.go
+++ b/internal/umodel/schemaspec/registry.go
@@ -1,0 +1,270 @@
+package schemaspec
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"sort"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Registry struct {
+	schemas map[string]*Schema
+}
+
+func NewRegistry(efs embed.FS, dir string) (*Registry, error) {
+	entries, err := efs.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded dir %q: %w", dir, err)
+	}
+	reg := &Registry{schemas: make(map[string]*Schema)}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := dir + "/" + entry.Name()
+		body, err := efs.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		s, err := parseSchemaBytes(body)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if s == nil {
+			continue
+		}
+		if existing, ok := reg.schemas[s.Name]; ok {
+			return nil, fmt.Errorf("duplicate schema name %q (in %s and earlier source)", s.Name, path)
+		} else {
+			_ = existing
+		}
+		reg.schemas[s.Name] = s
+	}
+	return reg, nil
+}
+
+func newRegistryFromFS(efs fs.ReadDirFS, dir string) (*Registry, error) {
+	entries, err := efs.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %q: %w", dir, err)
+	}
+	reg := &Registry{schemas: make(map[string]*Schema)}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		body, err := fs.ReadFile(efs, dir+"/"+entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+		}
+		s, err := parseSchemaBytes(body)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", entry.Name(), err)
+		}
+		if s != nil {
+			reg.schemas[s.Name] = s
+		}
+	}
+	return reg, nil
+}
+
+func (r *Registry) Lookup(kind string) *Schema {
+	if r == nil {
+		return nil
+	}
+	return r.schemas[kind]
+}
+
+func (r *Registry) Kinds() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.schemas))
+	for k := range r.schemas {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+var (
+	defaultOnce sync.Once
+	defaultReg  *Registry
+	defaultErr  error
+)
+
+func Default() *Registry {
+	defaultOnce.Do(func() {
+		defaultReg, defaultErr = NewRegistry(embeddedFS, embeddedDir)
+	})
+	if defaultErr != nil {
+		panic(fmt.Errorf("schemaspec.Default: %w", defaultErr))
+	}
+	return defaultReg
+}
+
+func parseSchemaBytes(body []byte) (*Schema, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("yaml: %w", err)
+	}
+	return schemaFromRaw(raw)
+}
+
+func schemaFromRaw(raw map[string]any) (*Schema, error) {
+	name, _ := raw["name"].(string)
+	if name == "" {
+		return nil, fmt.Errorf("schema missing name")
+	}
+	versionsRaw, _ := raw["versions"].([]any)
+	if len(versionsRaw) == 0 {
+		return nil, fmt.Errorf("schema %q has no versions", name)
+	}
+	v0, _ := versionsRaw[0].(map[string]any)
+	if v0 == nil {
+		return nil, fmt.Errorf("schema %q versions[0] is malformed", name)
+	}
+	versionName, _ := v0["name"].(string)
+	v0Spec, _ := v0["spec"].(map[string]any)
+	if v0Spec == nil {
+		return nil, fmt.Errorf("schema %q versions[0] has no spec", name)
+	}
+	rootProps, _ := v0Spec["properties"].(map[string]any)
+	if rootProps == nil {
+		return nil, fmt.Errorf("schema %q root spec has no properties", name)
+	}
+	userSpecRaw, _ := rootProps["spec"].(map[string]any)
+	if userSpecRaw == nil {
+		return nil, fmt.Errorf("schema %q has no 'spec' property under versions[0].spec.properties", name)
+	}
+	p, err := parseProperty(userSpecRaw)
+	if err != nil {
+		return nil, fmt.Errorf("schema %q: %w", name, err)
+	}
+	return &Schema{
+		Name:    name,
+		Version: versionName,
+		Spec:    p,
+	}, nil
+}
+
+func parseProperty(raw map[string]any) (Property, error) {
+	var p Property
+	if v, ok := raw["type"].(string); ok {
+		p.Type = v
+	}
+	if v, ok := raw["release_stage"].(string); ok {
+		p.ReleaseStage = v
+	}
+	if propsRaw, ok := raw["properties"].(map[string]any); ok && propsRaw != nil {
+		p.Properties = make(map[string]Property, len(propsRaw))
+		for k, v := range propsRaw {
+			vm, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			sub, err := parseProperty(vm)
+			if err != nil {
+				return p, fmt.Errorf(".properties.%s: %w", k, err)
+			}
+			p.Properties[k] = sub
+		}
+	}
+	if cRaw, ok := raw["constraint"].(map[string]any); ok && cRaw != nil {
+		c, err := parseConstraint(cRaw)
+		if err != nil {
+			return p, fmt.Errorf(".constraint: %w", err)
+		}
+		p.Constraint = &c
+	}
+	return p, nil
+}
+
+func parseConstraint(raw map[string]any) (Constraint, error) {
+	var c Constraint
+	if v, ok := raw["required"].(bool); ok {
+		c.Required = v
+	}
+	if v, ok := raw["pattern"].(string); ok && v != "" {
+		re, err := regexp.Compile(v)
+		if err != nil {
+			return c, fmt.Errorf("pattern %q: %w", v, err)
+		}
+		c.Pattern = re
+		c.PatternStr = v
+	}
+	if v, ok := intFromAny(raw["min_len"]); ok {
+		c.MinLen = &v
+	}
+	if v, ok := intFromAny(raw["max_len"]); ok {
+		c.MaxLen = &v
+	}
+	if v, present := raw["default_value"]; present {
+		c.DefaultValue = v
+	}
+	if e, ok := raw["enum"].(map[string]any); ok && e != nil {
+		if vals, ok := e["values"].([]any); ok {
+			c.Enum = vals
+		}
+	}
+	if arr, ok := raw["array"].(map[string]any); ok && arr != nil {
+		var spec ArraySpec
+		if item, ok := arr["item"].(map[string]any); ok && item != nil {
+			p, err := parseProperty(item)
+			if err != nil {
+				return c, fmt.Errorf("array.item: %w", err)
+			}
+			spec.Item = p
+		}
+		if v, ok := intFromAny(arr["min_size"]); ok {
+			spec.MinSize = &v
+		}
+		if v, ok := intFromAny(arr["max_size"]); ok {
+			spec.MaxSize = &v
+		}
+		c.Array = &spec
+	}
+	if m, ok := raw["map"].(map[string]any); ok && m != nil {
+		var spec MapSpec
+		if k, ok := m["key"].(map[string]any); ok && k != nil {
+			p, err := parseProperty(k)
+			if err != nil {
+				return c, fmt.Errorf("map.key: %w", err)
+			}
+			spec.Key = p
+		}
+		if vv, ok := m["value"].(map[string]any); ok && vv != nil {
+			p, err := parseProperty(vv)
+			if err != nil {
+				return c, fmt.Errorf("map.value: %w", err)
+			}
+			spec.Value = p
+		}
+		if v, ok := intFromAny(m["min_size"]); ok {
+			spec.MinSize = &v
+		}
+		if v, ok := intFromAny(m["max_size"]); ok {
+			spec.MaxSize = &v
+		}
+		c.Map = &spec
+	}
+	return c, nil
+}
+
+func intFromAny(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case uint64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/internal/umodel/schemaspec/registry_test.go
+++ b/internal/umodel/schemaspec/registry_test.go
@@ -1,0 +1,97 @@
+package schemaspec
+
+import (
+	"testing"
+)
+
+func TestDefaultRegistryLoadsEveryKindFromManifest(t *testing.T) {
+	reg := Default()
+	expected := []string{
+		"entity_set", "entity_source", "metric_set", "log_set", "event_set",
+		"trace_set", "profile_set", "runbook_set", "explorer",
+		"sls_logstore", "sls_metricstore", "sls_entitystore",
+		"external_storage", "aliyun_prometheus",
+		"entity_set_link", "entity_source_link", "data_link",
+		"storage_link", "runbook_link", "explorer_link",
+	}
+	for _, kind := range expected {
+		if reg.Lookup(kind) == nil {
+			t.Errorf("expected schema for kind %q to be loaded", kind)
+		}
+	}
+	got := reg.Kinds()
+	if len(got) != len(expected) {
+		t.Fatalf("expected %d kinds, got %d: %v", len(expected), len(got), got)
+	}
+}
+
+func TestRegistryLookupReturnsNilForUnknownKind(t *testing.T) {
+	if Default().Lookup("not_a_real_kind") != nil {
+		t.Fatal("unknown kind should return nil")
+	}
+}
+
+func TestEntitySetLinkSchemaCarriesRequiredEntityLinkType(t *testing.T) {
+	s := Default().Lookup("entity_set_link")
+	if s == nil {
+		t.Fatal("entity_set_link schema missing")
+	}
+	prop, ok := s.Spec.Properties["entity_link_type"]
+	if !ok {
+		t.Fatal("entity_link_type property not present in spec")
+	}
+	if prop.Constraint == nil || !prop.Constraint.Required {
+		t.Fatalf("entity_link_type must be required, got constraint=%+v", prop.Constraint)
+	}
+}
+
+func TestEntitySetLinkSchemaCarriesSrcAndDestEndpoints(t *testing.T) {
+	s := Default().Lookup("entity_set_link")
+	for _, endpoint := range []string{"src", "dest"} {
+		prop, ok := s.Spec.Properties[endpoint]
+		if !ok {
+			t.Fatalf("%s endpoint property is missing", endpoint)
+		}
+		for _, field := range []string{"domain", "kind", "name"} {
+			sub, ok := prop.Properties[field]
+			if !ok {
+				t.Errorf("%s.%s is missing", endpoint, field)
+				continue
+			}
+			if sub.Constraint == nil || !sub.Constraint.Required {
+				t.Errorf("%s.%s should be required, got constraint=%+v", endpoint, field, sub.Constraint)
+			}
+		}
+	}
+}
+
+func TestEntitySetSchemaCarriesFieldsArrayWithRequiredItemNameAndType(t *testing.T) {
+	s := Default().Lookup("entity_set")
+	if s == nil {
+		t.Fatal("entity_set schema missing")
+	}
+	fields, ok := s.Spec.Properties["fields"]
+	if !ok {
+		t.Fatal("fields property missing")
+	}
+	if fields.Type != "array" {
+		t.Fatalf("fields.type expected array, got %q", fields.Type)
+	}
+	if fields.Constraint == nil || fields.Constraint.Array == nil {
+		t.Fatal("fields.constraint.array missing")
+	}
+	item := fields.Constraint.Array.Item
+	if item.Type != "object" {
+		t.Fatalf("fields[].type expected object, got %q", item.Type)
+	}
+	for _, want := range []string{"name", "type"} {
+		sub, ok := item.Properties[want]
+		if !ok {
+			t.Errorf("fields[].%s missing", want)
+			continue
+		}
+		if sub.Constraint == nil || !sub.Constraint.Required {
+			t.Errorf("fields[].%s should be required, got constraint=%+v", want, sub.Constraint)
+		}
+	}
+}

--- a/internal/umodel/schemaspec/types.go
+++ b/internal/umodel/schemaspec/types.go
@@ -1,0 +1,51 @@
+package schemaspec
+
+import "regexp"
+
+type Schema struct {
+	Name    string
+	Version string
+	Spec    Property
+}
+
+type Property struct {
+	Type         string
+	Properties   map[string]Property
+	Constraint   *Constraint
+	ReleaseStage string
+}
+
+type Constraint struct {
+	Required     bool
+	Enum         []any
+	Pattern      *regexp.Regexp
+	PatternStr   string
+	MinLen       *int
+	MaxLen       *int
+	Array        *ArraySpec
+	Map          *MapSpec
+	DefaultValue any
+}
+
+type ArraySpec struct {
+	Item    Property
+	MinSize *int
+	MaxSize *int
+}
+
+type MapSpec struct {
+	Key     Property
+	Value   Property
+	MinSize *int
+	MaxSize *int
+}
+
+type Result struct {
+	Errors   []Issue
+	Warnings []Issue
+}
+
+type Issue struct {
+	Path   string
+	Reason string
+}

--- a/internal/umodel/schemaspec/validator.go
+++ b/internal/umodel/schemaspec/validator.go
@@ -1,0 +1,47 @@
+package schemaspec
+
+import (
+	"fmt"
+
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+type Validator struct {
+	registry *Registry
+}
+
+func NewValidator(reg *Registry) *Validator {
+	return &Validator{registry: reg}
+}
+
+func DefaultValidator() *Validator {
+	return NewValidator(Default())
+}
+
+// NewNoopValidator returns a validator that accepts every element. Intended for
+// test code that needs to exercise downstream behavior without supplying a
+// schema-complete spec.
+func NewNoopValidator() *Validator {
+	return &Validator{}
+}
+
+// Validate returns the result of validating element.Spec against the schema for
+// element.Kind. The returned error is non-nil only when the kind itself is
+// unknown to the registry; field-level problems are reported in Result.
+//
+// TODO(v2): respect element.Version; today we always use versions[0].
+// TODO(v2): also validate the kind/schema/metadata envelope (currently
+// elementFromPayload validates the minimum imperatively before the element
+// reaches this layer).
+func (v *Validator) Validate(element model.UModelElement) (Result, error) {
+	if v == nil || v.registry == nil {
+		return Result{}, nil
+	}
+	s := v.registry.Lookup(element.Kind)
+	if s == nil {
+		return Result{}, fmt.Errorf("unknown kind %q", element.Kind)
+	}
+	var res Result
+	walk(element.Spec, s.Spec, "spec", &res)
+	return res, nil
+}

--- a/internal/umodel/schemaspec/validator_test.go
+++ b/internal/umodel/schemaspec/validator_test.go
@@ -1,0 +1,203 @@
+package schemaspec_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/umodel/schemaspec"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+func TestValidateReturnsErrorForUnknownKind(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	_, err := v.Validate(model.UModelElement{Kind: "not_a_real_kind", Domain: "d", Name: "n"})
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+	if !strings.Contains(err.Error(), "unknown kind") {
+		t.Fatalf("error message should mention unknown kind, got: %v", err)
+	}
+}
+
+func TestNoopValidatorAcceptsEverything(t *testing.T) {
+	v := schemaspec.NewNoopValidator()
+	res, err := v.Validate(model.UModelElement{Kind: "anything_goes", Spec: map[string]any{"garbage": true}})
+	if err != nil {
+		t.Fatalf("noop validator must never error, got %v", err)
+	}
+	if len(res.Errors) != 0 || len(res.Warnings) != 0 {
+		t.Fatalf("noop validator must produce no issues, got %+v", res)
+	}
+}
+
+func TestValidateEntitySetLinkRegression(t *testing.T) {
+	// Regression: the pre-fix incident-investigation YAMLs used the wrong
+	// field names (source/destination/relation_type) and were missing the
+	// required entity_link_type. Verify that this combination is caught.
+	v := schemaspec.DefaultValidator()
+	el := model.UModelElement{
+		Kind: "entity_set_link", Domain: "demo", Name: "demo.bad",
+		Spec: map[string]any{
+			"source":        map[string]any{"domain": "x", "name": "y"},
+			"destination":   map[string]any{"domain": "z", "name": "w"},
+			"relation_type": "depends_on",
+		},
+	}
+	res, err := v.Validate(el)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasErrorAt(res, "spec.entity_link_type", "required") {
+		t.Errorf("expected required-missing error for spec.entity_link_type, got %+v", res.Errors)
+	}
+	for _, unknown := range []string{"spec.source", "spec.destination", "spec.relation_type"} {
+		if !hasWarningAt(res, unknown, "not defined") {
+			t.Errorf("expected unknown-field warning for %s, got %+v", unknown, res.Warnings)
+		}
+	}
+}
+
+func TestValidateEntitySetLinkValidShape(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	el := model.UModelElement{
+		Kind: "entity_set_link", Domain: "demo", Name: "demo.good",
+		Spec: map[string]any{
+			"src":              map[string]any{"domain": "demo", "kind": "entity_set", "name": "a"},
+			"dest":             map[string]any{"domain": "demo", "kind": "entity_set", "name": "b"},
+			"entity_link_type": "depends_on",
+		},
+	}
+	res, err := v.Validate(el)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("valid link should have zero errors, got %+v", res.Errors)
+	}
+}
+
+func TestValidateEnumViolation(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	// fields[].type carries an enum (string/integer/float/boolean/time/json_object/json_array).
+	el := model.UModelElement{
+		Kind: "entity_set", Domain: "demo", Name: "demo.x",
+		Spec: map[string]any{
+			"fields": []any{
+				map[string]any{"name": "f1", "type": "totally_made_up_type"},
+			},
+		},
+	}
+	res, _ := v.Validate(el)
+	if !hasErrorAt(res, "spec.fields[0].type", "enum") {
+		t.Errorf("expected enum violation on fields[0].type, got %+v", res.Errors)
+	}
+}
+
+func TestValidatePatternViolation(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	// fields[].name carries the pattern ^[a-zA-Z0-9_][a-zA-Z0-9-_\.:]{0,127}$
+	el := model.UModelElement{
+		Kind: "entity_set", Domain: "demo", Name: "demo.x",
+		Spec: map[string]any{
+			"fields": []any{
+				map[string]any{"name": "!!!bad name!!!", "type": "string"},
+			},
+		},
+	}
+	res, _ := v.Validate(el)
+	if !hasErrorAt(res, "spec.fields[0].name", "pattern") {
+		t.Errorf("expected pattern violation on fields[0].name, got %+v", res.Errors)
+	}
+}
+
+func TestValidateTypeMismatch(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	// fields[].name expects string; pass an integer instead.
+	el := model.UModelElement{
+		Kind: "entity_set", Domain: "demo", Name: "demo.x",
+		Spec: map[string]any{
+			"fields": []any{map[string]any{"name": 42, "type": "string"}},
+		},
+	}
+	res, _ := v.Validate(el)
+	if !hasErrorAt(res, "spec.fields[0].name", "expected type") {
+		t.Errorf("expected type mismatch on fields[0].name, got %+v", res.Errors)
+	}
+}
+
+func TestValidateRequiredMissingForNestedEndpoint(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	// src present but missing its required name field.
+	el := model.UModelElement{
+		Kind: "entity_set_link", Domain: "demo", Name: "demo.partial",
+		Spec: map[string]any{
+			"src":              map[string]any{"domain": "demo", "kind": "entity_set"},
+			"dest":             map[string]any{"domain": "demo", "kind": "entity_set", "name": "b"},
+			"entity_link_type": "depends_on",
+		},
+	}
+	res, _ := v.Validate(el)
+	if !hasErrorAt(res, "spec.src.name", "required") {
+		t.Errorf("expected required-missing on spec.src.name, got %+v", res.Errors)
+	}
+}
+
+func TestValidateEntitySetMinimalSpecAccepted(t *testing.T) {
+	// Most existing tests construct minimal entity_set elements; ensure they
+	// still pass to keep blast radius low.
+	v := schemaspec.DefaultValidator()
+	for _, spec := range []map[string]any{
+		nil,
+		{},
+		{"fields": []any{map[string]any{"name": "id", "type": "string"}}},
+	} {
+		el := model.UModelElement{Kind: "entity_set", Domain: "demo", Name: "demo.x", Spec: spec}
+		res, err := v.Validate(el)
+		if err != nil {
+			t.Errorf("validate err for spec %+v: %v", spec, err)
+		}
+		if len(res.Errors) != 0 {
+			t.Errorf("minimal entity_set %+v should pass, got errors %+v", spec, res.Errors)
+		}
+	}
+}
+
+func TestValidateRequiredMissingForEmptyValue(t *testing.T) {
+	// "required" should also fire when the value is nil, not just when the key
+	// is absent. Use entity_set_link.src=nil.
+	v := schemaspec.DefaultValidator()
+	el := model.UModelElement{
+		Kind: "entity_set_link", Domain: "demo", Name: "demo.nilsrc",
+		Spec: map[string]any{
+			"src":              nil,
+			"dest":             map[string]any{"domain": "demo", "kind": "entity_set", "name": "b"},
+			"entity_link_type": "depends_on",
+		},
+	}
+	res, _ := v.Validate(el)
+	// src itself isn't required (only its children are when src is present);
+	// nil should be treated as absence, so no required-missing on src.name.
+	for _, issue := range res.Errors {
+		if strings.HasPrefix(issue.Path, "spec.src") && issue.Reason != "required field is missing" {
+			t.Errorf("did not expect non-required error on spec.src.*: %+v", issue)
+		}
+	}
+}
+
+func hasErrorAt(res schemaspec.Result, pathPrefix, reasonSubstring string) bool {
+	for _, e := range res.Errors {
+		if strings.HasPrefix(e.Path, pathPrefix) && strings.Contains(e.Reason, reasonSubstring) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWarningAt(res schemaspec.Result, pathPrefix, reasonSubstring string) bool {
+	for _, w := range res.Warnings {
+		if strings.HasPrefix(w.Path, pathPrefix) && strings.Contains(w.Reason, reasonSubstring) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/umodel/schemaspec/walk.go
+++ b/internal/umodel/schemaspec/walk.go
@@ -1,0 +1,198 @@
+package schemaspec
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func walk(value any, prop Property, path string, res *Result) {
+	if prop.ReleaseStage == "experimental" || prop.ReleaseStage == "deprecated" {
+		res.Warnings = append(res.Warnings, Issue{
+			Path:   path,
+			Reason: fmt.Sprintf("field is %s and may change in future versions", prop.ReleaseStage),
+		})
+	}
+
+	if value == nil {
+		if prop.Constraint != nil && prop.Constraint.Required {
+			res.Errors = append(res.Errors, Issue{Path: path, Reason: "required field is missing"})
+		}
+		return
+	}
+
+	if prop.Type != "" && !typeMatches(value, prop.Type) {
+		res.Errors = append(res.Errors, Issue{
+			Path:   path,
+			Reason: fmt.Sprintf("expected type %s, got %T", prop.Type, value),
+		})
+		return
+	}
+
+	if prop.Constraint != nil {
+		applyConstraints(value, prop.Constraint, prop.Type, path, res)
+	}
+
+	switch prop.Type {
+	case "object":
+		obj, ok := value.(map[string]any)
+		if !ok {
+			return
+		}
+		walkObject(obj, prop, path, res)
+	case "array":
+		arr, ok := value.([]any)
+		if !ok {
+			return
+		}
+		if prop.Constraint != nil && prop.Constraint.Array != nil {
+			for i, item := range arr {
+				walk(item, prop.Constraint.Array.Item, fmt.Sprintf("%s[%d]", path, i), res)
+			}
+		}
+	case "map":
+		m, ok := value.(map[string]any)
+		if !ok {
+			return
+		}
+		if prop.Constraint != nil && prop.Constraint.Map != nil {
+			for k, v := range m {
+				walk(v, prop.Constraint.Map.Value, path+"."+k, res)
+			}
+		}
+	}
+}
+
+func walkObject(obj map[string]any, prop Property, path string, res *Result) {
+	for k, v := range obj {
+		sub, defined := prop.Properties[k]
+		if !defined {
+			res.Warnings = append(res.Warnings, Issue{
+				Path:   path + "." + k,
+				Reason: "field is not defined in schema",
+			})
+			continue
+		}
+		walk(v, sub, path+"."+k, res)
+	}
+	for k, sub := range prop.Properties {
+		if _, present := obj[k]; present {
+			continue
+		}
+		if sub.Constraint != nil && sub.Constraint.Required {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path + "." + k,
+				Reason: "required field is missing",
+			})
+		}
+	}
+}
+
+func applyConstraints(value any, c *Constraint, propType string, path string, res *Result) {
+	if c == nil {
+		return
+	}
+	if s, ok := value.(string); ok {
+		if c.Pattern != nil && !c.Pattern.MatchString(s) {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("value %q does not match pattern %s", s, c.PatternStr),
+			})
+		}
+		if c.MinLen != nil && len(s) < *c.MinLen {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("length %d is below min_len %d", len(s), *c.MinLen),
+			})
+		}
+		if c.MaxLen != nil && len(s) > *c.MaxLen {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("length %d exceeds max_len %d", len(s), *c.MaxLen),
+			})
+		}
+	}
+	if arr, ok := value.([]any); ok && c.Array != nil {
+		if c.Array.MinSize != nil && len(arr) < *c.Array.MinSize {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("array size %d below min %d", len(arr), *c.Array.MinSize),
+			})
+		}
+		if c.Array.MaxSize != nil && len(arr) > *c.Array.MaxSize {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("array size %d above max %d", len(arr), *c.Array.MaxSize),
+			})
+		}
+	}
+	if m, ok := value.(map[string]any); ok && c.Map != nil {
+		if c.Map.MinSize != nil && len(m) < *c.Map.MinSize {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("map size %d below min %d", len(m), *c.Map.MinSize),
+			})
+		}
+		if c.Map.MaxSize != nil && len(m) > *c.Map.MaxSize {
+			res.Errors = append(res.Errors, Issue{
+				Path:   path,
+				Reason: fmt.Sprintf("map size %d above max %d", len(m), *c.Map.MaxSize),
+			})
+		}
+	}
+	if len(c.Enum) > 0 {
+		if c.DefaultValue != nil && reflect.DeepEqual(value, c.DefaultValue) {
+			return
+		}
+		for _, e := range c.Enum {
+			if reflect.DeepEqual(value, e) {
+				return
+			}
+		}
+		res.Errors = append(res.Errors, Issue{
+			Path:   path,
+			Reason: fmt.Sprintf("value %v is not in enum %v", value, c.Enum),
+		})
+	}
+}
+
+func typeMatches(value any, t string) bool {
+	switch t {
+	case "", "any":
+		return true
+	case "string", "enum", "time":
+		_, ok := value.(string)
+		return ok
+	case "integer":
+		switch x := value.(type) {
+		case int, int64, uint64:
+			return true
+		case float64:
+			return x == float64(int64(x))
+		}
+		return false
+	case "number", "float":
+		switch value.(type) {
+		case int, int64, uint64, float64:
+			return true
+		}
+		return false
+	case "boolean", "bool":
+		_, ok := value.(bool)
+		return ok
+	case "object", "map":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "semantic_string":
+		switch value.(type) {
+		case string, map[string]any:
+			return true
+		}
+		return false
+	case "json", "json_object", "json_array":
+		return true
+	}
+	return true
+}

--- a/internal/umodel/service.go
+++ b/internal/umodel/service.go
@@ -2,8 +2,10 @@ package umodel
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/alibaba/UnifiedModel/internal/umodel/schemaspec"
 	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
 )
@@ -13,18 +15,40 @@ type graphStore interface {
 	GetUModelSnapshot(ctx context.Context, req model.UModelSnapshotRequest) (model.UModelSnapshot, error)
 }
 
+// SchemaValidator is the contract Service uses to enforce schema-driven
+// validation on UModel elements. schemaspec.Validator implements it.
+type SchemaValidator interface {
+	Validate(element model.UModelElement) (schemaspec.Result, error)
+}
+
 type Service struct {
 	graph              graphStore
+	validator          SchemaValidator
 	mu                 sync.RWMutex
 	indexes            map[string]*schemaIndex
 	commonSchemaLoader CommonSchemaLoader
 }
 
-func NewService(graph graphStore) *Service {
-	return &Service{
-		graph:   graph,
-		indexes: make(map[string]*schemaIndex),
+// Option configures Service.
+type Option func(*Service)
+
+// WithValidator overrides the schema validator. Pass
+// schemaspec.NewNoopValidator() in tests that intentionally exercise specs
+// outside the schema (e.g. graphstore round-trip tests).
+func WithValidator(v SchemaValidator) Option {
+	return func(s *Service) { s.validator = v }
+}
+
+func NewService(graph graphStore, opts ...Option) *Service {
+	s := &Service{
+		graph:     graph,
+		validator: schemaspec.DefaultValidator(),
+		indexes:   make(map[string]*schemaIndex),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 type CommonSchemaLoader interface {
@@ -38,18 +62,44 @@ func (s *Service) SetCommonSchemaLoader(loader CommonSchemaLoader) {
 }
 
 func (s *Service) Validate(ctx context.Context, workspace string, elements []model.UModelElement) (model.ValidationResult, error) {
-	for _, element := range elements {
+	var errors, warnings []model.ErrorDetail
+	for i, element := range elements {
 		if element.Kind == "" || element.Domain == "" || element.Name == "" {
-			return model.ValidationResult{
-				Valid: false,
-				Errors: []model.ErrorDetail{{
-					Field:  "kind/domain/name",
-					Reason: "umodel element kind, domain, and name are required",
-				}},
-			}, nil
+			errors = append(errors, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].kind/domain/name", i),
+				Reason: "umodel element kind, domain, and name are required",
+			})
+			continue
+		}
+		if s.validator == nil {
+			continue
+		}
+		res, err := s.validator.Validate(element)
+		if err != nil {
+			errors = append(errors, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].kind", i),
+				Reason: err.Error(),
+			})
+			continue
+		}
+		for _, e := range res.Errors {
+			errors = append(errors, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].%s", i, e.Path),
+				Reason: e.Reason,
+			})
+		}
+		for _, w := range res.Warnings {
+			warnings = append(warnings, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].%s", i, w.Path),
+				Reason: w.Reason,
+			})
 		}
 	}
-	return model.ValidationResult{Valid: true}, nil
+	return model.ValidationResult{
+		Valid:    len(errors) == 0,
+		Errors:   errors,
+		Warnings: warnings,
+	}, nil
 }
 
 func (s *Service) PutElements(ctx context.Context, batch model.UModelElementBatch) (model.WriteResult, error) {
@@ -61,15 +111,21 @@ func (s *Service) PutElements(ctx context.Context, batch model.UModelElementBatc
 		return model.WriteResult{}, err
 	}
 	if !validation.Valid {
-		return model.WriteResult{}, apperrors.WithDetails(apperrors.CodeValidationFailed, "umodel validation failed", map[string]string{
-			"field": validation.Errors[0].Field,
-		})
+		details := map[string]string{
+			"field":  validation.Errors[0].Field,
+			"reason": validation.Errors[0].Reason,
+		}
+		if len(validation.Errors) > 1 {
+			details["additional_errors"] = fmt.Sprintf("%d", len(validation.Errors)-1)
+		}
+		return model.WriteResult{}, apperrors.WithDetails(apperrors.CodeValidationFailed, "umodel validation failed", details)
 	}
 	result, err := s.graph.PutUModelElements(ctx, batch)
 	if err != nil {
 		return model.WriteResult{}, err
 	}
 	s.mergeIndex(batch.Workspace, batch.Elements)
+	result.Warnings = append(result.Warnings, validation.Warnings...)
 	return result, nil
 }
 

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -91,6 +91,7 @@ type WriteResult struct {
 	Accepted int               `json:"accepted"`
 	Failed   int               `json:"failed"`
 	Items    []BatchItemResult `json:"items,omitempty"`
+	Warnings []ErrorDetail     `json:"warnings,omitempty"`
 }
 
 type UModelElement struct {
@@ -153,8 +154,9 @@ type UModelSnapshot struct {
 }
 
 type ValidationResult struct {
-	Valid  bool          `json:"valid"`
-	Errors []ErrorDetail `json:"errors,omitempty"`
+	Valid    bool          `json:"valid"`
+	Errors   []ErrorDetail `json:"errors,omitempty"`
+	Warnings []ErrorDetail `json:"warnings,omitempty"`
 }
 
 type EntityTypeRef struct {


### PR DESCRIPTION
## Summary

- `Service.Validate` previously only checked `kind/domain/name` were non-empty. Any spec block sailed through `umctl umodel put`, REST `PUT /api/v1/umodel/{ws}/elements`, the `umodel_import` MCP tool, and the directory import — only CI's offline Python validator (`make example-validate`) caught schema violations. That's exactly how PR #5's entity_set_link YAMLs (`source/destination/relation_type` instead of `src/dest/entity_link_type`) were silently persisted.
- This PR ports schema-driven validation into Go, so every runtime write path enforces it the same way the offline Python validator does.

## What's new

- **New `internal/umodel/schemaspec` package** owns schemas + validator + tests. The 20 `expanded_schemas/*.expanded.yaml` are mirrored into `internal/umodel/schemaspec/data/` and consumed via `//go:embed` (binary stays self-contained).
- **v1 checks**: `required`, type, `enum`, `pattern`, `min_len/max_len`, array `min/max_size`, unknown-field → warning, `release_stage` → warning, unknown-kind → error. Matches the Python validator for the rules in scope; `oneOf`, deep `semantic_string`, and cross-field constraints are explicitly deferred to v2 (`// TODO` comments mark the gaps).
- **Warnings flow through to clients**: new optional `Warnings` field on `model.ValidationResult` and `model.WriteResult`. REST `/validate`, PUT elements, MCP `umodel_validate`, and `umodel_import` all surface unknown-field / experimental-field warnings without rejecting the write.
- **`umodel.NewService` takes a `WithValidator` option** (default: `schemaspec.DefaultValidator()`). Tests that intentionally exercise lax inputs can opt out via `schemaspec.NewNoopValidator()` — used only where genuinely needed (zero such uses in this PR; the strict default fit ≤1 existing fixture change).
- **`make schemas-embed`** target syncs the mirror from `expanded_schemas/`; **`make schemas-embed-check`** (chained into `make ci`) fails the build if the mirror drifts.

## Blast radius

Audited every site that constructs `UModelElement` or calls `PutElements`. Only **one** existing test fixture broke (`TestValidateAcceptsValidUModelElements` constructed an `entity_set` field without the schema-required `type`); fixed by adding `type: \"string\"`. Every bundled example (`examples/quickstart-multidomain/**`, `examples/incident-investigation/**`) passes the strict validator end-to-end through the directory import path.

## Test plan

- [ ] \`make schemas-embed-check\`
- [ ] \`go test ./internal/umodel/schemaspec/...\` (registry + table-driven validator tests, including the incident-investigation regression)
- [ ] \`go test ./...\`
- [ ] \`make example-validate\` (Python parity smoke)
- [ ] Manual: hit \`POST /api/v1/umodel/demo/validate\` with a known-bad entity_set_link via curl, verify response has \`errors\` and \`warnings\` arrays populated
- [ ] Manual MCP: invoke \`umodel_validate\` via \`umodel-mcp\` with the same bad element and verify warnings propagate

## Out of scope (documented)

- Validating the kind/schema/metadata envelope (handled imperatively in `elementFromPayload` today)
- Per-workspace schema overrides (signature preserved for v2)
- Replacing the Python validator — both coexist; CI's `make example-validate` stays for cross-language parity