### PR TITLE
fix(ci): re-embed runbook_set schema to unblock main

### DIFF
--- a/internal/umodel/schemaspec/data/runbook_set.expanded.yaml
+++ b/internal/umodel/schemaspec/data/runbook_set.expanded.yaml
@@ -1266,7 +1266,7 @@ versions:
                                 type: string
                     content_type:
                       description:
-                        zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel buildin 支持的类型为 markdown。
+                        zh_cn: 内容类型，支持markdown、html、url、pdf等。UModel 内置支持的类型为 markdown。
                         en_us: >-
                           Content type such as markdown, html, url, pdf. UModel built-in supported type is markdown.
                       type: string


### PR DESCRIPTION
## Summary

- Main CI has been failing since #4 because that commit updated `expanded_schemas/runbook_set.expanded.yaml` (rename `UModel buildin` → `UModel 内置`) but did not regenerate the embedded copy under `internal/umodel/schemaspec/data/`.
- `make schemas-embed-check` (part of `make ci`) detects this drift and fails the build.
- This PR runs `make schemas-embed` so the embedded copy matches the source of truth. One-line change in the generated file.

## Test plan

- [x] `make schemas-embed-check` passes locally
- [x] `diff -r expanded_schemas/ internal/umodel/schemaspec/data/ --exclude='*.md'` is empty
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)