### PR TITLE
Add native search query support

### DIFF
--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -290,7 +290,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/QueryResult"
+                $ref: "#/components/schemas/QueryExecuteResponse"
   /api/v1/query/{workspace}/explain:
     post:
       operationId: explainQuery
@@ -558,6 +558,48 @@ components:
               type: string
         explain:
           $ref: "#/components/schemas/QueryExplain"
+    QueryExecuteResponse:
+      type: object
+      required: [code, data, message, success]
+      properties:
+        code:
+          type: string
+          example: "200"
+        message:
+          type: string
+          example: successful
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          required: [data, header, responseStatus]
+          properties:
+            data:
+              type: array
+              items:
+                type: array
+                items: {}
+            header:
+              type: array
+              items:
+                type: string
+            responseStatus:
+              type: object
+              required: [result, retryPolicy, level, statusItem]
+              properties:
+                result:
+                  type: string
+                  example: Success
+                retryPolicy:
+                  type: string
+                  example: None
+                level:
+                  type: string
+                  example: Info
+                statusItem:
+                  type: array
+                  items: {}
     QueryExplain:
       type: object
       properties:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/alibaba/UnifiedModel/internal/graphstore/provider/ladybug"
 	"github.com/alibaba/UnifiedModel/internal/query"
 	"github.com/alibaba/UnifiedModel/internal/sampledata"
+	"github.com/alibaba/UnifiedModel/internal/search"
 	"github.com/alibaba/UnifiedModel/internal/umodel"
 	"github.com/alibaba/UnifiedModel/internal/workspace"
 	"github.com/alibaba/UnifiedModel/pkg/contract"
@@ -31,6 +32,7 @@ type App struct {
 	EntityStore  *entitystore.Service
 	Samples      *sampledata.Service
 	Query        *query.Service
+	Search       *search.Service
 	AgentGateway *agentgateway.Service
 }
 
@@ -74,10 +76,15 @@ func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig) (*A
 	if err != nil {
 		return nil, fmt.Errorf("create graphstore provider: %w", err)
 	}
-	umodelSvc := umodel.NewService(graph)
-	entitySvc := entitystore.NewService(graph, umodelSvc)
+	searchProvider, err := search.NewProvider(search.ProviderConfig{Type: search.ProviderTypeMemory, DataRoot: dataRoot})
+	if err != nil {
+		return nil, fmt.Errorf("create search provider: %w", err)
+	}
+	searchSvc := search.NewService(searchProvider, nil, search.ProviderTypeMemory)
+	umodelSvc := umodel.NewService(graph, umodel.WithSearchIndexer(searchSvc))
+	entitySvc := entitystore.NewService(graph, umodelSvc, entitystore.WithSearchIndexer(searchSvc))
 	sampleSvc := sampledata.NewService(umodelSvc, entitySvc)
-	querySvc := query.NewService(graph)
+	querySvc := query.NewServiceWithSearch(graph, searchSvc)
 	agentSvc := agentgateway.NewService(querySvc, agentgateway.WithWriteServices(umodelSvc, entitySvc))
 
 	return &App{
@@ -87,6 +94,7 @@ func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig) (*A
 		EntityStore:  entitySvc,
 		Samples:      sampleSvc,
 		Query:        querySvc,
+		Search:       searchSvc,
 		AgentGateway: agentSvc,
 	}, nil
 }
@@ -336,7 +344,7 @@ func (a *App) handleQuery(w http.ResponseWriter, r *http.Request) {
 			writeError(w, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, result)
+		writeJSON(w, http.StatusOK, model.NewQueryExecuteResponse(result))
 	case "explain":
 		explain, err := a.Query.Explain(r.Context(), workspaceID, req)
 		if err != nil {

--- a/internal/bootstrap/quickstart_test.go
+++ b/internal/bootstrap/quickstart_test.go
@@ -39,6 +39,55 @@ func TestLoadQuickStartCreatesWorkspaceAndImportsSample(t *testing.T) {
 	if len(rows.Rows) == 0 {
 		t.Fatalf("expected quickstart sample entity rows, got %+v", rows)
 	}
+
+	entitySearch, err := app.Query.Execute(ctx, DefaultQuickStartWorkspaceID, model.QueryRequest{
+		Query: ".entity with(domain='devops', name='devops.service', query='checkout', mode='vector', topk=5)",
+	})
+	if err != nil {
+		t.Fatalf("search quickstart entities: %v", err)
+	}
+	assertSearchResult(t, entitySearch, "vector")
+
+	umodelSearch, err := app.Query.Execute(ctx, DefaultQuickStartWorkspaceID, model.QueryRequest{
+		Query: ".umodel with(kind='entity_set', query='service', mode='keyword', topk=5)",
+	})
+	if err != nil {
+		t.Fatalf("search quickstart umodel: %v", err)
+	}
+	assertSearchResult(t, umodelSearch, "keyword")
+}
+
+func TestRunbookSetSearchIsConfigured(t *testing.T) {
+	ctx := context.Background()
+	app := NewMemoryApp(t.TempDir())
+
+	if _, err := app.Samples.Import(ctx, "incident", "incident-investigation"); err != nil {
+		t.Fatalf("import incident sample: %v", err)
+	}
+
+	result, err := app.Query.Execute(ctx, "incident", model.QueryRequest{
+		Query: ".runbook_set with(domain='platform', type='knowledge', query='retry', mode='keyword', topk=5)",
+	})
+	if err != nil {
+		t.Fatalf("search runbook set: %v", err)
+	}
+	assertSearchResult(t, result, "keyword")
+}
+
+func assertSearchResult(t *testing.T, result model.QueryResult, mode string) {
+	t.Helper()
+	if len(result.Rows) == 0 {
+		t.Fatalf("expected search rows, got %+v", result)
+	}
+	if result.Explain == nil {
+		t.Fatalf("expected search explain, got %+v", result)
+	}
+	if result.Explain.SearchMode != mode {
+		t.Fatalf("unexpected search mode: %+v", result.Explain)
+	}
+	if result.Explain.SearchProvider != "memory" {
+		t.Fatalf("unexpected search provider: %+v", result.Explain)
+	}
 }
 
 func TestLoadQuickStartIsSafeWithExistingWorkspace(t *testing.T) {

--- a/internal/entitystore/service.go
+++ b/internal/entitystore/service.go
@@ -2,11 +2,13 @@ package entitystore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
 	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
 )
@@ -21,22 +23,38 @@ type schemaResolver interface {
 	ValidateRelationPayload(ctx context.Context, payload model.RelationPayload) (model.ValidationResult, error)
 }
 
+type searchIndexer interface {
+	Index(ctx context.Context, workspace string, chunks []searchcontract.Chunk) error
+	DeleteByDocID(ctx context.Context, workspace string, docIDs []string) error
+}
+
+type Option func(*Service)
+
+func WithSearchIndexer(indexer searchIndexer) Option {
+	return func(s *Service) { s.search = indexer }
+}
+
 type Service struct {
 	graph    graphStore
 	resolver schemaResolver
+	search   searchIndexer
 
 	mu                  sync.Mutex
 	entityIdempotency   map[string]model.WriteResult
 	relationIdempotency map[string]model.WriteResult
 }
 
-func NewService(graph graphStore, resolver schemaResolver) *Service {
-	return &Service{
+func NewService(graph graphStore, resolver schemaResolver, opts ...Option) *Service {
+	s := &Service{
 		graph:               graph,
 		resolver:            resolver,
 		entityIdempotency:   make(map[string]model.WriteResult),
 		relationIdempotency: make(map[string]model.WriteResult),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 func (s *Service) WriteEntities(ctx context.Context, workspace string, batch model.EntityWriteBatch) (model.WriteResult, error) {
@@ -76,6 +94,7 @@ func (s *Service) WriteEntities(ctx context.Context, workspace string, batch mod
 		if err != nil {
 			return model.WriteResult{}, err
 		}
+		s.indexEntities(ctx, workspace, valid.Entities, &graphResult)
 	}
 	result := mergeWriteResults(graphResult, validationResult)
 	if result.Failed > 0 && !batch.PartialSuccess {
@@ -152,6 +171,7 @@ func (s *Service) ExpireEntities(ctx context.Context, workspace string, req mode
 		if err != nil {
 			return model.WriteResult{}, err
 		}
+		s.deleteEntitiesFromSearch(ctx, workspace, req.IDs, &graphResult)
 	}
 	return mergeWriteResults(graphResult, parseResult), nil
 }
@@ -248,12 +268,137 @@ func failedItem(id string, code apperrors.Code, message string, details []model.
 	}
 }
 
+func (s *Service) indexEntities(ctx context.Context, workspace string, payloads []model.EntityPayload, result *model.WriteResult) {
+	if s.search == nil {
+		return
+	}
+	chunks, deleteIDs := entitySearchIndexBatch(payloads)
+	if len(deleteIDs) > 0 {
+		s.deleteEntitiesFromSearch(ctx, workspace, deleteIDs, result)
+	}
+	if len(chunks) == 0 {
+		return
+	}
+	if err := s.search.Index(ctx, workspace, chunks); err != nil {
+		result.Warnings = append(result.Warnings, model.ErrorDetail{
+			Field:  "search_index",
+			Reason: err.Error(),
+		})
+	}
+}
+
+func (s *Service) deleteEntitiesFromSearch(ctx context.Context, workspace string, ids []string, result *model.WriteResult) {
+	if s.search == nil || len(ids) == 0 {
+		return
+	}
+	docIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		docIDs = append(docIDs, "entity/"+id)
+	}
+	if len(docIDs) == 0 {
+		return
+	}
+	if err := s.search.DeleteByDocID(ctx, workspace, docIDs); err != nil {
+		result.Warnings = append(result.Warnings, model.ErrorDetail{
+			Field:  "search_index",
+			Reason: err.Error(),
+		})
+	}
+}
+
+func entitySearchIndexBatch(payloads []model.EntityPayload) ([]searchcontract.Chunk, []string) {
+	chunks := make([]searchcontract.Chunk, 0, len(payloads))
+	deleteIDs := make([]string, 0)
+	for _, payload := range payloads {
+		id := model.EntityStableKey(payload)
+		if id == "" {
+			continue
+		}
+		if entitySearchDeletes(payload) {
+			deleteIDs = append(deleteIDs, id)
+			continue
+		}
+		domain := entityPayloadString(payload["__domain__"])
+		entityType := entityPayloadString(payload["__entity_type__"])
+		entityID := entityPayloadString(payload["__entity_id__"])
+		method := entityPayloadString(payload["__method__"])
+		chunks = append(chunks, searchcontract.Chunk{
+			DocID:  "entity/" + id,
+			Source: ".entity",
+			Kind:   entityType,
+			Domain: domain,
+			Name:   entityType,
+			Text:   searchText(domain, entityType, entityID, method, payload),
+			Attrs: map[string]any{
+				"__entity_id__": entityID,
+				"__method__":    method,
+			},
+			Metadata: map[string]any{
+				"__entity_id__": entityID,
+				"__method__":    method,
+			},
+			Spec: payload,
+		})
+	}
+	return chunks, deleteIDs
+}
+
+func entitySearchDeletes(payload model.EntityPayload) bool {
+	switch strings.ToLower(entityPayloadString(payload["__method__"])) {
+	case "expire", "delete":
+		return true
+	default:
+		return false
+	}
+}
+
+func entityPayloadString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func searchText(parts ...any) string {
+	var builder strings.Builder
+	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte(' ')
+		}
+		switch typed := part.(type) {
+		case string:
+			builder.WriteString(typed)
+		default:
+			body, err := json.Marshal(typed)
+			if err != nil {
+				builder.WriteString(fmt.Sprint(typed))
+				continue
+			}
+			builder.Write(body)
+		}
+	}
+	return builder.String()
+}
+
 func mergeWriteResults(results ...model.WriteResult) model.WriteResult {
 	var merged model.WriteResult
 	for _, result := range results {
 		merged.Accepted += result.Accepted
 		merged.Failed += result.Failed
 		merged.Items = append(merged.Items, result.Items...)
+		merged.Warnings = append(merged.Warnings, result.Warnings...)
 	}
 	return merged
 }
@@ -313,6 +458,7 @@ func cloneWriteResult(result model.WriteResult) model.WriteResult {
 	for i := range result.Items {
 		result.Items[i].Details = cloneErrorDetails(result.Items[i].Details)
 	}
+	result.Warnings = cloneErrorDetails(result.Warnings)
 	return result
 }
 

--- a/internal/graphstore/provider/ladybug/provider_ladybug.go
+++ b/internal/graphstore/provider/ladybug/provider_ladybug.go
@@ -587,13 +587,41 @@ func entityMatches(payload model.EntityPayload, plan model.QueryPlan) bool {
 }
 
 func relationMatches(payload model.RelationPayload, plan model.QueryPlan) bool {
-	if asBool(payload["__deleted__"]) {
+	if asBool(payload["__deleted__"]) && !hasTimeRange(plan.TimeRange) {
 		return false
 	}
-	if !matchesFilter(asString(payload["__relation_type__"]), plan.Filters["relation_type"]) {
+	if !matchesFilter(asString(payload["__relation_type__"]), firstFilter(plan.Filters["relation_type"], plan.Filters["type"])) {
+		return false
+	}
+	if !matchesFilter(relationEndpointKey(payload, "src"), plan.Filters["src"]) {
+		return false
+	}
+	if !matchesFilter(relationEndpointKey(payload, "dest"), plan.Filters["dest"]) {
+		return false
+	}
+	if plan.GraphCall != nil && len(plan.GraphCall.SeedIDs) > 0 {
+		srcID := asString(payload["__src_entity_id__"])
+		destID := asString(payload["__dest_entity_id__"])
+		if !containsID(plan.GraphCall.SeedIDs, srcID) && !containsID(plan.GraphCall.SeedIDs, destID) {
+			return false
+		}
+	}
+	if !matchesSearch(map[string]any(payload), plan.Filters["query"]) {
 		return false
 	}
 	return visibleInRange(map[string]any(payload), plan.TimeRange)
+}
+
+func relationEndpointKey(payload model.RelationPayload, side string) string {
+	return strings.Join([]string{
+		asString(payload["__"+side+"_domain__"]),
+		asString(payload["__"+side+"_entity_type__"]),
+		asString(payload["__"+side+"_entity_id__"]),
+	}, "/")
+}
+
+func hasTimeRange(timeRange model.TimeRange) bool {
+	return timeRange.From != nil || timeRange.To != nil
 }
 
 func visibleInRange(payload map[string]any, timeRange model.TimeRange) bool {
@@ -618,6 +646,9 @@ func visibleInRange(payload map[string]any, timeRange model.TimeRange) bool {
 	}
 	if first >= to {
 		return false
+	}
+	if asBool(payload["__deleted__"]) {
+		return last > from
 	}
 	return last+keepAlive > from
 }
@@ -664,6 +695,24 @@ func matchesSearch(payload map[string]any, filter any) bool {
 	}
 	for _, value := range payload {
 		if strings.Contains(strings.ToLower(asString(value)), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstFilter(values ...any) any {
+	for _, value := range values {
+		if asString(value) != "" {
+			return value
+		}
+	}
+	return nil
+}
+
+func containsID(ids []string, value string) bool {
+	for _, id := range ids {
+		if id == value {
 			return true
 		}
 	}

--- a/internal/graphstore/provider/ladybug/provider_ladybug_test.go
+++ b/internal/graphstore/provider/ladybug/provider_ladybug_test.go
@@ -125,6 +125,26 @@ func TestLadybugProviderConformance(t *testing.T) {
 	if topoRows.Rows[0]["src"] != "apm/apm.service/54013ba69c196820e56801f1ef5aad54" || topoRows.Rows[0]["dest"] != "apm/apm.service/177627f91af678a9b03e993f1a91917f" || topoRows.Rows[0]["relation"] != "calls" {
 		t.Fatalf("unexpected topo row: %+v", topoRows.Rows[0])
 	}
+	if _, err := provider.WriteRelations(ctx, model.RelationWriteBatch{
+		Workspace: "demo",
+		Relations: []model.RelationPayload{relation("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "177627f91af678a9b03e993f1a91917f")},
+	}); err != nil {
+		t.Fatalf("write unrelated relation: %v", err)
+	}
+	seedTopoRows, err := provider.QueryTopo(ctx, model.TopoQueryPlan{
+		Workspace: "demo",
+		GraphCall: &model.GraphCallPlan{
+			Name:    "getDirectRelations",
+			SeedIDs: []string{"54013ba69c196820e56801f1ef5aad54"},
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("query topo graph-call seed: %v", err)
+	}
+	if len(seedTopoRows.Rows) != 1 || seedTopoRows.Rows[0]["src"] != "apm/apm.service/54013ba69c196820e56801f1ef5aad54" {
+		t.Fatalf("expected graph-call seed to filter unrelated relations, got %+v", seedTopoRows.Rows)
+	}
 	cypherRows, err := provider.QueryTopo(ctx, model.TopoQueryPlan{
 		Workspace: "demo",
 		GraphCall: &model.GraphCallPlan{

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -172,12 +172,12 @@ func paramName(value string) (string, bool) {
 }
 
 func detectSource(queryText string) (string, error) {
-	for _, source := range []string{".umodel", ".entity", ".topo"} {
+	for _, source := range []string{".umodel", ".entity", ".topo", ".runbook_set"} {
 		if strings.HasPrefix(queryText, source) && hasSourceBoundary(queryText, len(source)) {
 			return source, nil
 		}
 	}
-	return "", apperrors.New(apperrors.CodeQueryParseError, "query must start with .umodel, .entity, or .topo")
+	return "", apperrors.New(apperrors.CodeQueryParseError, "query must start with .umodel, .entity, .topo, or .runbook_set")
 }
 
 func hasSourceBoundary(queryText string, pos int) bool {

--- a/internal/query/search_routing.go
+++ b/internal/query/search_routing.go
@@ -1,0 +1,215 @@
+package query
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+const (
+	searchModeKeyword = "keyword"
+	searchModeVector  = "vector"
+	searchModeHybrid  = "hyper"
+)
+
+// searchService is the subset of contract.SearchService that query.Service
+// depends on. Declaring it here keeps the package self-contained and lets
+// tests fake the search path without pulling in pkg/contract.
+type searchService interface {
+	Keyword(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Vector(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Hybrid(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Capabilities(ctx context.Context) (model.SearchCapabilities, error)
+	Health(ctx context.Context) (model.SearchHealth, error)
+}
+
+// shouldRouteToSearch reports whether the plan must be executed by the
+// SearchService instead of the graph store. .runbook_set always routes;
+// the other sources route only when the user picked a search mode.
+func shouldRouteToSearch(plan model.QueryPlan) bool {
+	if plan.Source == ".runbook_set" {
+		return true
+	}
+	switch normalizeSearchMode(plan.Filters["mode"]) {
+	case searchModeKeyword, searchModeVector, searchModeHybrid:
+		return true
+	}
+	return false
+}
+
+func normalizeSearchMode(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.ToLower(strings.TrimSpace(typed))
+	default:
+		return ""
+	}
+}
+
+// buildSearchRequest projects a QueryPlan into the public SearchRequest shape.
+// Keys lifted from filters: domain / name(s) / kind(s) / query / origin /
+// embedding_model / hybrid_k. Remaining unknown keys are forwarded under
+// Filters so providers can use them for predicate pushdown.
+func buildSearchRequest(workspace string, plan model.QueryPlan) model.SearchRequest {
+	req := model.SearchRequest{
+		Workspace: workspace,
+		Source:    plan.Source,
+		TopK:      plan.TopK,
+	}
+	if req.TopK <= 0 {
+		req.TopK = plan.Limit
+	}
+
+	if d := stringFilter(plan.Filters["domain"]); d != "" {
+		req.Domain = d
+	}
+	req.Names = collectStrings(plan.Filters["name"], plan.Filters["names"])
+	req.Kinds = collectStrings(plan.Filters["kind"], plan.Filters["kinds"])
+	if q := stringFilter(plan.Filters["query"]); q != "" {
+		req.Query = q
+	}
+	if origin := stringFilter(plan.Filters["origin"]); origin != "" {
+		req.Origin = origin
+	}
+	if em := stringFilter(plan.Filters["embedding_model"]); em != "" {
+		req.EmbedModel = em
+	}
+	if hk := intFilter(plan.Filters["hybrid_k"]); hk > 0 {
+		req.HybridK = hk
+	}
+
+	known := map[string]struct{}{
+		"mode": {}, "topk": {}, "domain": {}, "name": {}, "names": {},
+		"kind": {}, "kinds": {}, "query": {}, "origin": {},
+		"embedding_model": {}, "hybrid_k": {},
+	}
+	for k, v := range plan.Filters {
+		if _, ok := known[k]; ok {
+			continue
+		}
+		if req.Filters == nil {
+			req.Filters = map[string]any{}
+		}
+		req.Filters[k] = v
+	}
+	return req
+}
+
+func collectStrings(values ...any) []string {
+	var out []string
+	for _, v := range values {
+		switch typed := v.(type) {
+		case string:
+			if typed != "" {
+				out = append(out, typed)
+			}
+		case []string:
+			out = append(out, typed...)
+		case []any:
+			for _, item := range typed {
+				if s, ok := item.(string); ok && s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// dispatchSearch runs the SearchService for plans selected by
+// shouldRouteToSearch and returns a QueryResult compatible with the existing
+// REST surface.
+func dispatchSearch(ctx context.Context, svc searchService, workspace string, plan model.QueryPlan) (model.SearchResult, string, error) {
+	if svc == nil {
+		return model.SearchResult{}, "", apperrors.New(apperrors.CodeProviderUnsupported, "search service is not configured for this query")
+	}
+	req := buildSearchRequest(workspace, plan)
+	mode := normalizeSearchMode(plan.Filters["mode"])
+	if mode == "" {
+		mode = searchModeKeyword
+	}
+	switch mode {
+	case searchModeVector:
+		res, err := svc.Vector(ctx, workspace, req)
+		return res, mode, err
+	case searchModeHybrid:
+		res, err := svc.Hybrid(ctx, workspace, req)
+		return res, mode, err
+	default:
+		res, err := svc.Keyword(ctx, workspace, req)
+		return res, mode, err
+	}
+}
+
+func searchResultToQueryResult(res model.SearchResult, source string, limit int) model.QueryResult {
+	if source == ".entity" {
+		return entitySearchResultToQueryResult(res, limit)
+	}
+	rows := make([]map[string]any, 0, len(res.Rows))
+	for _, row := range res.Rows {
+		rows = append(rows, row.AsMap())
+	}
+	return model.QueryResult{
+		Columns: []string{"__type__", "__domain__", "kind", "name", "metadata", "spec", "__score__"},
+		Rows:    rows,
+		Page:    model.PageRequest{Limit: limit},
+	}
+}
+
+func entitySearchResultToQueryResult(res model.SearchResult, limit int) model.QueryResult {
+	rows := make([]map[string]any, 0, len(res.Rows))
+	baseColumns := []string{
+		"__category__",
+		"__domain__",
+		"__entity_type__",
+		"__entity_id__",
+		"__method__",
+		"__first_observed_time__",
+		"__last_observed_time__",
+		"__keep_alive_seconds__",
+		"__deleted__",
+	}
+	seen := map[string]struct{}{}
+	for _, column := range baseColumns {
+		seen[column] = struct{}{}
+	}
+	extra := map[string]struct{}{}
+
+	for _, searchRow := range res.Rows {
+		row := make(map[string]any, len(searchRow.Spec)+4)
+		for key, value := range searchRow.Spec {
+			row[key] = value
+			if _, ok := seen[key]; !ok && key != "__score__" {
+				extra[key] = struct{}{}
+			}
+		}
+		if _, ok := row["__domain__"]; !ok && searchRow.Domain != "" {
+			row["__domain__"] = searchRow.Domain
+		}
+		if _, ok := row["__entity_type__"]; !ok && searchRow.Kind != "" {
+			row["__entity_type__"] = searchRow.Kind
+		}
+		if _, ok := row["__deleted__"]; !ok {
+			row["__deleted__"] = false
+		}
+		row["__score__"] = searchRow.Score
+		rows = append(rows, row)
+	}
+
+	extraColumns := make([]string, 0, len(extra))
+	for column := range extra {
+		extraColumns = append(extraColumns, column)
+	}
+	sort.Strings(extraColumns)
+	columns := append(append([]string(nil), baseColumns...), extraColumns...)
+	columns = append(columns, "__score__")
+
+	return model.QueryResult{
+		Columns: columns,
+		Rows:    rows,
+		Page:    model.PageRequest{Limit: limit},
+	}
+}

--- a/internal/query/search_routing_test.go
+++ b/internal/query/search_routing_test.go
@@ -1,0 +1,194 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+type fakeSearch struct {
+	lastReq  model.SearchRequest
+	lastMode string
+	rows     []model.SearchRow
+}
+
+func (f *fakeSearch) Keyword(ctx context.Context, ws string, req model.SearchRequest) (model.SearchResult, error) {
+	f.lastReq, f.lastMode = req, "keyword"
+	return model.SearchResult{Rows: f.rows}, nil
+}
+func (f *fakeSearch) Vector(ctx context.Context, ws string, req model.SearchRequest) (model.SearchResult, error) {
+	f.lastReq, f.lastMode = req, "vector"
+	return model.SearchResult{Rows: f.rows}, nil
+}
+func (f *fakeSearch) Hybrid(ctx context.Context, ws string, req model.SearchRequest) (model.SearchResult, error) {
+	f.lastReq, f.lastMode = req, "hyper"
+	return model.SearchResult{Rows: f.rows}, nil
+}
+func (f *fakeSearch) Capabilities(ctx context.Context) (model.SearchCapabilities, error) {
+	return model.SearchCapabilities{VectorSearch: true, HybridSearch: true, RRF: true, EmbedderType: "noop"}, nil
+}
+func (f *fakeSearch) Health(ctx context.Context) (model.SearchHealth, error) {
+	return model.SearchHealth{Provider: "memory", Status: "ok"}, nil
+}
+
+func TestParseAcceptsRunbookSet(t *testing.T) {
+	plan, err := Parse(model.QueryRequest{Query: ".runbook_set with(domain='apm', type='knowledge', query='slow request', mode='hyper', topk=5)"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if plan.Source != ".runbook_set" {
+		t.Fatalf("source = %q, want .runbook_set", plan.Source)
+	}
+	if plan.Filters["type"] != "knowledge" {
+		t.Fatalf("filters[type] = %v, want knowledge", plan.Filters["type"])
+	}
+	if plan.Filters["mode"] != "hyper" {
+		t.Fatalf("filters[mode] = %v, want hyper", plan.Filters["mode"])
+	}
+	if plan.TopK != 5 {
+		t.Fatalf("topk = %d, want 5", plan.TopK)
+	}
+}
+
+func TestExecuteRoutesRunbookSetToSearch(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSearch{rows: []model.SearchRow{{
+		Type:   "apm.runbook_set",
+		Domain: "apm",
+		Kind:   "runbook_set",
+		Name:   "slow-request",
+		Score:  0.42,
+	}}}
+	svc := NewServiceWithSearch(graphstore.NewMemoryStore(), fake)
+
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".runbook_set with(domain='apm', type='knowledge', query='slow request', mode='hyper', topk=5)",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if fake.lastMode != "hyper" {
+		t.Fatalf("dispatched mode = %q, want hyper", fake.lastMode)
+	}
+	if fake.lastReq.Source != ".runbook_set" || fake.lastReq.Domain != "apm" {
+		t.Fatalf("search request misprojected: %+v", fake.lastReq)
+	}
+	if fake.lastReq.TopK != 5 {
+		t.Fatalf("topk lost: %d", fake.lastReq.TopK)
+	}
+	if got := fake.lastReq.Filters["type"]; got != "knowledge" {
+		t.Fatalf("filters[type] = %v, want knowledge", got)
+	}
+	if len(result.Rows) != 1 || result.Rows[0]["__score__"].(float64) != 0.42 {
+		t.Fatalf("rows not projected as search rows: %+v", result.Rows)
+	}
+	if result.Explain == nil || result.Explain.SearchProvider != "memory" || result.Explain.EmbedModel != "noop" || result.Explain.SearchMode != "hyper" {
+		t.Fatalf("explain missing search annotations: %+v", result.Explain)
+	}
+}
+
+func TestExecuteRoutesEntityVectorMode(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSearch{rows: []model.SearchRow{{
+		Domain: "apm",
+		Kind:   "apm.service",
+		Name:   "apm.service",
+		Spec: map[string]any{
+			"__category__":            "entity",
+			"__domain__":              "apm",
+			"__entity_type__":         "apm.service",
+			"__entity_id__":           "10000000000000000000000000000101",
+			"__method__":              "Update",
+			"__first_observed_time__": int64(1704067200),
+			"__last_observed_time__":  int64(4102444800),
+			"__keep_alive_seconds__":  int64(3600),
+			"display_name":            "checkout-service",
+			"status":                  "degraded",
+		},
+		Score: 0.9,
+	}}}
+	svc := NewServiceWithSearch(graphstore.NewMemoryStore(), fake)
+
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity with(domain='apm', name='apm.service', query='checkout', mode='vector', topk=20)",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if fake.lastMode != "vector" {
+		t.Fatalf("dispatched mode = %q, want vector", fake.lastMode)
+	}
+	if len(fake.lastReq.Names) != 1 || fake.lastReq.Names[0] != "apm.service" {
+		t.Fatalf("name not forwarded: %+v", fake.lastReq.Names)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected one result row: %+v", result.Rows)
+	}
+	row := result.Rows[0]
+	if _, ok := row["spec"]; ok {
+		t.Fatalf("entity search row should flatten payload instead of returning spec: %+v", row)
+	}
+	if row["display_name"] != "checkout-service" || row["status"] != "degraded" || row["__score__"] != 0.9 {
+		t.Fatalf("entity payload was not flattened: %+v", row)
+	}
+	for _, column := range []string{"__category__", "__domain__", "__entity_type__", "__entity_id__", "__method__", "__first_observed_time__", "__last_observed_time__", "__keep_alive_seconds__", "__deleted__", "display_name", "status"} {
+		if !containsColumn(result.Columns, column) {
+			t.Fatalf("entity search columns should include %q, got %+v", column, result.Columns)
+		}
+	}
+	if containsColumn(result.Columns, "spec") {
+		t.Fatalf("entity search columns should expose flattened attributes, got %+v", result.Columns)
+	}
+}
+
+func TestExecuteEntityKeywordModeStillRoutesToSearch(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSearch{}
+	svc := NewServiceWithSearch(graphstore.NewMemoryStore(), fake)
+
+	if _, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity with(domain='apm', name='apm.service', query='checkout', mode='keyword')",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if fake.lastMode != "keyword" {
+		t.Fatalf("dispatched mode = %q, want keyword", fake.lastMode)
+	}
+}
+
+func TestExecuteEntityWithoutModeStaysOnGraphStore(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSearch{}
+	svc := NewServiceWithSearch(graphstore.NewMemoryStore(), fake)
+
+	if _, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity with(domain='apm', name='apm.service', query='checkout')",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if fake.lastMode != "" {
+		t.Fatalf("search service called for non-mode query: %q", fake.lastMode)
+	}
+}
+
+func TestRunbookSetRequiresSearchService(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".runbook_set with(domain='apm', type='knowledge', query='x')",
+	})
+	if !apperrors.IsCode(err, apperrors.CodeProviderUnsupported) {
+		t.Fatalf("want provider-unsupported error, got %v", err)
+	}
+}
+
+func containsColumn(columns []string, want string) bool {
+	for _, column := range columns {
+		if column == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -16,13 +16,22 @@ type graphStore interface {
 
 type Service struct {
 	graph    graphStore
+	search   searchService
 	planner  Planner
 	executor *Executor
 }
 
 func NewService(graph graphStore) *Service {
+	return NewServiceWithSearch(graph, nil)
+}
+
+// NewServiceWithSearch builds a Service that can route .runbook_set and any
+// query carrying mode=keyword|vector|hyper to the supplied SearchService.
+// Pass nil for legacy graph-only behavior.
+func NewServiceWithSearch(graph graphStore, search searchService) *Service {
 	return &Service{
 		graph:    graph,
+		search:   search,
 		planner:  Planner{},
 		executor: NewExecutor(graph),
 	}
@@ -33,6 +42,19 @@ func (s *Service) Execute(ctx context.Context, workspace string, req model.Query
 	if err != nil {
 		return model.QueryResult{}, err
 	}
+
+	if shouldRouteToSearch(plan) {
+		searchRes, mode, err := dispatchSearch(ctx, s.search, workspace, plan)
+		if err != nil {
+			return model.QueryResult{}, err
+		}
+		result := searchResultToQueryResult(searchRes, plan.Source, plan.Limit)
+		explain := buildExplain(plan, caps, health)
+		s.annotateSearchExplain(ctx, &explain, mode)
+		result.Explain = &explain
+		return result, nil
+	}
+
 	result, err := s.executor.Execute(ctx, workspace, plan)
 	if err != nil {
 		return model.QueryResult{}, err
@@ -47,7 +69,15 @@ func (s *Service) Explain(ctx context.Context, workspace string, req model.Query
 	if err != nil {
 		return model.QueryExplain{}, err
 	}
-	return buildExplain(plan, caps, health), nil
+	explain := buildExplain(plan, caps, health)
+	if shouldRouteToSearch(plan) {
+		mode := normalizeSearchMode(plan.Filters["mode"])
+		if mode == "" {
+			mode = searchModeKeyword
+		}
+		s.annotateSearchExplain(ctx, &explain, mode)
+	}
+	return explain, nil
 }
 
 func (s *Service) Examples(ctx context.Context) ([]string, error) {
@@ -55,10 +85,27 @@ func (s *Service) Examples(ctx context.Context) ([]string, error) {
 		".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20",
 		".entity with(domain='devops', name='devops.service', query='checkout', topk=20)",
 		".entity with(domain='k8s', name='k8s.workload', query='checkout', topk=20)",
+		".entity with(domain='apm', name='apm.service', query='payment latency spikes', mode='vector', topk=20)",
+		".entity with(domain='apm', name='apm.service', query='checkout failure', mode='hyper', topk=20, hybrid_k=60)",
+		".runbook_set with(domain='apm', type='knowledge', query='how to mitigate slow request', mode='hyper', topk=5)",
+		".runbook_set with(domain='apm', type='observations', query='cache miss spike', mode='vector', topk=10)",
 		".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",
 		".topo | graph-call getDirectRelations([(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",
 		".topo | graph-call cypher(`MATCH (src)-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`)",
 	}, nil
+}
+
+func (s *Service) annotateSearchExplain(ctx context.Context, explain *model.QueryExplain, mode string) {
+	explain.SearchMode = mode
+	if s.search == nil {
+		return
+	}
+	if health, err := s.search.Health(ctx); err == nil {
+		explain.SearchProvider = health.Provider
+	}
+	if caps, err := s.search.Capabilities(ctx); err == nil {
+		explain.EmbedModel = caps.EmbedderType
+	}
 }
 
 func (s *Service) plan(ctx context.Context, workspace string, req model.QueryRequest) (model.QueryPlan, model.GraphStoreCapabilities, model.GraphStoreHealth, error) {

--- a/internal/search/contract/provider.go
+++ b/internal/search/contract/provider.go
@@ -1,0 +1,75 @@
+// Package searchcontract defines the internal Provider and Embedder
+// interfaces that the search Service composes. It is intentionally scoped to
+// internal/search and its sub-packages so external callers go through the
+// public contract.SearchService surface.
+package searchcontract
+
+import (
+	"context"
+
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+// Chunk is the unit of indexable content. A single UModel object may yield
+// multiple chunks (one per field, knowledge section, etc.).
+type Chunk struct {
+	DocID    string
+	Source   string
+	Kind     string
+	Domain   string
+	Name     string
+	Text     string
+	Vector   []float32
+	Attrs    map[string]any
+	Metadata map[string]any
+	Spec     map[string]any
+}
+
+// Hit is a single retrieval result emitted by a Provider.
+type Hit struct {
+	DocID    string
+	Score    float64
+	Type     string
+	Kind     string
+	Domain   string
+	Name     string
+	Metadata map[string]any
+	Spec     map[string]any
+}
+
+// Predicate is the filter-pushdown callback evaluated by the index against
+// the chunk attribute bag.
+type Predicate func(attrs map[string]any) bool
+
+// Query is the internal request shape passed from Service to Provider.
+type Query struct {
+	Workspace string
+	Source    string
+	Domain    string
+	Names     []string
+	Kinds     []string
+	Type      string
+	Text      string
+	Vector    []float32
+	TopK      int
+	Predicate Predicate
+}
+
+// Provider is the indexing + lookup backend that SearchService delegates to.
+type Provider interface {
+	OpenWorkspace(ctx context.Context, ws string) error
+	IndexChunks(ctx context.Context, ws string, chunks []Chunk) error
+	DeleteByDocID(ctx context.Context, ws string, docIDs []string) error
+	Keyword(ctx context.Context, q Query) ([]Hit, error)
+	Vector(ctx context.Context, q Query) ([]Hit, error)
+	Capabilities() model.SearchCapabilities
+	Health() model.SearchHealth
+	Close() error
+}
+
+// Embedder turns query text into a vector used on the vector axis of search.
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+	Dim() int
+	Model() string
+}

--- a/internal/search/embed/noop.go
+++ b/internal/search/embed/noop.go
@@ -1,0 +1,23 @@
+// Package embed holds the Embedder implementations used by the search
+// Service. Only the noop embedder is provided in the default build; real
+// local-ONNX or remote-endpoint embedders land behind build tags or in
+// follow-up milestones.
+package embed
+
+import "context"
+
+// Noop is an Embedder placeholder that returns a single-dim zero vector for
+// every input. It lets vector-mode search wiring pass through end-to-end
+// without pulling in any real embedding dependency.
+type Noop struct{}
+
+func (Noop) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{0}
+	}
+	return out, nil
+}
+
+func (Noop) Dim() int      { return 1 }
+func (Noop) Model() string { return "noop" }

--- a/internal/search/memory.go
+++ b/internal/search/memory.go
@@ -1,0 +1,189 @@
+package search
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+const memoryProviderName = "memory"
+
+// MemoryProvider is the in-process stub Provider used by the default build
+// and unit tests. Keyword retrieval is substring matching against
+// Chunk.Text; vector retrieval reuses a deterministic token-overlap score so
+// vector-mode wiring works end-to-end without a real ANN index.
+type MemoryProvider struct {
+	mu         sync.RWMutex
+	workspaces map[string]map[string]searchcontract.Chunk
+}
+
+func NewMemoryProvider() *MemoryProvider {
+	return &MemoryProvider{
+		workspaces: map[string]map[string]searchcontract.Chunk{},
+	}
+}
+
+func (m *MemoryProvider) OpenWorkspace(ctx context.Context, ws string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.workspaces[ws]; !ok {
+		m.workspaces[ws] = map[string]searchcontract.Chunk{}
+	}
+	return nil
+}
+
+func (m *MemoryProvider) IndexChunks(ctx context.Context, ws string, chunks []searchcontract.Chunk) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.workspaces[ws]; !ok {
+		m.workspaces[ws] = map[string]searchcontract.Chunk{}
+	}
+	for _, c := range chunks {
+		if c.DocID == "" {
+			continue
+		}
+		m.workspaces[ws][c.DocID] = c
+	}
+	return nil
+}
+
+func (m *MemoryProvider) DeleteByDocID(ctx context.Context, ws string, docIDs []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	bucket := m.workspaces[ws]
+	for _, id := range docIDs {
+		delete(bucket, id)
+	}
+	return nil
+}
+
+func (m *MemoryProvider) Keyword(ctx context.Context, q searchcontract.Query) ([]searchcontract.Hit, error) {
+	return m.search(q, false), nil
+}
+
+func (m *MemoryProvider) Vector(ctx context.Context, q searchcontract.Query) ([]searchcontract.Hit, error) {
+	return m.search(q, true), nil
+}
+
+func (m *MemoryProvider) search(q searchcontract.Query, vector bool) []searchcontract.Hit {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	bucket := m.workspaces[q.Workspace]
+	needle := strings.ToLower(q.Text)
+	hits := make([]searchcontract.Hit, 0, len(bucket))
+	for _, c := range bucket {
+		if !matchesFilters(c, q) {
+			continue
+		}
+		score := scoreChunk(c, needle, vector)
+		if score <= 0 {
+			continue
+		}
+		hits = append(hits, searchcontract.Hit{
+			DocID:    c.DocID,
+			Score:    score,
+			Type:     typeFromChunk(c),
+			Kind:     c.Kind,
+			Domain:   c.Domain,
+			Name:     c.Name,
+			Metadata: c.Metadata,
+			Spec:     c.Spec,
+		})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			return hits[i].DocID < hits[j].DocID
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	if q.TopK > 0 && len(hits) > q.TopK {
+		hits = hits[:q.TopK]
+	}
+	return hits
+}
+
+func (m *MemoryProvider) Capabilities() model.SearchCapabilities {
+	return model.SearchCapabilities{
+		VectorSearch:         true,
+		HybridSearch:         false,
+		FilteredVectorSearch: true,
+		RRF:                  false,
+		EmbedderType:         "stub",
+	}
+}
+
+func (m *MemoryProvider) Health() model.SearchHealth {
+	return model.SearchHealth{Provider: memoryProviderName, Status: "ok"}
+}
+
+func (m *MemoryProvider) Close() error { return nil }
+
+func matchesFilters(c searchcontract.Chunk, q searchcontract.Query) bool {
+	if q.Source != "" && c.Source != q.Source {
+		return false
+	}
+	if q.Domain != "" && c.Domain != q.Domain {
+		return false
+	}
+	if len(q.Names) > 0 && !containsString(q.Names, c.Name) {
+		return false
+	}
+	if len(q.Kinds) > 0 && !containsString(q.Kinds, c.Kind) {
+		return false
+	}
+	if q.Type != "" {
+		if attr, _ := c.Attrs["type"].(string); attr != "" && attr != q.Type {
+			return false
+		}
+	}
+	if q.Predicate != nil && !q.Predicate(c.Attrs) {
+		return false
+	}
+	return true
+}
+
+func scoreChunk(c searchcontract.Chunk, needleLower string, vector bool) float64 {
+	if needleLower == "" {
+		return 0
+	}
+	corpus := strings.ToLower(c.Text)
+	if !vector {
+		idx := strings.Index(corpus, needleLower)
+		if idx < 0 {
+			return 0
+		}
+		return 1.0 - float64(idx)/float64(len(c.Text)+1)
+	}
+	tokens := strings.Fields(needleLower)
+	if len(tokens) == 0 {
+		return 0
+	}
+	hit := 0
+	for _, tok := range tokens {
+		if strings.Contains(corpus, tok) {
+			hit++
+		}
+	}
+	return float64(hit) / float64(len(tokens))
+}
+
+func containsString(xs []string, x string) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func typeFromChunk(c searchcontract.Chunk) string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.Kind
+}

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -1,0 +1,64 @@
+package search
+
+import (
+	"fmt"
+	"sync"
+
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
+)
+
+const (
+	ProviderTypeMemory  = "memory"
+	DefaultProviderType = ProviderTypeMemory
+)
+
+type ProviderConfig struct {
+	Type     string
+	DataRoot string
+	Options  map[string]string
+}
+
+type ProviderFactory func(config ProviderConfig) (searchcontract.Provider, error)
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]ProviderFactory{}
+)
+
+func RegisterProvider(providerType string, factory ProviderFactory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[providerType] = factory
+}
+
+func NewProvider(config ProviderConfig) (searchcontract.Provider, error) {
+	providerType := config.Type
+	if providerType == "" {
+		providerType = DefaultProviderType
+	}
+
+	registryMu.RLock()
+	factory := registry[providerType]
+	registryMu.RUnlock()
+	if factory == nil {
+		return nil, fmt.Errorf("search provider %q is not registered", providerType)
+	}
+	return factory(config)
+}
+
+func RegisteredProviders() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	providers := make([]string, 0, len(registry))
+	for providerType := range registry {
+		providers = append(providers, providerType)
+	}
+	return providers
+}
+
+func init() {
+	RegisterProvider(ProviderTypeMemory, func(config ProviderConfig) (searchcontract.Provider, error) {
+		return NewMemoryProvider(), nil
+	})
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -1,0 +1,222 @@
+// Package search hosts the runtime SearchService implementation that backs
+// the `.umodel`, `.entity`, and `.runbook_set` query sources. The package
+// composes a Provider (keyword + vector retrieval) and an Embedder, and
+// implements RRF fusion in-tree for hybrid mode.
+package search
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
+	"github.com/alibaba/UnifiedModel/internal/search/embed"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+const (
+	defaultTopK    = 10
+	defaultHybridK = 60
+)
+
+// Service is the runtime SearchService that wires a Provider and an Embedder
+// together and implements pkg/contract.SearchService.
+type Service struct {
+	provider     searchcontract.Provider
+	embedder     searchcontract.Embedder
+	providerName string
+}
+
+// NewService builds a Service from an already-constructed Provider and
+// Embedder. Pass embed.Noop{} if no embedding stack is configured; the stub
+// memory provider ignores the produced vector anyway.
+func NewService(provider searchcontract.Provider, embedder searchcontract.Embedder, providerName string) *Service {
+	if embedder == nil {
+		embedder = embed.Noop{}
+	}
+	if providerName == "" {
+		providerName = "memory"
+	}
+	return &Service{provider: provider, embedder: embedder, providerName: providerName}
+}
+
+// OpenWorkspace forwards to the underlying Provider so callers can prepare a
+// workspace before issuing any IndexChunks/Search calls.
+func (s *Service) OpenWorkspace(ctx context.Context, ws string) error {
+	return s.provider.OpenWorkspace(ctx, ws)
+}
+
+// Index forwards a batch of chunks into the underlying Provider. The entity
+// and umodel write paths call this on every mutation.
+func (s *Service) Index(ctx context.Context, ws string, chunks []searchcontract.Chunk) error {
+	return s.provider.IndexChunks(ctx, ws, chunks)
+}
+
+// DeleteByDocID forwards a tombstone batch.
+func (s *Service) DeleteByDocID(ctx context.Context, ws string, docIDs []string) error {
+	return s.provider.DeleteByDocID(ctx, ws, docIDs)
+}
+
+func (s *Service) Keyword(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error) {
+	q := s.buildQuery(workspace, req, nil)
+	hits, err := s.provider.Keyword(ctx, q)
+	if err != nil {
+		return model.SearchResult{}, fmt.Errorf("search keyword: %w", err)
+	}
+	return s.rowsFromHits(hits, q.TopK), nil
+}
+
+func (s *Service) Vector(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error) {
+	vec, err := s.embedQuery(ctx, req.Query)
+	if err != nil {
+		return model.SearchResult{}, err
+	}
+	q := s.buildQuery(workspace, req, vec)
+	hits, err := s.provider.Vector(ctx, q)
+	if err != nil {
+		return model.SearchResult{}, fmt.Errorf("search vector: %w", err)
+	}
+	return s.rowsFromHits(hits, q.TopK), nil
+}
+
+func (s *Service) Hybrid(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error) {
+	vec, err := s.embedQuery(ctx, req.Query)
+	if err != nil {
+		return model.SearchResult{}, err
+	}
+	q := s.buildQuery(workspace, req, vec)
+
+	kwHits, err := s.provider.Keyword(ctx, q)
+	if err != nil {
+		return model.SearchResult{}, fmt.Errorf("search hybrid keyword: %w", err)
+	}
+	vecHits, err := s.provider.Vector(ctx, q)
+	if err != nil {
+		return model.SearchResult{}, fmt.Errorf("search hybrid vector: %w", err)
+	}
+
+	k := req.HybridK
+	if k <= 0 {
+		k = defaultHybridK
+	}
+	wKw, wVec := weights(req.Weights)
+	fused := rrf(kwHits, vecHits, k, wKw, wVec)
+	return s.rowsFromHits(fused, q.TopK), nil
+}
+
+func (s *Service) Capabilities(ctx context.Context) (model.SearchCapabilities, error) {
+	caps := s.provider.Capabilities()
+	caps.HybridSearch = true
+	caps.RRF = true
+	if caps.EmbedderType == "" {
+		caps.EmbedderType = s.embedder.Model()
+	}
+	if caps.MaxDim == 0 {
+		caps.MaxDim = s.embedder.Dim()
+	}
+	return caps, nil
+}
+
+func (s *Service) Health(ctx context.Context) (model.SearchHealth, error) {
+	return s.provider.Health(), nil
+}
+
+func (s *Service) embedQuery(ctx context.Context, text string) ([]float32, error) {
+	if text == "" {
+		return nil, nil
+	}
+	vecs, err := s.embedder.Embed(ctx, []string{text})
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+	if len(vecs) == 0 {
+		return nil, nil
+	}
+	return vecs[0], nil
+}
+
+func (s *Service) buildQuery(workspace string, req model.SearchRequest, vec []float32) searchcontract.Query {
+	topK := req.TopK
+	if topK <= 0 {
+		topK = defaultTopK
+	}
+	q := searchcontract.Query{
+		Workspace: workspace,
+		Source:    req.Source,
+		Domain:    req.Domain,
+		Names:     req.Names,
+		Kinds:     req.Kinds,
+		Text:      req.Query,
+		Vector:    vec,
+		TopK:      topK,
+	}
+	if t, ok := req.Filters["type"].(string); ok {
+		q.Type = t
+	}
+	return q
+}
+
+func (s *Service) rowsFromHits(hits []searchcontract.Hit, topK int) model.SearchResult {
+	if topK > 0 && len(hits) > topK {
+		hits = hits[:topK]
+	}
+	rows := make([]model.SearchRow, 0, len(hits))
+	for _, h := range hits {
+		rows = append(rows, model.SearchRow{
+			Type:       h.Type,
+			Domain:     h.Domain,
+			Kind:       h.Kind,
+			Name:       h.Name,
+			Metadata:   h.Metadata,
+			Spec:       h.Spec,
+			Score:      h.Score,
+			Provider:   s.providerName,
+			EmbedModel: s.embedder.Model(),
+		})
+	}
+	return model.SearchResult{Rows: rows}
+}
+
+func weights(w map[string]float64) (float64, float64) {
+	kw, vec := 1.0, 1.0
+	if v, ok := w["keyword"]; ok {
+		kw = v
+	}
+	if v, ok := w["vector"]; ok {
+		vec = v
+	}
+	return kw, vec
+}
+
+// rrf fuses two ranked hit lists with Reciprocal Rank Fusion. Each axis
+// contributes `weight / (k + rank)` to the doc's score; rank is 1-based per
+// the original RRF paper.
+func rrf(kwHits, vecHits []searchcontract.Hit, k int, wKw, wVec float64) []searchcontract.Hit {
+	score := map[string]float64{}
+	merged := map[string]searchcontract.Hit{}
+
+	for rank, h := range kwHits {
+		score[h.DocID] += wKw / float64(k+rank+1)
+		merged[h.DocID] = h
+	}
+	for rank, h := range vecHits {
+		score[h.DocID] += wVec / float64(k+rank+1)
+		if _, ok := merged[h.DocID]; !ok {
+			merged[h.DocID] = h
+		}
+	}
+
+	out := make([]searchcontract.Hit, 0, len(score))
+	for id, s := range score {
+		h := merged[id]
+		h.Score = s
+		out = append(out, h)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].DocID < out[j].DocID
+		}
+		return out[i].Score > out[j].Score
+	})
+	return out
+}

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -1,0 +1,148 @@
+package search_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/search"
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
+	"github.com/alibaba/UnifiedModel/internal/search/embed"
+	"github.com/alibaba/UnifiedModel/pkg/contract"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+func TestService_ImplementsSearchServiceContract(t *testing.T) {
+	var _ contract.SearchService = (*search.Service)(nil)
+}
+
+func TestService_KeywordVectorHybrid(t *testing.T) {
+	ctx := context.Background()
+
+	provider, err := search.NewProvider(search.ProviderConfig{Type: search.ProviderTypeMemory})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	svc := search.NewService(provider, embed.Noop{}, search.ProviderTypeMemory)
+
+	const ws = "demo"
+	if err := svc.OpenWorkspace(ctx, ws); err != nil {
+		t.Fatalf("open workspace: %v", err)
+	}
+	chunks := []searchcontract.Chunk{
+		{DocID: "a", Source: ".entity", Domain: "apm", Kind: "service", Name: "checkout", Text: "checkout service payment latency"},
+		{DocID: "b", Source: ".entity", Domain: "apm", Kind: "service", Name: "cart", Text: "cart service add remove item"},
+		{DocID: "c", Source: ".entity", Domain: "k8s", Kind: "pod", Name: "checkout-pod", Text: "checkout pod kubernetes"},
+	}
+	if err := svc.Index(ctx, ws, chunks); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	t.Run("keyword scoped by domain", func(t *testing.T) {
+		res, err := svc.Keyword(ctx, ws, model.SearchRequest{
+			Source: ".entity",
+			Domain: "apm",
+			Query:  "checkout",
+			TopK:   5,
+		})
+		if err != nil {
+			t.Fatalf("keyword: %v", err)
+		}
+		if len(res.Rows) != 1 {
+			t.Fatalf("want 1 row scoped to apm, got %d", len(res.Rows))
+		}
+		row := res.Rows[0]
+		if row.Name != "checkout" {
+			t.Fatalf("want name=checkout, got %q", row.Name)
+		}
+		if row.Provider != search.ProviderTypeMemory {
+			t.Fatalf("want provider tag, got %q", row.Provider)
+		}
+		if row.EmbedModel == "" {
+			t.Fatalf("want embed model populated")
+		}
+		if row.Score <= 0 {
+			t.Fatalf("want positive score, got %v", row.Score)
+		}
+	})
+
+	t.Run("vector matches token overlap", func(t *testing.T) {
+		res, err := svc.Vector(ctx, ws, model.SearchRequest{
+			Source: ".entity",
+			Query:  "checkout payment",
+			TopK:   5,
+		})
+		if err != nil {
+			t.Fatalf("vector: %v", err)
+		}
+		if len(res.Rows) == 0 {
+			t.Fatalf("want at least one hit")
+		}
+		if res.Rows[0].Name != "checkout" {
+			t.Fatalf("expected checkout to outrank cart/checkout-pod, got %q", res.Rows[0].Name)
+		}
+	})
+
+	t.Run("hybrid fuses both axes", func(t *testing.T) {
+		res, err := svc.Hybrid(ctx, ws, model.SearchRequest{
+			Source: ".entity",
+			Query:  "checkout",
+			TopK:   5,
+		})
+		if err != nil {
+			t.Fatalf("hybrid: %v", err)
+		}
+		if len(res.Rows) < 2 {
+			t.Fatalf("want at least 2 fused rows, got %d", len(res.Rows))
+		}
+		if res.Rows[0].Name != "checkout" && res.Rows[0].Name != "checkout-pod" {
+			t.Fatalf("want checkout-* on top, got %q", res.Rows[0].Name)
+		}
+	})
+
+	t.Run("topk clamps", func(t *testing.T) {
+		res, err := svc.Keyword(ctx, ws, model.SearchRequest{
+			Source: ".entity",
+			Query:  "service",
+			TopK:   1,
+		})
+		if err != nil {
+			t.Fatalf("keyword: %v", err)
+		}
+		if len(res.Rows) != 1 {
+			t.Fatalf("want topk=1 clamp, got %d", len(res.Rows))
+		}
+	})
+
+	t.Run("capabilities advertise hybrid + rrf", func(t *testing.T) {
+		caps, err := svc.Capabilities(ctx)
+		if err != nil {
+			t.Fatalf("caps: %v", err)
+		}
+		if !caps.HybridSearch || !caps.RRF {
+			t.Fatalf("want hybrid+rrf advertised, got %+v", caps)
+		}
+	})
+
+	t.Run("health reports ok", func(t *testing.T) {
+		h, err := svc.Health(ctx)
+		if err != nil {
+			t.Fatalf("health: %v", err)
+		}
+		if h.Status != "ok" {
+			t.Fatalf("want ok, got %q", h.Status)
+		}
+	})
+}
+
+func TestRegisteredProviders_HasMemory(t *testing.T) {
+	found := false
+	for _, p := range search.RegisteredProviders() {
+		if p == search.ProviderTypeMemory {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("memory provider not registered")
+	}
+}

--- a/internal/umodel/service.go
+++ b/internal/umodel/service.go
@@ -2,9 +2,12 @@ package umodel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
+	searchcontract "github.com/alibaba/UnifiedModel/internal/search/contract"
 	"github.com/alibaba/UnifiedModel/internal/umodel/schemaspec"
 	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
@@ -13,6 +16,11 @@ import (
 type graphStore interface {
 	PutUModelElements(ctx context.Context, batch model.UModelElementBatch) (model.WriteResult, error)
 	GetUModelSnapshot(ctx context.Context, req model.UModelSnapshotRequest) (model.UModelSnapshot, error)
+}
+
+type searchIndexer interface {
+	Index(ctx context.Context, workspace string, chunks []searchcontract.Chunk) error
+	DeleteByDocID(ctx context.Context, workspace string, docIDs []string) error
 }
 
 // SchemaValidator is the contract Service uses to enforce schema-driven
@@ -27,6 +35,7 @@ type Service struct {
 	mu                 sync.RWMutex
 	indexes            map[string]*schemaIndex
 	commonSchemaLoader CommonSchemaLoader
+	search             searchIndexer
 }
 
 // Option configures Service.
@@ -37,6 +46,11 @@ type Option func(*Service)
 // outside the schema (e.g. graphstore round-trip tests).
 func WithValidator(v SchemaValidator) Option {
 	return func(s *Service) { s.validator = v }
+}
+
+// WithSearchIndexer connects UModel writes to the runtime search index.
+func WithSearchIndexer(indexer searchIndexer) Option {
+	return func(s *Service) { s.search = indexer }
 }
 
 func NewService(graph graphStore, opts ...Option) *Service {
@@ -126,6 +140,14 @@ func (s *Service) PutElements(ctx context.Context, batch model.UModelElementBatc
 	}
 	s.mergeIndex(batch.Workspace, batch.Elements)
 	result.Warnings = append(result.Warnings, validation.Warnings...)
+	if s.search != nil {
+		if err := s.search.Index(ctx, batch.Workspace, umodelSearchChunks(batch.Elements)); err != nil {
+			result.Warnings = append(result.Warnings, model.ErrorDetail{
+				Field:  "search_index",
+				Reason: err.Error(),
+			})
+		}
+	}
 	return result, nil
 }
 
@@ -245,4 +267,78 @@ func validWriteMethod(value any) bool {
 	default:
 		return false
 	}
+}
+
+func umodelSearchChunks(elements []model.UModelElement) []searchcontract.Chunk {
+	chunks := make([]searchcontract.Chunk, 0, len(elements))
+	for _, element := range elements {
+		key := model.UModelElementKey(element)
+		if key == "" {
+			continue
+		}
+		chunks = append(chunks, searchcontract.Chunk{
+			DocID:  "umodel/" + key,
+			Source: ".umodel",
+			Kind:   element.Kind,
+			Domain: element.Domain,
+			Name:   element.Name,
+			Text:   searchText(element.Kind, element.Domain, element.Name, element.Version, element.Spec),
+			Metadata: map[string]any{
+				"version": element.Version,
+			},
+			Spec: element.Spec,
+		})
+		if element.Kind != "runbook_set" {
+			continue
+		}
+		for _, section := range []string{"knowledge", "observations", "actions", "automations", "skills"} {
+			value, ok := element.Spec[section]
+			if !ok || value == nil {
+				continue
+			}
+			chunks = append(chunks, searchcontract.Chunk{
+				DocID:  "runbook_set/" + key + "/" + section,
+				Source: ".runbook_set",
+				Kind:   element.Kind,
+				Domain: element.Domain,
+				Name:   element.Name,
+				Text:   searchText(element.Kind, element.Domain, element.Name, section, value),
+				Attrs: map[string]any{
+					"type": section,
+				},
+				Metadata: map[string]any{
+					"type":    section,
+					"version": element.Version,
+				},
+				Spec: map[string]any{
+					section: value,
+				},
+			})
+		}
+	}
+	return chunks
+}
+
+func searchText(parts ...any) string {
+	var builder strings.Builder
+	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte(' ')
+		}
+		switch typed := part.(type) {
+		case string:
+			builder.WriteString(typed)
+		default:
+			body, err := json.Marshal(typed)
+			if err != nil {
+				builder.WriteString(fmt.Sprint(typed))
+				continue
+			}
+			builder.Write(body)
+		}
+	}
+	return builder.String()
 }

--- a/pkg/contract/contracts.go
+++ b/pkg/contract/contracts.go
@@ -65,6 +65,18 @@ type QueryService interface {
 	Examples(ctx context.Context) ([]string, error)
 }
 
+// SearchService is the runtime-facing semantic search entrypoint for the
+// `.umodel`, `.entity`, and `.runbook_set` query sources. It mirrors the SLS
+// USearch SPL contract so the same `with(...)` invocation flows through both
+// the open-source engine and the SLS backend.
+type SearchService interface {
+	Keyword(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Vector(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Hybrid(ctx context.Context, workspace string, req model.SearchRequest) (model.SearchResult, error)
+	Capabilities(ctx context.Context) (model.SearchCapabilities, error)
+	Health(ctx context.Context) (model.SearchHealth, error)
+}
+
 type AgentGateway interface {
 	Discover(ctx context.Context, workspace string) (model.AgentDiscovery, error)
 	Tools(ctx context.Context) ([]model.AgentTool, error)

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -277,10 +278,87 @@ type QueryResult struct {
 	Explain *QueryExplain    `json:"explain,omitempty"`
 }
 
+type QueryExecuteResponse struct {
+	Code    string           `json:"code"`
+	Data    QueryExecuteData `json:"data"`
+	Message string           `json:"message"`
+	Success bool             `json:"success"`
+}
+
+type QueryExecuteData struct {
+	Data           [][]any             `json:"data"`
+	Header         []string            `json:"header"`
+	ResponseStatus QueryResponseStatus `json:"responseStatus"`
+}
+
+type QueryResponseStatus struct {
+	Result      string `json:"result"`
+	RetryPolicy string `json:"retryPolicy"`
+	Level       string `json:"level"`
+	StatusItem  []any  `json:"statusItem"`
+}
+
+func NewQueryExecuteResponse(result QueryResult) QueryExecuteResponse {
+	header := queryMatrixHeader(result.Columns, result.Rows)
+	return QueryExecuteResponse{
+		Code:    "200",
+		Message: "successful",
+		Success: true,
+		Data: QueryExecuteData{
+			Header: header,
+			Data:   queryRowsAsMatrix(header, result.Rows),
+			ResponseStatus: QueryResponseStatus{
+				Result:      "Success",
+				RetryPolicy: "None",
+				Level:       "Info",
+				StatusItem:  []any{},
+			},
+		},
+	}
+}
+
+func queryMatrixHeader(columns []string, rows []map[string]any) []string {
+	header := append([]string(nil), columns...)
+	seen := make(map[string]struct{}, len(header))
+	for _, column := range header {
+		seen[column] = struct{}{}
+	}
+	extras := map[string]struct{}{}
+	for _, row := range rows {
+		for column := range row {
+			if _, ok := seen[column]; ok {
+				continue
+			}
+			extras[column] = struct{}{}
+		}
+	}
+	extraColumns := make([]string, 0, len(extras))
+	for column := range extras {
+		extraColumns = append(extraColumns, column)
+	}
+	sort.Strings(extraColumns)
+	return append(header, extraColumns...)
+}
+
+func queryRowsAsMatrix(columns []string, rows []map[string]any) [][]any {
+	out := make([][]any, 0, len(rows))
+	for _, row := range rows {
+		values := make([]any, 0, len(columns))
+		for _, column := range columns {
+			values = append(values, row[column])
+		}
+		out = append(out, values)
+	}
+	return out
+}
+
 type QueryExplain struct {
 	Source           string   `json:"source"`
 	Provider         string   `json:"provider,omitempty"`
 	StorageProvider  string   `json:"storage_provider,omitempty"`
+	SearchProvider   string   `json:"search_provider,omitempty"`
+	EmbedModel       string   `json:"embed_model,omitempty"`
+	SearchMode       string   `json:"search_mode,omitempty"`
 	CypherDialect    string   `json:"cypher_dialect,omitempty"`
 	CypherEngine     string   `json:"cypher_engine,omitempty"`
 	Pushdown         []string `json:"pushdown,omitempty"`
@@ -366,6 +444,93 @@ type GraphStoreCapabilities struct {
 }
 
 type GraphStoreHealth struct {
+	Provider string `json:"provider"`
+	Status   string `json:"status"`
+	Message  string `json:"message,omitempty"`
+}
+
+// SearchRequest is the public input to SearchService.
+// It mirrors the SLS USearch SPL `with(...)` parameter set so the same SPL
+// can flow through both the open-source engine and the SLS backend.
+type SearchRequest struct {
+	Workspace  string             `json:"workspace,omitempty"`
+	Source     string             `json:"source"`
+	Domain     string             `json:"domain,omitempty"`
+	Kinds      []string           `json:"kinds,omitempty"`
+	Names      []string           `json:"names,omitempty"`
+	Query      string             `json:"query,omitempty"`
+	EmbedModel string             `json:"embed_model,omitempty"`
+	TopK       int                `json:"topk,omitempty"`
+	Origin     string             `json:"origin,omitempty"`
+	Filters    map[string]any     `json:"filters,omitempty"`
+	HybridK    int                `json:"hybrid_k,omitempty"`
+	Weights    map[string]float64 `json:"weights,omitempty"`
+}
+
+// SearchResult is the public output of SearchService.
+type SearchResult struct {
+	Rows []SearchRow `json:"rows"`
+}
+
+// SearchRow mirrors the SLS USearch result row shape. Field tags use the
+// `__field__` convention required by the SLS USearch contract.
+type SearchRow struct {
+	Type       string         `json:"__type__,omitempty"`
+	Domain     string         `json:"__domain__,omitempty"`
+	Kind       string         `json:"kind,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	Spec       map[string]any `json:"spec,omitempty"`
+	Score      float64        `json:"__score__"`
+	Provider   string         `json:"__provider__,omitempty"`
+	EmbedModel string         `json:"__embedding_model__,omitempty"`
+}
+
+// AsMap renders a SearchRow as a map for QueryResult.Rows.
+func (r SearchRow) AsMap() map[string]any {
+	m := map[string]any{
+		"__score__": r.Score,
+	}
+	if r.Type != "" {
+		m["__type__"] = r.Type
+	}
+	if r.Domain != "" {
+		m["__domain__"] = r.Domain
+	}
+	if r.Kind != "" {
+		m["kind"] = r.Kind
+	}
+	if r.Name != "" {
+		m["name"] = r.Name
+	}
+	if len(r.Metadata) > 0 {
+		m["metadata"] = r.Metadata
+	}
+	if len(r.Spec) > 0 {
+		m["spec"] = r.Spec
+	}
+	if r.Provider != "" {
+		m["__provider__"] = r.Provider
+	}
+	if r.EmbedModel != "" {
+		m["__embedding_model__"] = r.EmbedModel
+	}
+	return m
+}
+
+// SearchCapabilities advertises what a SearchService implementation supports.
+type SearchCapabilities struct {
+	VectorSearch         bool   `json:"vector_search"`
+	HybridSearch         bool   `json:"hybrid_search"`
+	FilteredVectorSearch bool   `json:"filtered_vector_search"`
+	RRF                  bool   `json:"rrf"`
+	ChunkChasing         bool   `json:"chunk_chasing"`
+	EmbedderType         string `json:"embedder_type,omitempty"`
+	MaxDim               int    `json:"max_dim,omitempty"`
+}
+
+// SearchHealth reports the runtime status of a SearchService implementation.
+type SearchHealth struct {
 	Provider string `json:"provider"`
 	Status   string `json:"status"`
 	Message  string `json:"message,omitempty"`

--- a/tests/e2e/business_flow_test.go
+++ b/tests/e2e/business_flow_test.go
@@ -322,6 +322,7 @@ func e2eDecodeResponse(t *testing.T, label string, resp *http.Response, allowedS
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode %s response: %v", label, err)
 	}
+	e2eNormalizeQueryExecutePayload(out)
 	return out
 }
 
@@ -340,6 +341,46 @@ func e2eRows(t *testing.T, payload map[string]any) []map[string]any {
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func e2eNormalizeQueryExecutePayload(payload map[string]any) {
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return
+	}
+	rawHeader, ok := data["header"].([]any)
+	if !ok {
+		return
+	}
+	rawData, ok := data["data"].([]any)
+	if !ok {
+		return
+	}
+	header := make([]any, 0, len(rawHeader))
+	headerStrings := make([]string, 0, len(rawHeader))
+	for _, raw := range rawHeader {
+		column, _ := raw.(string)
+		header = append(header, column)
+		headerStrings = append(headerStrings, column)
+	}
+	rows := make([]any, 0, len(rawData))
+	for _, rawRow := range rawData {
+		values, ok := rawRow.([]any)
+		if !ok {
+			continue
+		}
+		row := map[string]any{}
+		for i, column := range headerStrings {
+			if i < len(values) {
+				row[column] = values[i]
+			} else {
+				row[column] = nil
+			}
+		}
+		rows = append(rows, row)
+	}
+	payload["columns"] = header
+	payload["rows"] = rows
 }
 
 func e2eItems(t *testing.T, payload map[string]any) []map[string]any {
@@ -378,6 +419,7 @@ func e2eJSONMap(t *testing.T, body []byte) map[string]any {
 	if err := json.Unmarshal(body, &out); err != nil {
 		t.Fatalf("decode json %s: %v", body, err)
 	}
+	e2eNormalizeQueryExecutePayload(out)
 	return out
 }
 

--- a/tests/integration/capability_gate_test.go
+++ b/tests/integration/capability_gate_test.go
@@ -133,15 +133,16 @@ func TestCapabilityGate(t *testing.T) {
 			t.Fatalf("expected neighbor nodes at depth 2")
 		}
 
-		cypher := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+		cypherPayload := map[string]any{
 			"query":      ".topo | graph-call cypher(`MATCH (svc:``devops@devops.service`` {__entity_id__: $svc}) OPTIONAL MATCH path = (svc)-[r*1..2]-(neighbor) WITH svc, neighbor, relationships(path) AS rels WHERE neighbor IS NULL OR coalesce(neighbor.__deleted__, false) = false RETURN svc.__entity_id__ AS service, neighbor.__entity_id__ AS neighbor, [rel IN rels | type(rel)] AS relation_types, size(rels) AS hops ORDER BY hops, neighbor LIMIT 20`) | limit 20",
 			"parameters": map[string]any{"svc": "10000000000000000000000000000101"},
-		})
+		}
+		cypher := post(t, server.URL+"/api/v1/query/demo/execute", cypherPayload)
 		cypherRows := rows(t, cypher)
 		if len(cypherRows) == 0 {
 			t.Fatalf("expected cypher query results")
 		}
-		cypherExplain := cypher["explain"].(map[string]any)
+		cypherExplain := post(t, server.URL+"/api/v1/query/demo/explain", cypherPayload)
 		if cypherExplain["cypher_dialect"] != "ladybug" || cypherExplain["cypher_engine"] != "go" {
 			t.Fatalf("unexpected cypher explain: %+v", cypherExplain)
 		}

--- a/tests/integration/http_flow_test.go
+++ b/tests/integration/http_flow_test.go
@@ -61,19 +61,21 @@ func TestHTTPQuickFlow(t *testing.T) {
 	if len(rows(t, entityRows)) != 1 {
 		t.Fatalf("expected one entity row: %+v", entityRows)
 	}
+	assertQueryEnvelope(t, entityRows, []string{"__entity_id__", "display_name"})
 	topoRows := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{"query": ".topo | graph-call getDirectRelations([(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | project src,relation,dest | limit 10"})
 	if len(rows(t, topoRows)) != 1 {
 		t.Fatalf("expected one topo row: %+v", topoRows)
 	}
-	cypherRows := post(t, server.URL+"/api/v1/query/demo/execute", map[string]any{
+	cypherPayload := map[string]any{
 		"query":      ".topo | graph-call cypher(`MATCH (svc:``devops@devops.service`` {__entity_id__: $svc}) OPTIONAL MATCH path = (svc)-[r*1..2]-(neighbor) WITH svc, neighbor, relationships(path) AS rels WHERE neighbor IS NULL OR coalesce(neighbor.__deleted__, false) = false RETURN svc.__entity_id__ AS service, neighbor.__entity_id__ AS neighbor, [rel IN rels | type(rel)] AS relation_types, size(rels) AS hops ORDER BY hops, neighbor LIMIT 20`) | limit 20",
 		"parameters": map[string]any{"svc": "10000000000000000000000000000101"},
-	})
+	}
+	cypherRows := post(t, server.URL+"/api/v1/query/demo/execute", cypherPayload)
 	cypherResultRows := rows(t, cypherRows)
 	if len(cypherResultRows) == 0 || cypherResultRows[0].(map[string]any)["hops"] != float64(1) {
 		t.Fatalf("expected cypher topo rows: %+v", cypherRows)
 	}
-	cypherExplain := cypherRows["explain"].(map[string]any)
+	cypherExplain := post(t, server.URL+"/api/v1/query/demo/explain", cypherPayload)
 	if cypherExplain["cypher_dialect"] != "ladybug" || cypherExplain["cypher_engine"] != "go" {
 		t.Fatalf("unexpected cypher explain metadata: %+v", cypherExplain)
 	}
@@ -270,6 +272,7 @@ func postStatus(t *testing.T, url string, payload any, allowedStatuses ...int) m
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
+	normalizeQueryExecutePayload(out)
 	return out
 }
 
@@ -297,6 +300,77 @@ func rows(t *testing.T, payload map[string]any) []any {
 		t.Fatalf("payload has no rows: %+v", payload)
 	}
 	return rows
+}
+
+func assertQueryEnvelope(t *testing.T, payload map[string]any, wantHeader []string) {
+	t.Helper()
+	if payload["code"] != "200" || payload["message"] != "successful" || payload["success"] != true {
+		t.Fatalf("unexpected query envelope: %+v", payload)
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("query envelope has no data object: %+v", payload)
+	}
+	header, ok := data["header"].([]any)
+	if !ok {
+		t.Fatalf("query envelope has no header: %+v", payload)
+	}
+	if len(header) != len(wantHeader) {
+		t.Fatalf("header length = %d, want %d: %+v", len(header), len(wantHeader), header)
+	}
+	for i, want := range wantHeader {
+		if header[i] != want {
+			t.Fatalf("header[%d] = %v, want %s: %+v", i, header[i], want, header)
+		}
+	}
+	matrix, ok := data["data"].([]any)
+	if !ok || len(matrix) == 0 {
+		t.Fatalf("query envelope has no data matrix: %+v", payload)
+	}
+	status, ok := data["responseStatus"].(map[string]any)
+	if !ok || status["result"] != "Success" || status["retryPolicy"] != "None" || status["level"] != "Info" {
+		t.Fatalf("unexpected responseStatus: %+v", data["responseStatus"])
+	}
+}
+
+func normalizeQueryExecutePayload(payload map[string]any) {
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return
+	}
+	rawHeader, ok := data["header"].([]any)
+	if !ok {
+		return
+	}
+	rawData, ok := data["data"].([]any)
+	if !ok {
+		return
+	}
+	header := make([]any, 0, len(rawHeader))
+	headerStrings := make([]string, 0, len(rawHeader))
+	for _, raw := range rawHeader {
+		column, _ := raw.(string)
+		header = append(header, column)
+		headerStrings = append(headerStrings, column)
+	}
+	rows := make([]any, 0, len(rawData))
+	for _, rawRow := range rawData {
+		values, ok := rawRow.([]any)
+		if !ok {
+			continue
+		}
+		row := map[string]any{}
+		for i, column := range headerStrings {
+			if i < len(values) {
+				row[column] = values[i]
+			} else {
+				row[column] = nil
+			}
+		}
+		rows = append(rows, row)
+	}
+	payload["columns"] = header
+	payload["rows"] = rows
 }
 
 func errorCode(t *testing.T, payload map[string]any) string {

--- a/web/e2e/query-capability.spec.ts
+++ b/web/e2e/query-capability.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test'
 
-const TOPO_DIRECT = `.topo | graph-call getDirectRelations([(:"devops@devops.service" {__entity_id__: '10000000000000000000000000000101'})]) | project src,relation,dest | limit 20`
-
 test.describe('Query capability via UI', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
@@ -17,12 +15,10 @@ test.describe('Query capability via UI', () => {
   })
 
   test('umodel query returns rows', async ({ page }) => {
-    await page.locator('text=Query').click()
-    await expect(page.locator('text=Unified SPL Query')).toBeVisible()
-
-    const textarea = page.locator('textarea').first()
-    await textarea.fill(".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20")
-    await page.locator('button:has-text("Execute")').click()
+    await page.getByRole('button', { name: 'Query' }).click()
+    await expect(page.getByRole('button', { name: 'Execute' })).toBeVisible()
+    await page.getByRole('button', { name: '.umodel' }).click()
+    await page.getByRole('button', { name: 'Execute' }).click()
 
     await expect(page.locator('.om-table tbody tr').first()).toBeVisible({ timeout: 10_000 })
     const rowCount = await page.locator('.om-table tbody tr').count()
@@ -30,32 +26,26 @@ test.describe('Query capability via UI', () => {
   })
 
   test('entity query finds checkout service', async ({ page }) => {
-    await page.locator('text=Query').click()
-
-    const textarea = page.locator('textarea').first()
-    await textarea.fill(".entity with(domain='devops', name='devops.service', query='checkout', topk=20) | project __entity_id__,display_name,status,owner")
-    await page.locator('button:has-text("Execute")').click()
+    await page.getByRole('button', { name: 'Query' }).click()
+    await page.getByRole('button', { name: '.entity' }).click()
+    await page.getByRole('button', { name: 'Execute' }).click()
 
     await expect(page.locator('.om-table')).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator('.om-table').locator('text=checkout').first()).toBeVisible()
+    await expect(page.locator('.om-table').locator('text=checkout-service').first()).toBeVisible()
   })
 
   test('topo query returns direct relations', async ({ page }) => {
-    await page.locator('text=Query').click()
-
-    const textarea = page.locator('textarea').first()
-    await textarea.fill(TOPO_DIRECT)
-    await page.locator('button:has-text("Execute")').click()
+    await page.getByRole('button', { name: 'Query' }).click()
+    await page.getByRole('button', { name: 'direct' }).click()
+    await page.getByRole('button', { name: 'Execute' }).click()
 
     await expect(page.locator('.om-table tbody tr').first()).toBeVisible({ timeout: 10_000 })
   })
 
   test('explain shows provider info', async ({ page }) => {
-    await page.locator('text=Query').click()
-
-    const textarea = page.locator('textarea').first()
-    await textarea.fill(".umodel with(kind='entity_set') | limit 5")
-    await page.locator('button:has-text("Explain")').click()
+    await page.getByRole('button', { name: 'Query' }).click()
+    await page.getByRole('button', { name: '.umodel' }).click()
+    await page.getByRole('button', { name: 'Explain' }).click()
 
     await expect(page.locator('text=memory')).toBeVisible({ timeout: 10_000 })
   })

--- a/web/e2e/quickstart-demo.spec.ts
+++ b/web/e2e/quickstart-demo.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '@playwright/test'
 
 const API = 'http://localhost:8080'
 
+type QueryRows = { rows: Record<string, unknown>[]; columns: string[] }
+type QueryExecuteEnvelope = {
+  data?: {
+    data?: unknown[][]
+    header?: string[]
+  }
+}
+
 async function queryAPI(query: string, parameters?: Record<string, unknown>) {
   const resp = await fetch(`${API}/api/v1/query/demo/execute`, {
     method: 'POST',
@@ -9,7 +17,24 @@ async function queryAPI(query: string, parameters?: Record<string, unknown>) {
     body: JSON.stringify({ query, parameters }),
   })
   if (!resp.ok) throw new Error(`query failed: ${resp.status} ${await resp.text()}`)
-  return resp.json() as Promise<{ rows: Record<string, unknown>[]; columns: string[] }>
+  return normalizeQueryResult(await resp.json())
+}
+
+function normalizeQueryResult(payload: unknown): QueryRows {
+  const result = payload as QueryRows
+  if (Array.isArray(result.rows) && Array.isArray(result.columns)) return result
+
+  const envelope = payload as QueryExecuteEnvelope
+  const header = envelope.data?.header
+  const data = envelope.data?.data
+  if (Array.isArray(header) && Array.isArray(data)) {
+    return {
+      columns: header,
+      rows: data.map((row) => Object.fromEntries(header.map((column, index) => [column, row[index]]))),
+    }
+  }
+
+  throw new Error(`unexpected query response: ${JSON.stringify(payload)}`)
 }
 
 test.describe('Quickstart demo data validation', () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   ExpireRequest,
   HealthResponse,
   Page,
+  QueryExecuteResponse,
   QueryExplain,
   QueryRequest,
   QueryResult,
@@ -82,10 +83,10 @@ export class UModelApi {
   }
 
   query(workspace: string, payload: QueryRequest): Promise<QueryResult> {
-    return this.request(`/api/v1/query/${encodeURIComponent(workspace)}/execute`, {
+    return this.request<QueryResult | QueryExecuteResponse>(`/api/v1/query/${encodeURIComponent(workspace)}/execute`, {
       method: 'POST',
       body: payload,
-    })
+    }).then(normalizeQueryResult)
   }
 
   explain(workspace: string, payload: QueryRequest): Promise<QueryExplain> {
@@ -193,4 +194,34 @@ export class UModelApi {
     }
     return payload as T
   }
+}
+
+function normalizeQueryResult(payload: QueryResult | QueryExecuteResponse): QueryResult {
+  if (isQueryExecuteResponse(payload)) {
+    const columns = payload.data.header
+    const rows = payload.data.data.map((values) => {
+      const row: Record<string, unknown> = {}
+      columns.forEach((column, index) => {
+        row[column] = values[index]
+      })
+      return row
+    })
+    return {
+      columns,
+      rows,
+      page: {},
+    }
+  }
+  return payload
+}
+
+function isQueryExecuteResponse(payload: QueryResult | QueryExecuteResponse): payload is QueryExecuteResponse {
+  return Boolean(
+    payload &&
+      typeof payload === 'object' &&
+      'success' in payload &&
+      'data' in payload &&
+      Array.isArray((payload as QueryExecuteResponse).data?.header) &&
+      Array.isArray((payload as QueryExecuteResponse).data?.data),
+  )
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -156,6 +156,22 @@ export interface QueryResult {
   explain?: QueryExplain
 }
 
+export interface QueryExecuteResponse {
+  code: string
+  message: string
+  success: boolean
+  data: {
+    data: unknown[][]
+    header: string[]
+    responseStatus: {
+      result: string
+      retryPolicy: string
+      level: string
+      statusItem: unknown[]
+    }
+  }
+}
+
 export interface EntityWriteBatch {
   workspace?: string
   idempotency_key?: string

--- a/web/src/features/query/QueryPage.tsx
+++ b/web/src/features/query/QueryPage.tsx
@@ -43,7 +43,11 @@ const splMaxEditorHeight = 117
 
 const examples = [
   { label: '.umodel', query: ".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20" },
-  { label: '.entity', query: ".entity with(domain='devops', name='devops.service', query='checkout', topk=20) | project __entity_id__,display_name,status,owner" },
+  {
+    label: '.entity',
+    query:
+      ".entity with(domain='devops', name='devops.service', query='checkout', mode='vector', topk=20) | project __category__,__domain__,__entity_type__,__entity_id__,__method__,__first_observed_time__,__last_observed_time__,__keep_alive_seconds__,display_name,status,owner",
+  },
   { label: '.topo', query: '.topo | limit 20' },
   {
     label: 'direct',
@@ -90,11 +94,11 @@ export function QueryPage({ api, workspaceId }: { api: UModelApi; workspaceId: s
       if (from || to) request.time_range = { from, to }
 
       if (kind === 'execute') {
-        const next = await api.query(workspaceId, request)
+        const [next, nextExplain] = await Promise.all([api.query(workspaceId, request), api.explain(workspaceId, request)])
         const nextTopoEntityRows = await loadTopoEntityRows(api, workspaceId, next, request.time_range).catch(() => [])
         setResult(next)
         setTopoEntityRows(nextTopoEntityRows)
-        setExplain(next.explain || null)
+        setExplain(nextExplain)
         setExplainOpen(false)
         setResultView('table')
       } else {


### PR DESCRIPTION
Summary
- Add in-tree memory search service and route query-shaped reads for .umodel, .entity, and .runbook_set.
- Index model and entity writes so query execution can return scored, flattened rows.
- Normalize the execute REST envelope for matrix-style header/data responses and adapt the web query page.
- Fix local.ladybug topology graph-call filtering so seed-scoped direct/neighbor queries do not return global relations.

Verification
- git diff --check
- make guard
- go test ./internal/bootstrap ./internal/query ./internal/search ./internal/graphstore ./tests/integration ./tests/e2e
- UMODEL_TEST_LADYBUG=1 go test -tags ladybug ./internal/graphstore/provider/ladybug
- npm run build
- Browser storage smoke for file.memory, memory, and local.ladybug

Closes #10