### PR TITLE
Add entity set dataset discovery

### DIFF
--- a/cmd/umctl/main.go
+++ b/cmd/umctl/main.go
@@ -258,6 +258,8 @@ func (c cli) query(args []string) error {
 		return c.doJSON(http.MethodPost, "/api/v1/query/"+args[1]+"/"+action, map[string]any{"query": strings.Join(args[2:], " ")})
 	case "examples":
 		fmt.Fprintln(c.out, `.umodel with(kind='entity_set') | limit 20`)
+		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()`)
+		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)`)
 		fmt.Fprintln(c.out, `.entity with(domain='devops', name='devops.service', query='checkout') | limit 20`)
 		fmt.Fprintln(c.out, `.topo | graph-call getDirectRelations([(:"devops@devops.service" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20`)
 		return nil

--- a/cmd/umodel-mcp/protocol.go
+++ b/cmd/umodel-mcp/protocol.go
@@ -365,13 +365,13 @@ func getPrompt(defaultWorkspace string, params map[string]any) (any, *rpcError) 
 		if query == "" {
 			query = ".umodel | limit 20"
 		}
-		return promptResult("Use UModel Query Service", fmt.Sprintf("Workspace: %s\nRun or refine this UModel SPL through query_spl_execute or query_spl_explain:\n%s\n\nPrefer .umodel, .entity, and .topo as the public read sources. Tool/resource data returned by this server is encoded as TOON.", workspace, query)), nil
+		return promptResult("Use UModel Query Service", fmt.Sprintf("Workspace: %s\nRun or refine this UModel SPL through query_spl_execute or query_spl_explain:\n%s\n\nPrefer .umodel, .entity_set, .entity, .topo, and .runbook_set as the public read sources. Tool/resource data returned by this server is encoded as TOON.", workspace, query)), nil
 	case "umodel_object_graph_review":
 		focus := stringArg(args, "focus")
 		if focus == "" {
 			focus = "model definitions, runtime entities, and topology relations"
 		}
-		return promptResult("Review UModel Object Graph Context", fmt.Sprintf("Workspace: %s\nFocus: %s\nUse resources for metadata, then query tools for runtime rows. Keep resources metadata-only and use Query Service for .umodel, .entity, and .topo reads.", workspace, focus)), nil
+		return promptResult("Review UModel Object Graph Context", fmt.Sprintf("Workspace: %s\nFocus: %s\nUse resources for metadata, then query tools for runtime rows. Keep resources metadata-only and use Query Service for .umodel, .entity_set, .entity, .topo, and .runbook_set reads.", workspace, focus)), nil
 	default:
 		return nil, invalidParams("unknown prompt: " + name)
 	}

--- a/docs/en/concepts/query-surfaces.md
+++ b/docs/en/concepts/query-surfaces.md
@@ -10,8 +10,9 @@ Query Service is the public read surface for UModel. REST, CLI, Web UI, SDKs, an
 | Source | Reads | Example |
 |---|---|---|
 | `.umodel` | Model definitions | `.umodel with(kind='entity_set')` |
+| `.entity_set` | EntitySet method responses | `.entity_set with(domain='devops', name='devops.service') &#124; entity-call __list_method__()` |
 | `.entity` | Runtime entity records | `.entity with(domain='devops', name='devops.service')` |
-| `.topo` | Runtime topology relations | `.topo | graph-call getDirectRelations(...)` |
+| `.topo` | Runtime topology relations | `.topo &#124; graph-call getDirectRelations(...)` |
 
 ## Query Flow
 

--- a/docs/en/guides/query-service.md
+++ b/docs/en/guides/query-service.md
@@ -2,7 +2,7 @@
 
 中文：[Query Service 指南](../../zh/guides/query-service.md)
 
-Query Service is the only public read path for UModel definitions, entities, relations, and topology. It accepts SPL strings that start with `.umodel`, `.entity`, or `.topo`.
+Query Service is the only public read path for UModel definitions, entities, relations, topology, and EntitySet call planning. It accepts SPL strings that start with `.umodel`, `.entity_set`, `.entity`, `.topo`, or `.runbook_set`.
 
 ## Why Reads Go Through Query Service
 
@@ -69,6 +69,17 @@ Agent and REST callers can bind named parameters into `with(...)` filters and `w
 }
 ```
 
+## `.entity_set`
+
+`.entity_set` handles EntitySet method calls with UModel Assistant-compatible response data. The current scope supports metadata/discovery methods that return `responseType=2` with `header` and `data`.
+
+```bash
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
+```
+
+The required filters are `domain` and `name`; `ids` is accepted as EntitySet call context. The currently supported methods are `__list_method__` and `list_data_set` (`list_dataset` alias); method parameters are validated against the UModel Assistant signatures.
+
 ## `.topo`
 
 `.topo` reads runtime topology relations.
@@ -95,6 +106,7 @@ The local query layer supports the operations used by tests, examples, and the W
 - `project` to select output fields.
 - `sort` to order rows.
 - `limit` to bound output.
+- `entity-call` for EntitySet method planning.
 - `graph-call` for topology functions.
 
 Run the built-in examples:
@@ -113,7 +125,7 @@ go run ./cmd/umctl --addr http://localhost:8080 query explain demo ".entity with
 
 Explain output reports:
 
-- Query source: `.umodel`, `.entity`, or `.topo`.
+- Query source: `.umodel`, `.entity_set`, `.entity`, `.topo`, or `.runbook_set`.
 - Active provider.
 - Storage provider.
 - Planned filters and limits.

--- a/docs/en/reference/mcp.md
+++ b/docs/en/reference/mcp.md
@@ -78,7 +78,7 @@ output[6]: ".umodel with(kind='entity_set') | project domain,name,kind | sort do
 
 | Tool | Enabled by default | Purpose |
 |---|---:|---|
-| `query_spl_execute` | Yes | Execute `.umodel`, `.entity`, or `.topo` SPL. |
+| `query_spl_execute` | Yes | Execute `.umodel`, `.entity_set`, `.entity`, `.topo`, or `.runbook_set` SPL. |
 | `query_spl_explain` | Yes | Explain a query plan. |
 | `query_spl_examples` | Yes | Return safe query examples. |
 | `umodel_validate` | Yes | Validate UModel elements. |
@@ -94,7 +94,7 @@ Write tools are disabled by default so MCP clients start from a safe read-orient
 |---|---|---|
 | `overview` | `umodel://workspace/{workspace}/overview` | Workspace-scoped API and capability overview. |
 | `schema-index` | `umodel://workspace/{workspace}/schema-index` | Model/schema metadata summary. |
-| `query-templates` | `umodel://workspace/{workspace}/query-templates` | Query templates for `.umodel`, `.entity`, and `.topo`. |
+| `query-templates` | `umodel://workspace/{workspace}/query-templates` | Query templates for `.umodel`, `.entity_set`, `.entity`, and `.topo`. |
 | `tool-capability-metadata` | `umodel://workspace/{workspace}/tool-capability-metadata` | Tool capability and write-enablement metadata. |
 
 Resources are read-only and metadata-oriented. Runtime rows should be returned by tools such as `query_spl_execute`.

--- a/docs/zh/concepts/query-surfaces.md
+++ b/docs/zh/concepts/query-surfaces.md
@@ -10,8 +10,9 @@ Query Service 是 UModel 的公共读取面。REST、CLI、Web UI、SDK 和 MCP 
 | Source | 读取内容 | 示例 |
 |---|---|---|
 | `.umodel` | 模型定义 | `.umodel with(kind='entity_set')` |
+| `.entity_set` | EntitySet 方法响应 | `.entity_set with(domain='devops', name='devops.service') &#124; entity-call __list_method__()` |
 | `.entity` | 运行时实体 | `.entity with(domain='devops', name='devops.service')` |
-| `.topo` | 运行时拓扑关系 | `.topo | graph-call getDirectRelations(...)` |
+| `.topo` | 运行时拓扑关系 | `.topo &#124; graph-call getDirectRelations(...)` |
 
 ## 查询流程
 

--- a/docs/zh/guides/query-service.md
+++ b/docs/zh/guides/query-service.md
@@ -2,7 +2,7 @@
 
 English: [Query Service Guide](../../en/guides/query-service.md)
 
-Query Service 是 UModel 定义、实体、关系和拓扑的唯一公共读取路径。它接受以 `.umodel`、`.entity` 或 `.topo` 开头的 SPL 字符串。
+Query Service 是 UModel 定义、实体、关系、拓扑和 EntitySet 调用规划的唯一公共读取路径。它接受以 `.umodel`、`.entity_set`、`.entity`、`.topo` 或 `.runbook_set` 开头的 SPL 字符串。
 
 
 ## 为什么读取统一走 Query Service
@@ -64,6 +64,17 @@ Agent 和 REST 调用方可以把命名参数绑定到 `with(...)` filters 和 `
 }
 ```
 
+## `.entity_set`
+
+`.entity_set` 用于处理 EntitySet 方法调用，返回与 UModel Assistant 一致的响应数据。本轮范围支持元信息/发现类方法，返回 `responseType=2` 以及 `header`/`data`。
+
+```bash
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
+```
+
+`domain` 和 `name` 是必填 filter；`ids` 可作为 EntitySet 调用上下文。当前支持的方法是 `__list_method__` 和 `list_data_set`（兼容 `list_dataset` 别名）；方法参数按 UModel Assistant 的签名校验。
+
 ## `.topo`
 
 读取运行时拓扑关系：
@@ -88,6 +99,7 @@ go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-ca
 - `project`：选择字段。
 - `sort`：排序。
 - `limit`：限制输出。
+- `entity-call`：EntitySet 方法调用规划。
 - `graph-call`：拓扑函数。
 
 查看内置示例：

--- a/docs/zh/reference/mcp.md
+++ b/docs/zh/reference/mcp.md
@@ -79,7 +79,7 @@ output[6]: ".umodel with(kind='entity_set') | project domain,name,kind | sort do
 
 | Tool | 默认启用 | 用途 |
 |---|---:|---|
-| `query_spl_execute` | Yes | 执行 `.umodel`、`.entity`、`.topo` SPL。 |
+| `query_spl_execute` | Yes | 执行 `.umodel`、`.entity_set`、`.entity`、`.topo` 或 `.runbook_set` SPL。 |
 | `query_spl_explain` | Yes | 返回查询计划。 |
 | `query_spl_examples` | Yes | 返回安全查询示例。 |
 | `umodel_validate` | Yes | 校验 UModel elements。 |
@@ -95,7 +95,7 @@ output[6]: ".umodel with(kind='entity_set') | project domain,name,kind | sort do
 |---|---|---|
 | `overview` | `umodel://workspace/{workspace}/overview` | Workspace-scoped API 和能力概览。 |
 | `schema-index` | `umodel://workspace/{workspace}/schema-index` | 模型/schema 元数据摘要。 |
-| `query-templates` | `umodel://workspace/{workspace}/query-templates` | `.umodel`、`.entity`、`.topo` 查询模板。 |
+| `query-templates` | `umodel://workspace/{workspace}/query-templates` | `.umodel`、`.entity_set`、`.entity` 和 `.topo` 查询模板。 |
 | `tool-capability-metadata` | `umodel://workspace/{workspace}/tool-capability-metadata` | Tool 能力和写启用元数据。 |
 
 Resources 只读且面向元数据。运行时 rows 应由 `query_spl_execute` 等 tools 返回。

--- a/examples/quickstart-multidomain/README.md
+++ b/examples/quickstart-multidomain/README.md
@@ -4,7 +4,7 @@
 
 The Kubernetes domain is intentionally coarse-grained: it models the runtime objects that help explain service topology, not a full Kubernetes object model.
 
-This pack is entity-topology only. It intentionally does not define `metric_set`, `log_set`, `trace_set`, `event_set`, `profile_set`, `runbook_set`, `data_link`, or `storage_link` objects in any domain.
+This pack includes entity topology plus a minimal DevOps observability chain. `devops.service` is linked to one `metric_set`, one `log_set`, and one `event_set`; each dataset is linked to a storage definition so EntitySet dataset discovery can be tested against real UModel data.
 
 ## Contents
 
@@ -14,7 +14,9 @@ This pack is entity-topology only. It intentionally does not define `metric_set`
 | Kubernetes entity sets | `k8s/entity_set/` | 7 | Coarse clusters, namespaces, workloads, pods, nodes, services, and ingresses. |
 | Enterprise demo entity sets | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | Entity topology reused from `Demo/umodel-demo-2/umodel`. |
 | Entity links | `*/link/entity_set_link/`, `cross-domain/link/entity_set_link/` | 42 | In-domain and cross-domain topology semantics. |
-| Dataset definitions | not included | 0 | Quickstart stays focused on entity and topology modeling. |
+| DevOps data sets | `devops/metric_set/`, `devops/log_set/`, `devops/event_set/` | 3 | Minimal service metrics, logs, and deployment events for EntitySet dataset discovery. |
+| Data and storage links | `devops/link/data_link/`, `devops/link/storage_link/` | 6 | Connect `devops.service` to datasets and datasets to storage. |
+| Storage definitions | `devops/storage/` | 3 | Prometheus, Elasticsearch, and MySQL query-planning metadata. |
 | Runtime entities | `sample-data/entities.json` | 93 | CMS 2.0 compatible entity payloads. |
 | Runtime relations | `sample-data/relations.json` | 125 | CMS 2.0 compatible topology payloads. |
 
@@ -41,13 +43,15 @@ go run ./cmd/umctl --addr http://localhost:8080 query run demo ".umodel with(kin
 
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__,display_name,status,owner | limit 10"
 
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
+
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
 ```
 
 ## Maintenance Rules
 
 - Keep model YAML, entity payloads, relation payloads, and docs aligned.
-- Keep this pack free of dataset kinds such as `metric_set`, `log_set`, `trace_set`, `event_set`, `profile_set`, and `runbook_set`.
+- Keep the DevOps observability chain small: one service `metric_set`, one service `log_set`, one service `event_set`, and their `data_link` / `storage_link` definitions.
 - Keep k8s coarse for quickstart readability.
-- Reuse only `entity_set` and `entity_set_link` from `Demo/umodel-demo-2/umodel`; do not copy its metric, log, storage, or storage link definitions into quickstart.
+- Reuse only `entity_set` and `entity_set_link` from `Demo/umodel-demo-2/umodel`; keep dataset/storage definitions purpose-built for quickstart discovery.
 - Run `make example-validate` and `go test ./internal/sampledata ./internal/bootstrap ./internal/query` after changing this pack.

--- a/examples/quickstart-multidomain/README.zh-CN.md
+++ b/examples/quickstart-multidomain/README.zh-CN.md
@@ -6,7 +6,7 @@ English: [Multi-Domain Quickstart Example Pack](README.md)
 
 Kubernetes 域刻意保持粗粒度：只建模能解释服务拓扑的运行时对象，不照搬完整 Kubernetes 对象模型。
 
-这个样例只覆盖实体和拓扑。所有域都不定义 `metric_set`、`log_set`、`trace_set`、`event_set`、`profile_set`、`runbook_set`、`data_link` 或 `storage_link`。
+这个样例覆盖实体拓扑，并包含一条最小 DevOps 可观测链路。`devops.service` 关联一个 `metric_set`、一个 `log_set` 和一个 `event_set`，每个 DataSet 都关联到对应 Storage，用于基于真实 UModel 数据验证 EntitySet 的 DataSet 发现能力。
 
 ## 内容
 
@@ -16,7 +16,9 @@ Kubernetes 域刻意保持粗粒度：只建模能解释服务拓扑的运行时
 | Kubernetes EntitySet | `k8s/entity_set/` | 7 | 粗粒度集群、命名空间、工作负载、Pod、节点、Service、Ingress。 |
 | 企业 demo EntitySet | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | 直接复用 `Demo/umodel-demo-2/umodel` 的实体拓扑定义。 |
 | EntitySetLink | `*/link/entity_set_link/`, `cross-domain/link/entity_set_link/` | 42 | 域内和跨域拓扑语义。 |
-| DataSet 定义 | 不包含 | 0 | Quickstart 聚焦实体和拓扑建模。 |
+| DevOps DataSet | `devops/metric_set/`, `devops/log_set/`, `devops/event_set/` | 3 | 用于 EntitySet DataSet 发现的最小服务指标、日志和部署事件。 |
+| DataLink 和 StorageLink | `devops/link/data_link/`, `devops/link/storage_link/` | 6 | 连接 `devops.service` 到 DataSet，并连接 DataSet 到 Storage。 |
+| Storage 定义 | `devops/storage/` | 3 | Prometheus、Elasticsearch 和 MySQL 查询规划元数据。 |
 | Runtime entities | `sample-data/entities.json` | 93 | CMS 2.0 兼容实体 payload。 |
 | Runtime relations | `sample-data/relations.json` | 125 | CMS 2.0 兼容拓扑 payload。 |
 
@@ -43,13 +45,15 @@ go run ./cmd/umctl --addr http://localhost:8080 query run demo ".umodel with(kin
 
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__,display_name,status,owner | limit 10"
 
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
+
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
 ```
 
 ## 维护规则
 
 - 保持模型 YAML、entity payload、relation payload 和文档一致。
-- 保持这个样例不包含 `metric_set`、`log_set`、`trace_set`、`event_set`、`profile_set`、`runbook_set` 等 DataSet kind。
+- 保持 DevOps 可观测链路足够小：一个服务 `metric_set`、一个服务 `log_set`、一个服务 `event_set`，以及对应的 `data_link` / `storage_link`。
 - quickstart 里的 k8s 保持粗粒度，避免变成完整 Kubernetes 规范。
-- 只从 `Demo/umodel-demo-2/umodel` 复用 `entity_set` 和 `entity_set_link`，不要把其中的 metric、log、storage 或 storage link 定义复制进 quickstart。
+- 只从 `Demo/umodel-demo-2/umodel` 复用 `entity_set` 和 `entity_set_link`；DataSet/Storage 定义保持为 quickstart discovery 专用的最小版本。
 - 修改后运行 `make example-validate` 和 `go test ./internal/sampledata ./internal/bootstrap ./internal/query`。

--- a/examples/quickstart-multidomain/devops/event_set/devops.event.deployment.yaml
+++ b/examples/quickstart-multidomain/devops/event_set/devops.event.deployment.yaml
@@ -1,0 +1,63 @@
+kind: event_set
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.event.deployment"
+  domain: devops
+  display_name:
+    en_us: "Deployment Events"
+    zh_cn: "部署事件"
+  description:
+    en_us: "Deployment lifecycle events related to DevOps services in the quickstart workspace."
+    zh_cn: "Quickstart workspace 中与 DevOps 服务关联的部署生命周期事件。"
+spec:
+  fields:
+    - name: event_time
+      type: time
+      display_name:
+        en_us: "Event Time"
+        zh_cn: "事件时间"
+    - name: service_id
+      type: string
+      display_name:
+        en_us: "Service ID"
+        zh_cn: "服务 ID"
+    - name: environment
+      type: string
+      display_name:
+        en_us: "Environment"
+        zh_cn: "环境"
+    - name: deployment_id
+      type: string
+      display_name:
+        en_us: "Deployment ID"
+        zh_cn: "部署 ID"
+    - name: status
+      type: string
+      display_name:
+        en_us: "Status"
+        zh_cn: "状态"
+    - name: actor
+      type: string
+      display_name:
+        en_us: "Actor"
+        zh_cn: "操作者"
+  time_field: event_time
+  name_fields:
+    - deployment_id
+    - status
+  tag_fields:
+    - service_id
+    - environment
+    - status
+  ordered_fields:
+    - event_time
+    - service_id
+    - deployment_id
+    - status
+  default_order: desc
+  entity_fields:
+    entity_id: service_id
+    domain: domain
+    entity_type: entity_type

--- a/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.event.deployment.yaml
+++ b/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.event.deployment.yaml
@@ -1,0 +1,23 @@
+kind: data_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.service_related_to_devops.event.deployment"
+  domain: devops
+  display_name:
+    en_us: "Service related to deployment events"
+    zh_cn: "服务关联部署事件"
+spec:
+  src:
+    domain: devops
+    kind: entity_set
+    name: devops.service
+  dest:
+    domain: devops
+    kind: event_set
+    name: devops.event.deployment
+  fields_mapping:
+    id: service_id
+    environment: environment
+  data_link_type: related_to

--- a/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.log.service.yaml
+++ b/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.log.service.yaml
@@ -1,0 +1,23 @@
+kind: data_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.service_related_to_devops.log.service"
+  domain: devops
+  display_name:
+    en_us: "Service related to service logs"
+    zh_cn: "服务关联服务日志"
+spec:
+  src:
+    domain: devops
+    kind: entity_set
+    name: devops.service
+  dest:
+    domain: devops
+    kind: log_set
+    name: devops.log.service
+  fields_mapping:
+    id: service_id
+    environment: environment
+  data_link_type: related_to

--- a/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.metric.service.yaml
+++ b/examples/quickstart-multidomain/devops/link/data_link/devops.service_related_to_devops.metric.service.yaml
@@ -1,0 +1,23 @@
+kind: data_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.service_related_to_devops.metric.service"
+  domain: devops
+  display_name:
+    en_us: "Service related to service metrics"
+    zh_cn: "服务关联服务指标"
+spec:
+  src:
+    domain: devops
+    kind: entity_set
+    name: devops.service
+  dest:
+    domain: devops
+    kind: metric_set
+    name: devops.metric.service
+  fields_mapping:
+    id: service_id
+    environment: environment
+  data_link_type: related_to

--- a/examples/quickstart-multidomain/devops/link/storage_link/devops.event.deployment_to_mysql.yaml
+++ b/examples/quickstart-multidomain/devops/link/storage_link/devops.event.deployment_to_mysql.yaml
@@ -1,0 +1,23 @@
+kind: storage_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.event.deployment_to_mysql"
+  domain: devops
+  display_name:
+    en_us: "Deployment events stored in MySQL"
+    zh_cn: "部署事件存储在 MySQL"
+spec:
+  src:
+    domain: devops
+    kind: event_set
+    name: devops.event.deployment
+  dest:
+    domain: devops
+    kind: mysql
+    name: devops.mysql.events
+  fields_mapping:
+    service_id: service_id
+    environment: environment
+    event_time: event_time

--- a/examples/quickstart-multidomain/devops/link/storage_link/devops.log.service_to_elasticsearch.yaml
+++ b/examples/quickstart-multidomain/devops/link/storage_link/devops.log.service_to_elasticsearch.yaml
@@ -1,0 +1,23 @@
+kind: storage_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.log.service_to_elasticsearch"
+  domain: devops
+  display_name:
+    en_us: "Service logs stored in Elasticsearch"
+    zh_cn: "服务日志存储在 Elasticsearch"
+spec:
+  src:
+    domain: devops
+    kind: log_set
+    name: devops.log.service
+  dest:
+    domain: devops
+    kind: elasticsearch
+    name: devops.elasticsearch.logs
+  fields_mapping:
+    service_id: service_id
+    environment: environment
+    timestamp: timestamp

--- a/examples/quickstart-multidomain/devops/link/storage_link/devops.metric.service_to_prometheus.yaml
+++ b/examples/quickstart-multidomain/devops/link/storage_link/devops.metric.service_to_prometheus.yaml
@@ -1,0 +1,22 @@
+kind: storage_link
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.metric.service_to_prometheus"
+  domain: devops
+  display_name:
+    en_us: "Service metrics stored in Prometheus"
+    zh_cn: "服务指标存储在 Prometheus"
+spec:
+  src:
+    domain: devops
+    kind: metric_set
+    name: devops.metric.service
+  dest:
+    domain: devops
+    kind: prometheus
+    name: devops.prometheus.core
+  fields_mapping:
+    service_id: service_id
+    environment: environment

--- a/examples/quickstart-multidomain/devops/log_set/devops.log.service.yaml
+++ b/examples/quickstart-multidomain/devops/log_set/devops.log.service.yaml
@@ -1,0 +1,58 @@
+kind: log_set
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.log.service"
+  domain: devops
+  display_name:
+    en_us: "Service Logs"
+    zh_cn: "服务日志"
+  description:
+    en_us: "Application logs emitted by DevOps services in the quickstart workspace."
+    zh_cn: "Quickstart workspace 中 DevOps 服务产生的应用日志。"
+spec:
+  fields:
+    - name: timestamp
+      type: time
+      display_name:
+        en_us: "Timestamp"
+        zh_cn: "时间"
+    - name: service_id
+      type: string
+      display_name:
+        en_us: "Service ID"
+        zh_cn: "服务 ID"
+    - name: environment
+      type: string
+      display_name:
+        en_us: "Environment"
+        zh_cn: "环境"
+    - name: level
+      type: string
+      display_name:
+        en_us: "Level"
+        zh_cn: "级别"
+    - name: message
+      type: string
+      display_name:
+        en_us: "Message"
+        zh_cn: "消息"
+    - name: trace_id
+      type: string
+      display_name:
+        en_us: "Trace ID"
+        zh_cn: "Trace ID"
+  time_field: timestamp
+  name_fields:
+    - message
+  tag_fields:
+    - service_id
+    - environment
+    - level
+  ordered_fields:
+    - timestamp
+    - service_id
+    - level
+    - message
+  default_order: desc

--- a/examples/quickstart-multidomain/devops/metric_set/devops.metric.service.yaml
+++ b/examples/quickstart-multidomain/devops/metric_set/devops.metric.service.yaml
@@ -1,0 +1,63 @@
+kind: metric_set
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.metric.service"
+  domain: devops
+  display_name:
+    en_us: "Service Metrics"
+    zh_cn: "服务指标"
+  description:
+    en_us: "Golden metrics for DevOps services in the quickstart workspace."
+    zh_cn: "Quickstart workspace 中 DevOps 服务的黄金指标。"
+spec:
+  labels:
+    keys:
+      - name: service_id
+        type: string
+        display_name:
+          en_us: "Service ID"
+          zh_cn: "服务 ID"
+      - name: environment
+        type: string
+        display_name:
+          en_us: "Environment"
+          zh_cn: "环境"
+    dynamic: false
+  metrics:
+    - name: request_count
+      display_name:
+        en_us: "Request Count"
+        zh_cn: "请求数"
+      unit: count
+      data_format: KMB
+      type: gauge
+      query_mode: range
+      generator: "sum(rate(devops_service_request_total{service_id=\"$service_id\"}[1m]))"
+      aggregator: sum
+      golden_metric: true
+    - name: error_count
+      display_name:
+        en_us: "Error Count"
+        zh_cn: "错误数"
+      unit: count
+      data_format: KMB
+      type: gauge
+      query_mode: range
+      generator: "sum(rate(devops_service_error_total{service_id=\"$service_id\"}[1m]))"
+      aggregator: sum
+      golden_metric: true
+    - name: latency_ms
+      display_name:
+        en_us: "Latency"
+        zh_cn: "延迟"
+      unit: ms
+      data_format: ms
+      type: gauge
+      query_mode: range
+      generator: "histogram_quantile(0.95, sum(rate(devops_service_request_duration_seconds_bucket{service_id=\"$service_id\"}[1m])) by (le)) * 1000"
+      aggregator: avg
+      golden_metric: true
+  query_type: prom
+  needs_processing: true

--- a/examples/quickstart-multidomain/devops/storage/devops.elasticsearch.logs.yaml
+++ b/examples/quickstart-multidomain/devops/storage/devops.elasticsearch.logs.yaml
@@ -1,0 +1,26 @@
+kind: elasticsearch
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.elasticsearch.logs"
+  domain: devops
+  display_name:
+    en_us: "DevOps Elasticsearch Logs"
+    zh_cn: "DevOps Elasticsearch 日志"
+  description:
+    en_us: "Elasticsearch-compatible log index used by the quickstart service log set."
+    zh_cn: "Quickstart 服务日志集使用的 Elasticsearch 兼容日志索引。"
+spec:
+  endpoint: "https://elasticsearch.devops.example:9200"
+  index: "devops-service-logs-*"
+  index_pattern: "devops-service-logs-${yyyy.MM.dd}"
+  version: "8.x"
+  query_dialect: elasticsearch_dsl
+  time_field: timestamp
+  default_size: 1000
+  max_size: 10000
+  tls_verify: true
+  tags:
+    sample: multi-domain-quickstart
+    role: logs

--- a/examples/quickstart-multidomain/devops/storage/devops.mysql.events.yaml
+++ b/examples/quickstart-multidomain/devops/storage/devops.mysql.events.yaml
@@ -1,0 +1,27 @@
+kind: mysql
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.mysql.events"
+  domain: devops
+  display_name:
+    en_us: "DevOps MySQL Events"
+    zh_cn: "DevOps MySQL 事件"
+  description:
+    en_us: "MySQL table metadata used by the quickstart deployment event set."
+    zh_cn: "Quickstart 部署事件集使用的 MySQL 表元数据。"
+spec:
+  endpoint: "mysql.devops.example:3306"
+  database: "devops_observability"
+  table: "deployment_events"
+  sql_dialect: mysql
+  time_field: event_time
+  time_unit: datetime
+  default_limit: 1000
+  max_limit: 10000
+  read_only: true
+  tls_mode: preferred
+  tags:
+    sample: multi-domain-quickstart
+    role: events

--- a/examples/quickstart-multidomain/devops/storage/devops.prometheus.core.yaml
+++ b/examples/quickstart-multidomain/devops/storage/devops.prometheus.core.yaml
@@ -1,0 +1,28 @@
+kind: prometheus
+schema:
+  url: "umodel.aliyun.com"
+  version: "v1.0.0"
+metadata:
+  name: "devops.prometheus.core"
+  domain: devops
+  display_name:
+    en_us: "DevOps Prometheus"
+    zh_cn: "DevOps Prometheus"
+  description:
+    en_us: "Prometheus-compatible metrics endpoint used by the quickstart service metric set."
+    zh_cn: "Quickstart 服务指标集使用的 Prometheus 兼容指标端点。"
+spec:
+  endpoint: "http://prometheus.devops.example:9090"
+  api_prefix: "/api/v1"
+  default_query_type: range
+  default_step: 1m
+  lookback_delta: 5m
+  tenant: quickstart
+  tenant_header: "X-Scope-OrgID"
+  tls_verify: true
+  external_labels:
+    workspace: quickstart
+    domain: devops
+  tags:
+    sample: multi-domain-quickstart
+    role: metrics

--- a/examples/quickstart-multidomain/sample-data/manifest.json
+++ b/examples/quickstart-multidomain/sample-data/manifest.json
@@ -2,7 +2,7 @@
   "sample": "multi-domain-quickstart",
   "title": "Multi-domain quickstart sample",
   "schema_pack": "examples/quickstart-multidomain",
-  "source_hint": "Enterprise demo domains reuse EntitySet and EntitySetLink topology from Demo/umodel-demo-2/umodel; dataset, storage, metric, and log definitions are intentionally excluded.",
+  "source_hint": "Enterprise demo domains reuse EntitySet and EntitySetLink topology from Demo/umodel-demo-2/umodel; DevOps includes a minimal MetricSet/LogSet/EventSet/DataLink/StorageLink chain for EntitySet discovery.",
   "domains": [
     "devops",
     "k8s",
@@ -22,20 +22,16 @@
   "counts": {
     "entity_sets": 35,
     "entity_set_links": 42,
-    "data_sets": 0,
-    "data_links": 0,
-    "storage_links": 0,
+    "data_sets": 3,
+    "data_links": 3,
+    "storage_links": 3,
+    "storages": 3,
     "entities": 93,
     "relations": 125
   },
   "excluded_kinds": [
-    "metric_set",
-    "log_set",
     "trace_set",
-    "event_set",
     "profile_set",
-    "runbook_set",
-    "data_link",
-    "storage_link"
+    "runbook_set"
   ]
 }

--- a/expanded_schemas/elasticsearch.expanded.yaml
+++ b/expanded_schemas/elasticsearch.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: ElasticSearch 存储，用于描述 ElasticSearch 实例的配置和连接信息。
+  zh_cn: Elasticsearch 存储，用于描述 Elasticsearch 集群、索引以及查询规划所需的连接信息。
   en_us: >-
-    ElasticSearch storage, used to define the ElasticSearch instance configuration and connection details.
+    Elasticsearch storage, used to define the Elasticsearch cluster, index, and connection metadata required for query planning.
 name: elasticsearch
 versions:
 - name: v1.0.0
@@ -191,34 +191,106 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+          zh_cn: Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
           en_us: >-
-            The specification section containing ElasticSearch configuration, including connection and index parameters.
+            The specification section for Elasticsearch. UModel uses these fields to generate Elasticsearch query plans only;
+            it does not execute queries or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: ElasticSearch 实例的访问地址（URL）。
-              en_us: The endpoint URL of the ElasticSearch instance.
+              zh_cn: Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
+              en_us: The Elasticsearch cluster endpoint, for example https://es.example.com:9200.
             type: string
             constraint:
               required: true
           index:
             description:
-              zh_cn: ElasticSearch 索引名称。
-              en_us: The name of the ElasticSearch index.
+              zh_cn: 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
+              en_us: >-
+                The default index name to query. It may also be an Elasticsearch-supported index wildcard expression.
             type: string
             constraint:
               required: true
+          index_pattern:
+            description:
+              zh_cn: 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+              en_us: >-
+                Index pattern for time-rolled indices, for example logs-${yyyy.MM.dd}. When empty, query planning uses the
+                index field.
+            type: string
           version:
             description:
-              zh_cn: ElasticSearch 的版本号（如 7.x、8.x）。
-              en_us: The version of the ElasticSearch instance (e.g. 7.x, 8.x).
+              zh_cn: Elasticsearch 版本号或版本族，例如 7.x、8.x。
+              en_us: The Elasticsearch version or version family, for example 7.x or 8.x.
             type: string
+          query_dialect:
+            description:
+              zh_cn: 查询生成方言。默认生成 Elasticsearch Query DSL。
+              en_us: Query generation dialect. Elasticsearch Query DSL is used by default.
+            type: string
+            constraint:
+              enum:
+                values:
+                - elasticsearch_dsl
+                - lucene
+                - eql
+              default_value: elasticsearch_dsl
+          time_field:
+            description:
+              zh_cn: 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+              en_us: Time field used to push request time ranges into Elasticsearch queries.
+            type: string
+          default_size:
+            description:
+              zh_cn: 未显式指定 limit 时生成查询的默认 size。
+              en_us: Default query size when no explicit limit is provided.
+            type: integer
+            constraint:
+              default_value: 1000
+          max_size:
+            description:
+              zh_cn: 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+              en_us: >-
+                Maximum query size allowed by the planner to avoid producing excessively large query plans.
+            type: integer
+            constraint:
+              default_value: 10000
+          routing:
+            description:
+              zh_cn: 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+              en_us: >-
+                Optional Elasticsearch routing value for queries that should target a fixed routing key.
+            type: string
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://es-prod-readonly. Plaintext usernames, passwords, or tokens must
+                not be stored in UModel.
+            type: string
+          tls_verify:
+            description:
+              zh_cn: 是否校验 TLS 证书。默认值为 true。
+              en_us: Whether TLS certificates should be verified. Defaults to true.
+            type: boolean
+            constraint:
+              default_value: true
+          headers:
+            description:
+              zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+              en_us: >-
+                Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
           properties:
             description:
-              zh_cn: ElasticSearch 的额外配置信息，以键值对形式存储。
-              en_us: >-
-                Additional configuration of the ElasticSearch instance, stored as key-value pairs.
+              zh_cn: Elasticsearch 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive Elasticsearch configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -228,8 +300,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 ElasticSearch 存储的标签。
-              en_us: This field is used to represent the tags of the ElasticSearch storage.
+              zh_cn: 用于标注该 Elasticsearch 存储的标签。
+              en_us: Tags used to describe this Elasticsearch storage.
             type: map
             constraint:
               map:

--- a/expanded_schemas/mysql.expanded.yaml
+++ b/expanded_schemas/mysql.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: MySQL 存储，用于描述 MySQL 数据库实例的配置和连接信息。
+  zh_cn: MySQL 存储，用于描述 MySQL 实例、数据库、表以及查询规划所需的连接信息。
   en_us: >-
-    MySQL storage, used to define the MySQL database instance configuration and connection details.
+    MySQL storage, used to define the MySQL instance, database, table, and connection metadata required for query planning.
 name: mysql
 versions:
 - name: v1.0.0
@@ -191,38 +191,117 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+          zh_cn: MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
           en_us: >-
-            The specification section containing MySQL configuration, including connection and query parameters.
+            The specification section for MySQL. UModel uses these fields to generate read-only SQL query plans only; it does
+            not connect to databases or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: MySQL 实例的访问地址（host:port）。
-              en_us: The endpoint address of the MySQL instance (host:port).
+              zh_cn: MySQL 实例访问地址，格式通常为 host:port。
+              en_us: The MySQL instance endpoint, usually in host:port format.
             type: string
             constraint:
               required: true
           database:
             description:
-              zh_cn: MySQL 数据库名称。
-              en_us: The name of the MySQL database.
+              zh_cn: 默认查询数据库名称。
+              en_us: The default database name to query.
             type: string
             constraint:
               required: true
           table:
             description:
-              zh_cn: MySQL 表名称。
-              en_us: The name of the MySQL table.
+              zh_cn: 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
+              en_us: >-
+                The default table name to query. It can be overridden by the DataSet or query parameters.
             type: string
-          sql:
+          sql_template:
             description:
-              zh_cn: SQL 查询语句，用于从 MySQL 中提取数据。
-              en_us: SQL query statement for extracting data from MySQL.
+              zh_cn: 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
+              en_us: >-
+                Optional SQL template for special query planning scenarios. The template must keep read-only semantics and
+                should not contain INSERT, UPDATE, DELETE, DDL, or similar statements.
             type: string
+          sql_dialect:
+            description:
+              zh_cn: SQL 方言。MySQL 存储默认使用 mysql。
+              en_us: SQL dialect. MySQL storage uses mysql by default.
+            type: string
+            constraint:
+              enum:
+                values:
+                - mysql
+                - ansi
+              default_value: mysql
+          time_field:
+            description:
+              zh_cn: 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+              en_us: Time field used to push request time ranges into SQL WHERE conditions.
+            type: string
+          time_unit:
+            description:
+              zh_cn: time_field 的时间单位。默认值为 second。
+              en_us: Time unit of time_field. Defaults to second.
+            type: string
+            constraint:
+              enum:
+                values:
+                - second
+                - millisecond
+                - microsecond
+                - nanosecond
+                - datetime
+              default_value: second
+          default_limit:
+            description:
+              zh_cn: 未显式指定 limit 时生成查询的默认 LIMIT。
+              en_us: Default SQL LIMIT when no explicit limit is provided.
+            type: integer
+            constraint:
+              default_value: 1000
+          max_limit:
+            description:
+              zh_cn: 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+              en_us: >-
+                Maximum SQL LIMIT allowed by the planner to avoid producing excessively large query plans.
+            type: integer
+            constraint:
+              default_value: 10000
+          read_only:
+            description:
+              zh_cn: 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+              en_us: >-
+                Indicates whether this storage should only plan read-only queries. Defaults to true; UModel PaaS query planning
+                should not generate write statements.
+            type: boolean
+            constraint:
+              default_value: true
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://mysql-prod-readonly. Plaintext usernames, passwords, or tokens
+                must not be stored in UModel.
+            type: string
+          tls_mode:
+            description:
+              zh_cn: MySQL TLS 模式。默认值为 preferred。
+              en_us: MySQL TLS mode. Defaults to preferred.
+            type: string
+            constraint:
+              enum:
+                values:
+                - disabled
+                - preferred
+                - required
+                - verify_ca
+                - verify_identity
+              default_value: preferred
           properties:
             description:
-              zh_cn: MySQL 的额外配置信息，以键值对形式存储。
-              en_us: Additional configuration of the MySQL instance, stored as key-value pairs.
+              zh_cn: MySQL 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive MySQL configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -232,8 +311,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 MySQL 存储的标签。
-              en_us: This field is used to represent the tags of the MySQL storage.
+              zh_cn: 用于标注该 MySQL 存储的标签。
+              en_us: Tags used to describe this MySQL storage.
             type: map
             constraint:
               map:

--- a/expanded_schemas/prometheus.expanded.yaml
+++ b/expanded_schemas/prometheus.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: Prometheus 存储，用于描述开源 Prometheus 实例的配置和连接信息。
+  zh_cn: Prometheus 存储，用于描述开源 Prometheus 或 Prometheus 兼容接口的配置和查询规划信息。
   en_us: >-
-    Prometheus storage, used to define the open-source Prometheus instance configuration and connection details.
+    Prometheus storage, used to define open-source Prometheus or Prometheus-compatible endpoint metadata for query planning.
 name: prometheus
 versions:
 - name: v1.0.0
@@ -191,21 +191,100 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+          zh_cn: Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
           en_us: >-
-            The specification section containing Prometheus configuration, including connection and query parameters.
+            The specification section for Prometheus. UModel uses these fields to generate PromQL query plans only; it does
+            not execute queries or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: Prometheus 实例的访问地址（URL）。
-              en_us: The endpoint URL of the Prometheus instance.
+              zh_cn: Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
+              en_us: >-
+                The endpoint URL of Prometheus or a Prometheus-compatible service, for example http://prometheus:9090.
             type: string
             constraint:
               required: true
+          api_prefix:
+            description:
+              zh_cn: Prometheus HTTP API 前缀。默认值为 /api/v1。
+              en_us: Prometheus HTTP API prefix. Defaults to /api/v1.
+            type: string
+            constraint:
+              default_value: /api/v1
+          default_query_type:
+            description:
+              zh_cn: 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+              en_us: >-
+                Default PromQL query type. instant means instant query and range means range query.
+            type: string
+            constraint:
+              enum:
+                values:
+                - instant
+                - range
+              default_value: instant
+          default_step:
+            description:
+              zh_cn: 区间查询的默认 step，例如 60s、1m。
+              en_us: Default step for range queries, for example 60s or 1m.
+            type: string
+          lookback_delta:
+            description:
+              zh_cn: PromQL 查询规划使用的默认回看窗口，例如 5m。
+              en_us: Default PromQL lookback window used by query planning, for example 5m.
+            type: string
+          tenant:
+            description:
+              zh_cn: 可选租户标识，用于多租户 Prometheus 兼容系统。
+              en_us: Optional tenant identifier for multi-tenant Prometheus-compatible systems.
+            type: string
+          tenant_header:
+            description:
+              zh_cn: 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+              en_us: Tenant HTTP header name used by multi-tenant systems, for example X-Scope-OrgID.
+            type: string
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://prometheus-prod-readonly. Plaintext usernames, passwords, or tokens
+                must not be stored in UModel.
+            type: string
+          tls_verify:
+            description:
+              zh_cn: 是否校验 TLS 证书。默认值为 true。
+              en_us: Whether TLS certificates should be verified. Defaults to true.
+            type: boolean
+            constraint:
+              default_value: true
+          external_labels:
+            description:
+              zh_cn: Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+              en_us: >-
+                Prometheus external labels used to enrich query-planning context or describe result origin.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
+          headers:
+            description:
+              zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+              en_us: >-
+                Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
           properties:
             description:
-              zh_cn: Prometheus 的额外配置信息，以键值对形式存储。
-              en_us: Additional configuration of the Prometheus instance, stored as key-value pairs.
+              zh_cn: Prometheus 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive Prometheus configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -215,8 +294,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 Prometheus 存储的标签。
-              en_us: This field is used to represent the tags of the Prometheus storage.
+              zh_cn: 用于标注该 Prometheus 存储的标签。
+              en_us: Tags used to describe this Prometheus storage.
             type: map
             constraint:
               map:

--- a/generated/java/src/main/java/com/umodel/schema/ElasticsearchV100.java
+++ b/generated/java/src/main/java/com/umodel/schema/ElasticsearchV100.java
@@ -42,7 +42,7 @@ public class ElasticsearchV100 implements UModelCoreObject {
     }
 
     /**
-     * ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+     * Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
      */
     @JSONField(name = "spec")
     private ElasticsearchV100Spec spec;
@@ -62,11 +62,11 @@ public class ElasticsearchV100 implements UModelCoreObject {
     }
 
     /**
-     * ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+     * Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
      */
     public static class ElasticsearchV100Spec {
         /**
-         * ElasticSearch 实例的访问地址（URL）。
+         * Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
          */
         @JSONField(name = "endpoint")
         private String endpoint;
@@ -80,7 +80,7 @@ public class ElasticsearchV100 implements UModelCoreObject {
         }
 
         /**
-         * ElasticSearch 索引名称。
+         * 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
          */
         @JSONField(name = "index")
         private String index;
@@ -94,7 +94,21 @@ public class ElasticsearchV100 implements UModelCoreObject {
         }
 
         /**
-         * ElasticSearch 的版本号（如 7.x、8.x）。
+         * 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+         */
+        @JSONField(name = "index_pattern")
+        private String indexPattern;
+
+        public String getIndexPattern() {
+            return indexPattern;
+        }
+
+        public void setIndexPattern(String indexPattern) {
+            this.indexPattern = indexPattern;
+        }
+
+        /**
+         * Elasticsearch 版本号或版本族，例如 7.x、8.x。
          */
         @JSONField(name = "version")
         private String version;
@@ -108,7 +122,119 @@ public class ElasticsearchV100 implements UModelCoreObject {
         }
 
         /**
-         * ElasticSearch 的额外配置信息，以键值对形式存储。
+         * 查询生成方言。默认生成 Elasticsearch Query DSL。
+         */
+        @JSONField(name = "query_dialect")
+        private String queryDialect;
+
+        public String getQueryDialect() {
+            return queryDialect;
+        }
+
+        public void setQueryDialect(String queryDialect) {
+            this.queryDialect = queryDialect;
+        }
+
+        /**
+         * 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+         */
+        @JSONField(name = "time_field")
+        private String timeField;
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public void setTimeField(String timeField) {
+            this.timeField = timeField;
+        }
+
+        /**
+         * 未显式指定 limit 时生成查询的默认 size。
+         */
+        @JSONField(name = "default_size")
+        private Long defaultSize;
+
+        public Long getDefaultSize() {
+            return defaultSize;
+        }
+
+        public void setDefaultSize(Long defaultSize) {
+            this.defaultSize = defaultSize;
+        }
+
+        /**
+         * 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+         */
+        @JSONField(name = "max_size")
+        private Long maxSize;
+
+        public Long getMaxSize() {
+            return maxSize;
+        }
+
+        public void setMaxSize(Long maxSize) {
+            this.maxSize = maxSize;
+        }
+
+        /**
+         * 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+         */
+        @JSONField(name = "routing")
+        private String routing;
+
+        public String getRouting() {
+            return routing;
+        }
+
+        public void setRouting(String routing) {
+            this.routing = routing;
+        }
+
+        /**
+         * 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+         */
+        @JSONField(name = "credential_ref")
+        private String credentialRef;
+
+        public String getCredentialRef() {
+            return credentialRef;
+        }
+
+        public void setCredentialRef(String credentialRef) {
+            this.credentialRef = credentialRef;
+        }
+
+        /**
+         * 是否校验 TLS 证书。默认值为 true。
+         */
+        @JSONField(name = "tls_verify")
+        private Boolean tlsVerify;
+
+        public Boolean getTlsVerify() {
+            return tlsVerify;
+        }
+
+        public void setTlsVerify(Boolean tlsVerify) {
+            this.tlsVerify = tlsVerify;
+        }
+
+        /**
+         * 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+         */
+        @JSONField(name = "headers")
+        private Map<String, String> headers;
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+        }
+
+        /**
+         * Elasticsearch 的额外非敏感配置，以键值对形式存储。
          */
         @JSONField(name = "properties")
         private Map<String, String> properties;
@@ -122,7 +248,7 @@ public class ElasticsearchV100 implements UModelCoreObject {
         }
 
         /**
-         * 用于表示该 ElasticSearch 存储的标签。
+         * 用于标注该 Elasticsearch 存储的标签。
          */
         @JSONField(name = "tags")
         private Map<String, String> tags;

--- a/generated/java/src/main/java/com/umodel/schema/MysqlV100.java
+++ b/generated/java/src/main/java/com/umodel/schema/MysqlV100.java
@@ -42,7 +42,7 @@ public class MysqlV100 implements UModelCoreObject {
     }
 
     /**
-     * MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+     * MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
      */
     @JSONField(name = "spec")
     private MysqlV100Spec spec;
@@ -62,11 +62,11 @@ public class MysqlV100 implements UModelCoreObject {
     }
 
     /**
-     * MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+     * MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
      */
     public static class MysqlV100Spec {
         /**
-         * MySQL 实例的访问地址（host:port）。
+         * MySQL 实例访问地址，格式通常为 host:port。
          */
         @JSONField(name = "endpoint")
         private String endpoint;
@@ -80,7 +80,7 @@ public class MysqlV100 implements UModelCoreObject {
         }
 
         /**
-         * MySQL 数据库名称。
+         * 默认查询数据库名称。
          */
         @JSONField(name = "database")
         private String database;
@@ -94,7 +94,7 @@ public class MysqlV100 implements UModelCoreObject {
         }
 
         /**
-         * MySQL 表名称。
+         * 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
          */
         @JSONField(name = "table")
         private String table;
@@ -108,21 +108,133 @@ public class MysqlV100 implements UModelCoreObject {
         }
 
         /**
-         * SQL 查询语句，用于从 MySQL 中提取数据。
+         * 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
          */
-        @JSONField(name = "sql")
-        private String sql;
+        @JSONField(name = "sql_template")
+        private String sqlTemplate;
 
-        public String getSql() {
-            return sql;
+        public String getSqlTemplate() {
+            return sqlTemplate;
         }
 
-        public void setSql(String sql) {
-            this.sql = sql;
+        public void setSqlTemplate(String sqlTemplate) {
+            this.sqlTemplate = sqlTemplate;
         }
 
         /**
-         * MySQL 的额外配置信息，以键值对形式存储。
+         * SQL 方言。MySQL 存储默认使用 mysql。
+         */
+        @JSONField(name = "sql_dialect")
+        private String sqlDialect;
+
+        public String getSqlDialect() {
+            return sqlDialect;
+        }
+
+        public void setSqlDialect(String sqlDialect) {
+            this.sqlDialect = sqlDialect;
+        }
+
+        /**
+         * 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+         */
+        @JSONField(name = "time_field")
+        private String timeField;
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public void setTimeField(String timeField) {
+            this.timeField = timeField;
+        }
+
+        /**
+         * time_field 的时间单位。默认值为 second。
+         */
+        @JSONField(name = "time_unit")
+        private String timeUnit;
+
+        public String getTimeUnit() {
+            return timeUnit;
+        }
+
+        public void setTimeUnit(String timeUnit) {
+            this.timeUnit = timeUnit;
+        }
+
+        /**
+         * 未显式指定 limit 时生成查询的默认 LIMIT。
+         */
+        @JSONField(name = "default_limit")
+        private Long defaultLimit;
+
+        public Long getDefaultLimit() {
+            return defaultLimit;
+        }
+
+        public void setDefaultLimit(Long defaultLimit) {
+            this.defaultLimit = defaultLimit;
+        }
+
+        /**
+         * 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+         */
+        @JSONField(name = "max_limit")
+        private Long maxLimit;
+
+        public Long getMaxLimit() {
+            return maxLimit;
+        }
+
+        public void setMaxLimit(Long maxLimit) {
+            this.maxLimit = maxLimit;
+        }
+
+        /**
+         * 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+         */
+        @JSONField(name = "read_only")
+        private Boolean readOnly;
+
+        public Boolean getReadOnly() {
+            return readOnly;
+        }
+
+        public void setReadOnly(Boolean readOnly) {
+            this.readOnly = readOnly;
+        }
+
+        /**
+         * 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+         */
+        @JSONField(name = "credential_ref")
+        private String credentialRef;
+
+        public String getCredentialRef() {
+            return credentialRef;
+        }
+
+        public void setCredentialRef(String credentialRef) {
+            this.credentialRef = credentialRef;
+        }
+
+        /**
+         * MySQL TLS 模式。默认值为 preferred。
+         */
+        @JSONField(name = "tls_mode")
+        private String tlsMode;
+
+        public String getTlsMode() {
+            return tlsMode;
+        }
+
+        public void setTlsMode(String tlsMode) {
+            this.tlsMode = tlsMode;
+        }
+
+        /**
+         * MySQL 的额外非敏感配置，以键值对形式存储。
          */
         @JSONField(name = "properties")
         private Map<String, String> properties;
@@ -136,7 +248,7 @@ public class MysqlV100 implements UModelCoreObject {
         }
 
         /**
-         * 用于表示该 MySQL 存储的标签。
+         * 用于标注该 MySQL 存储的标签。
          */
         @JSONField(name = "tags")
         private Map<String, String> tags;

--- a/generated/java/src/main/java/com/umodel/schema/PrometheusV100.java
+++ b/generated/java/src/main/java/com/umodel/schema/PrometheusV100.java
@@ -42,7 +42,7 @@ public class PrometheusV100 implements UModelCoreObject {
     }
 
     /**
-     * Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+     * Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
      */
     @JSONField(name = "spec")
     private PrometheusV100Spec spec;
@@ -62,11 +62,11 @@ public class PrometheusV100 implements UModelCoreObject {
     }
 
     /**
-     * Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+     * Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
      */
     public static class PrometheusV100Spec {
         /**
-         * Prometheus 实例的访问地址（URL）。
+         * Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
          */
         @JSONField(name = "endpoint")
         private String endpoint;
@@ -80,7 +80,147 @@ public class PrometheusV100 implements UModelCoreObject {
         }
 
         /**
-         * Prometheus 的额外配置信息，以键值对形式存储。
+         * Prometheus HTTP API 前缀。默认值为 /api/v1。
+         */
+        @JSONField(name = "api_prefix")
+        private String apiPrefix;
+
+        public String getApiPrefix() {
+            return apiPrefix;
+        }
+
+        public void setApiPrefix(String apiPrefix) {
+            this.apiPrefix = apiPrefix;
+        }
+
+        /**
+         * 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+         */
+        @JSONField(name = "default_query_type")
+        private String defaultQueryType;
+
+        public String getDefaultQueryType() {
+            return defaultQueryType;
+        }
+
+        public void setDefaultQueryType(String defaultQueryType) {
+            this.defaultQueryType = defaultQueryType;
+        }
+
+        /**
+         * 区间查询的默认 step，例如 60s、1m。
+         */
+        @JSONField(name = "default_step")
+        private String defaultStep;
+
+        public String getDefaultStep() {
+            return defaultStep;
+        }
+
+        public void setDefaultStep(String defaultStep) {
+            this.defaultStep = defaultStep;
+        }
+
+        /**
+         * PromQL 查询规划使用的默认回看窗口，例如 5m。
+         */
+        @JSONField(name = "lookback_delta")
+        private String lookbackDelta;
+
+        public String getLookbackDelta() {
+            return lookbackDelta;
+        }
+
+        public void setLookbackDelta(String lookbackDelta) {
+            this.lookbackDelta = lookbackDelta;
+        }
+
+        /**
+         * 可选租户标识，用于多租户 Prometheus 兼容系统。
+         */
+        @JSONField(name = "tenant")
+        private String tenant;
+
+        public String getTenant() {
+            return tenant;
+        }
+
+        public void setTenant(String tenant) {
+            this.tenant = tenant;
+        }
+
+        /**
+         * 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+         */
+        @JSONField(name = "tenant_header")
+        private String tenantHeader;
+
+        public String getTenantHeader() {
+            return tenantHeader;
+        }
+
+        public void setTenantHeader(String tenantHeader) {
+            this.tenantHeader = tenantHeader;
+        }
+
+        /**
+         * 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+         */
+        @JSONField(name = "credential_ref")
+        private String credentialRef;
+
+        public String getCredentialRef() {
+            return credentialRef;
+        }
+
+        public void setCredentialRef(String credentialRef) {
+            this.credentialRef = credentialRef;
+        }
+
+        /**
+         * 是否校验 TLS 证书。默认值为 true。
+         */
+        @JSONField(name = "tls_verify")
+        private Boolean tlsVerify;
+
+        public Boolean getTlsVerify() {
+            return tlsVerify;
+        }
+
+        public void setTlsVerify(Boolean tlsVerify) {
+            this.tlsVerify = tlsVerify;
+        }
+
+        /**
+         * Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+         */
+        @JSONField(name = "external_labels")
+        private Map<String, String> externalLabels;
+
+        public Map<String, String> getExternalLabels() {
+            return externalLabels;
+        }
+
+        public void setExternalLabels(Map<String, String> externalLabels) {
+            this.externalLabels = externalLabels;
+        }
+
+        /**
+         * 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+         */
+        @JSONField(name = "headers")
+        private Map<String, String> headers;
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+        }
+
+        /**
+         * Prometheus 的额外非敏感配置，以键值对形式存储。
          */
         @JSONField(name = "properties")
         private Map<String, String> properties;
@@ -94,7 +234,7 @@ public class PrometheusV100 implements UModelCoreObject {
         }
 
         /**
-         * 用于表示该 Prometheus 存储的标签。
+         * 用于标注该 Prometheus 存储的标签。
          */
         @JSONField(name = "tags")
         private Map<String, String> tags;

--- a/internal/agentgateway/service.go
+++ b/internal/agentgateway/service.go
@@ -93,7 +93,7 @@ func (s *Service) ReadResource(ctx context.Context, workspace string, req model.
 			"read_model": map[string]any{
 				"entrypoint": "/api/v1/query/" + workspace + "/execute",
 				"tool":       "query_spl_execute",
-				"sources":    []string{".umodel", ".entity", ".topo"},
+				"sources":    []string{".umodel", ".entity_set", ".entity", ".topo", ".runbook_set"},
 			},
 			"resource_policy": "Resources expose metadata and templates only; runtime rows are returned through Query API calls.",
 		}
@@ -102,6 +102,7 @@ func (s *Service) ReadResource(ctx context.Context, workspace string, req model.
 			"workspace": workspace,
 			"sources": []map[string]any{
 				{"source": ".umodel", "description": "UModel snapshot metadata", "query_api": "/api/v1/query/" + workspace + "/execute"},
+				{"source": ".entity_set", "description": "EntitySet method call planning through the Query Service", "query_api": "/api/v1/query/" + workspace + "/execute"},
 				{"source": ".entity", "description": "CMS 2.0 entity reads through the Query Service", "query_api": "/api/v1/query/" + workspace + "/execute"},
 				{"source": ".topo", "description": "Topology reads through the Query Service", "query_api": "/api/v1/query/" + workspace + "/execute"},
 			},
@@ -112,6 +113,8 @@ func (s *Service) ReadResource(ctx context.Context, workspace string, req model.
 			"workspace": workspace,
 			"templates": []map[string]any{
 				{"id": "list-umodel", "query": ".umodel with(kind='entity_set') | limit 20"},
+				{"id": "entity-set-methods", "query": ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"},
+				{"id": "entity-set-data-sets", "query": ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"},
 				{"id": "find-entity", "query": ".entity with(domain='devops', name='devops.service', query=$query) | limit 20", "parameters": map[string]any{"query": "checkout"}},
 				{"id": "topology-neighbors", "query": ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"},
 				{"id": "topology-cypher", "query": ".topo | graph-call cypher(`MATCH (src)-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`)"},
@@ -414,6 +417,8 @@ func nextActions(workspace string, examples []string) []model.AgentNextAction {
 func defaultExamples() []string {
 	return []string{
 		".umodel with(kind='entity_set') | limit 20",
+		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()",
+		".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
 		".entity with(domain='devops', name='devops.service', query='checkout') | limit 20",
 		".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",
 		".topo | graph-call cypher(`MATCH (src)-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`)",

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -27,6 +28,8 @@ func (e *Executor) Execute(ctx context.Context, workspace string, plan model.Que
 	switch plan.Source {
 	case ".umodel":
 		result, err = e.executeUModel(ctx, workspace, plan)
+	case ".entity_set":
+		result, err = e.executeEntitySetCall(ctx, workspace, plan)
 	case ".entity":
 		result, err = e.graph.QueryEntities(ctx, model.EntityQueryPlan(plan))
 	case ".topo":
@@ -67,7 +70,287 @@ func (e *Executor) executeUModel(ctx context.Context, workspace string, plan mod
 	}, nil
 }
 
+func (e *Executor) executeEntitySetCall(ctx context.Context, workspace string, plan model.QueryPlan) (model.QueryResult, error) {
+	if plan.EntityCall == nil {
+		return model.QueryResult{}, apperrors.New(apperrors.CodeQueryPlanError, ".entity_set requires entity-call")
+	}
+	switch plan.EntityCall.Name {
+	case "__list_method__":
+		return entitySetAssistantRawResponse(entityCallListMethodHeader(), entityCallListMethodRows()), nil
+	case "list_data_set":
+		return e.executeEntitySetListDataSet(ctx, workspace, plan)
+	default:
+		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "unsupported entity-call method", map[string]string{"name": plan.EntityCall.Name})
+	}
+}
+
+func entitySetAssistantRawResponse(header []string, data []map[string]any) model.QueryResult {
+	return model.QueryResult{
+		Columns: []string{"responseType", "query", "header", "data"},
+		Rows: []map[string]any{{
+			"responseType": 2,
+			"query":        "",
+			"header":       header,
+			"data":         data,
+		}},
+	}
+}
+
+func (e *Executor) executeEntitySetListDataSet(ctx context.Context, workspace string, plan model.QueryPlan) (model.QueryResult, error) {
+	snapshot, err := e.graph.GetUModelSnapshot(ctx, model.UModelSnapshotRequest{Workspace: workspace})
+	if err != nil {
+		return model.QueryResult{}, err
+	}
+	dataSetTypes := stringSet(stringSliceValue(plan.EntityCall.Parameters["data_set_types"]))
+	detail := boolValue(plan.EntityCall.Parameters["detail"])
+	rows := make([]map[string]any, 0)
+	for _, link := range snapshot.Elements {
+		if link.Kind != "data_link" {
+			continue
+		}
+		src := refFromSpec(link.Spec, "src")
+		dest := refFromSpec(link.Spec, "dest")
+		if src.Kind != "entity_set" || src.Domain != stringFilter(plan.Filters["domain"]) || src.Name != stringFilter(plan.Filters["name"]) {
+			continue
+		}
+		if len(dataSetTypes) > 0 {
+			if _, ok := dataSetTypes[dest.Kind]; !ok {
+				continue
+			}
+		}
+		dataSet, ok := findUModelElement(snapshot.Elements, dest.Kind, dest.Domain, dest.Name)
+		if !ok {
+			continue
+		}
+		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, link, dataSet, detail)))
+	}
+	return entitySetAssistantRawResponse(listDataSetHeader(), rows), nil
+}
+
+type setRef struct {
+	Domain string
+	Kind   string
+	Name   string
+}
+
+func entityCallRowValues(values []string) map[string]any {
+	return map[string]any{"values": values}
+}
+
+func entityCallListMethodHeader() []string {
+	return []string{"name", "display_name", "description", "params", "returns"}
+}
+
+func entityCallListMethodRows() []map[string]any {
+	rows := []map[string]any{}
+	for _, method := range []entityCallMethodInfo{
+		methodInfoListMethods(),
+		methodInfoListDataSet(),
+	} {
+		rows = append(rows, entityCallRowValues([]string{
+			method.Name,
+			method.DisplayName,
+			method.Description,
+			mustJSON(method.Params),
+			mustJSON(method.Returns),
+		}))
+	}
+	return rows
+}
+
+type entityCallMethodInfo struct {
+	Name        string
+	DisplayName string
+	Description string
+	Params      []assistantParamInfo
+	Returns     []assistantReturnInfo
+}
+
+type assistantParamInfo struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+	Default     any    `json:"default,omitempty"`
+}
+
+type assistantReturnInfo struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+}
+
+func methodInfoListMethods() entityCallMethodInfo {
+	return entityCallMethodInfo{
+		Name:        "__list_method__",
+		DisplayName: "List Available Methods",
+		Description: "Get all methods supported by current EntitySet",
+		Returns: []assistantReturnInfo{
+			{Key: "name", Type: "varchar", DisplayName: "Method Name"},
+			{Key: "display_name", Type: "varchar", DisplayName: "Method Display Name"},
+			{Key: "description", Type: "varchar", DisplayName: "Method Description"},
+			{Key: "params", Type: "varchar", DisplayName: "Method Parameters (JSON)"},
+			{Key: "returns", Type: "varchar", DisplayName: "Method Returns (JSON)"},
+		},
+	}
+}
+
+func methodInfoListDataSet() entityCallMethodInfo {
+	return entityCallMethodInfo{
+		Name:        "list_data_set",
+		DisplayName: "List DataSets",
+		Description: "Get DataSets(MetricSet, LogSet, TraceSet, EventSet...) related to EntitySet",
+		Params: []assistantParamInfo{
+			{Key: "data_set_types", Type: "array<varchar>", DisplayName: "Data Set Types, metric_set, log_set, trace_set, event_set"},
+			{Key: "detail", Type: "boolean", DisplayName: "Detail Info, if true, return all fields of DataSet", Default: false},
+		},
+		Returns: returnsFromHeader(listDataSetHeader()),
+	}
+}
+
+func returnsFromHeader(header []string) []assistantReturnInfo {
+	out := make([]assistantReturnInfo, 0, len(header))
+	for _, key := range header {
+		out = append(out, assistantReturnInfo{Key: key, Type: "varchar", DisplayName: key})
+	}
+	return out
+}
+
+func listDataSetHeader() []string {
+	return []string{"data_set_id", "type", "domain", "name", "fields_mapping", "filterable_fields", "fields", "storage_info", "storage_link_info", "data_link_detail", "data_set_detail", "storage_detail", "storage_link_detail"}
+}
+
+func listDataSetValues(elements []model.UModelElement, link model.UModelElement, dataSet model.UModelElement, detail bool) []string {
+	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet)
+	dataLinkDetail := "{}"
+	dataSetDetail := "{}"
+	if detail {
+		dataLinkDetail = mustJSON(link)
+		dataSetDetail = mustJSON(dataSet)
+	} else {
+		storageDetail = []model.UModelElement{}
+		storageLinkDetail = []model.UModelElement{}
+	}
+	fieldsMapping := mapValue(link.Spec["fields_mapping"])
+	return []string{
+		uniqueID(dataSet.Domain, dataSet.Kind, dataSet.Name),
+		dataSet.Kind,
+		dataSet.Domain,
+		dataSet.Name,
+		mustJSON(fieldsMapping),
+		mustJSON(filterableFields(dataSet)),
+		mustJSON(dataSet.Spec["fields"]),
+		mustJSON(storageInfo),
+		mustJSON(storageLinkInfo),
+		dataLinkDetail,
+		dataSetDetail,
+		mustJSON(storageDetail),
+		mustJSON(storageLinkDetail),
+	}
+}
+
+func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
+	storageInfo := []map[string]any{}
+	storageLinkInfo := []map[string]any{}
+	storageDetail := []model.UModelElement{}
+	storageLinkDetail := []model.UModelElement{}
+	for _, link := range elements {
+		if link.Kind != "storage_link" {
+			continue
+		}
+		src := refFromSpec(link.Spec, "src")
+		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
+			continue
+		}
+		dest := refFromSpec(link.Spec, "dest")
+		if storage, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name); ok {
+			storageInfo = append(storageInfo, map[string]any{
+				"domain": storage.Domain,
+				"type":   storage.Kind,
+				"name":   storage.Name,
+				"config": storage.Spec,
+			})
+			storageDetail = append(storageDetail, storage)
+		}
+		storageLinkInfo = append(storageLinkInfo, map[string]any{
+			"domain": link.Domain,
+			"name":   link.Name,
+			"spec":   link.Spec,
+		})
+		storageLinkDetail = append(storageLinkDetail, link)
+	}
+	return storageInfo, storageLinkInfo, storageDetail, storageLinkDetail
+}
+
+func refFromSpec(spec map[string]any, key string) setRef {
+	value, _ := spec[key].(map[string]any)
+	return setRef{
+		Domain: stringValue(value["domain"]),
+		Kind:   stringValue(value["kind"]),
+		Name:   stringValue(value["name"]),
+	}
+}
+
+func findUModelElement(elements []model.UModelElement, kind, domain, name string) (model.UModelElement, bool) {
+	for _, element := range elements {
+		if element.Kind == kind && element.Domain == domain && element.Name == name {
+			return element, true
+		}
+	}
+	return model.UModelElement{}, false
+}
+
+func filterableFields(element model.UModelElement) []string {
+	fields, ok := element.Spec["fields"].([]any)
+	if !ok {
+		return []string{}
+	}
+	out := []string{}
+	for _, field := range fields {
+		item, ok := field.(map[string]any)
+		if !ok {
+			continue
+		}
+		if boolValue(item["filterable"]) || boolValue(item["analysable"]) {
+			out = append(out, stringValue(item["name"]))
+		}
+	}
+	return out
+}
+
+func mapValue(value any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	return map[string]any{}
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func uniqueID(domain, kind, name string) string {
+	return strings.Join([]string{domain, kind, name}, "@")
+}
+
+func mustJSON(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "null"
+	}
+	return string(encoded)
+}
+
 func applyPipeline(source string, rows []map[string]any, columns []string, plan model.QueryPlan) ([]map[string]any, []string) {
+	if source == ".entity_set" {
+		return limitRows(rows, plan.Limit), columns
+	}
 	if !hasOperator(plan.Pipeline, "with") && len(plan.Filters) > 0 {
 		rows = filterRows(source, rows, plan.Filters)
 	}
@@ -140,6 +423,13 @@ func rowMatchesFilters(source string, row map[string]any, filters map[string]any
 			return false
 		}
 		if !matchesIDs(rowString(row, "__entity_id__"), filters["ids"]) {
+			return false
+		}
+	case ".entity_set":
+		if !stringMatches(rowString(row, "domain"), filters["domain"]) {
+			return false
+		}
+		if !stringMatches(rowString(row, "name"), filters["name"]) {
 			return false
 		}
 	case ".topo":
@@ -376,6 +666,17 @@ func stringValue(value any) string {
 		return ""
 	default:
 		return fmt.Sprint(value)
+	}
+}
+
+func boolValue(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(typed, "true")
+	default:
+		return false
 	}
 }
 

--- a/internal/query/explain.go
+++ b/internal/query/explain.go
@@ -12,6 +12,7 @@ func buildExplain(plan model.QueryPlan, caps model.GraphStoreCapabilities, healt
 		Source:           plan.Source,
 		Provider:         provider,
 		StorageProvider:  provider,
+		EntityCall:       plan.EntityCall,
 		Pushdown:         pushdownForPlan(plan, caps),
 		Fallback:         fallbackForPlan(plan, caps),
 		Operators:        append([]string(nil), plan.Operators...),
@@ -52,6 +53,9 @@ func fallbackForPlan(plan model.QueryPlan, caps model.GraphStoreCapabilities) []
 	fallback := []string{}
 	if plan.Source == ".umodel" {
 		fallback = append(fallback, "snapshot_filter")
+	}
+	if plan.Source == ".entity_set" {
+		fallback = append(fallback, "entity_call_plan")
 	}
 	if plan.Source == ".entity" && !caps.ServerSideFilter {
 		fallback = append(fallback, "application_filter")

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -50,6 +50,10 @@ func ParseAST(query string) (AST, error) {
 		}
 	}
 
+	if err := validateAST(ast); err != nil {
+		return AST{}, err
+	}
+
 	return ast, nil
 }
 
@@ -65,6 +69,7 @@ func planFromAST(req model.QueryRequest, ast AST) model.QueryPlan {
 	project := []string{}
 	sortSpecs := []model.QuerySort{}
 	var graphCall *model.GraphCallPlan
+	var entityCall *model.EntityCallPlan
 	topk := intFilter(filters["topk"])
 
 	for idx, operator := range pipeline {
@@ -87,6 +92,14 @@ func planFromAST(req model.QueryRequest, ast AST) model.QueryPlan {
 		if operator.GraphCall != nil {
 			copy := *operator.GraphCall
 			graphCall = &copy
+		}
+		if operator.EntityCall != nil {
+			copy := *operator.EntityCall
+			copy.Arguments = resolveArgumentValues(copy.Arguments, req.Params)
+			copy.NamedArguments = resolveNamedArgumentValues(copy.NamedArguments, req.Params)
+			pipeline[idx].EntityCall = &copy
+			operator.EntityCall = &copy
+			entityCall = &copy
 		}
 	}
 
@@ -116,6 +129,7 @@ func planFromAST(req model.QueryRequest, ast AST) model.QueryPlan {
 		Project:    project,
 		Sort:       sortSpecs,
 		GraphCall:  graphCall,
+		EntityCall: entityCall,
 		TopK:       topk,
 		TimeRange:  req.TimeRange,
 		Params:     req.Params,
@@ -158,6 +172,28 @@ func resolveParamValue(value any, params map[string]any) any {
 	}
 }
 
+func resolveArgumentValues(args []any, params map[string]any) []any {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(args))
+	for _, item := range args {
+		out = append(out, resolveParamValue(item, params))
+	}
+	return out
+}
+
+func resolveNamedArgumentValues(args map[string]any, params map[string]any) map[string]any {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(args))
+	for key, value := range args {
+		out[key] = resolveParamValue(value, params)
+	}
+	return out
+}
+
 func paramName(value string) (string, bool) {
 	if !strings.HasPrefix(value, "$") || len(value) == 1 {
 		return "", false
@@ -172,12 +208,30 @@ func paramName(value string) (string, bool) {
 }
 
 func detectSource(queryText string) (string, error) {
-	for _, source := range []string{".umodel", ".entity", ".topo", ".runbook_set"} {
+	for _, source := range []string{".umodel", ".entity_set", ".entity", ".topo", ".runbook_set"} {
 		if strings.HasPrefix(queryText, source) && hasSourceBoundary(queryText, len(source)) {
 			return source, nil
 		}
 	}
-	return "", apperrors.New(apperrors.CodeQueryParseError, "query must start with .umodel, .entity, .topo, or .runbook_set")
+	return "", apperrors.New(apperrors.CodeQueryParseError, "query must start with .umodel, .entity_set, .entity, .topo, or .runbook_set")
+}
+
+func validateAST(ast AST) error {
+	if ast.Source != ".entity_set" {
+		return nil
+	}
+	if stringFilter(ast.Filters["domain"]) == "" {
+		return apperrors.New(apperrors.CodeQueryParseError, ".entity_set requires with(domain=...)")
+	}
+	if stringFilter(ast.Filters["name"]) == "" {
+		return apperrors.New(apperrors.CodeQueryParseError, ".entity_set requires with(name=...)")
+	}
+	for _, operator := range ast.Operators {
+		if operator.EntityCall != nil {
+			return nil
+		}
+	}
+	return apperrors.New(apperrors.CodeQueryParseError, ".entity_set requires entity-call __list_method__() or list_data_set(...)")
 }
 
 func hasSourceBoundary(queryText string, pos int) bool {
@@ -229,6 +283,15 @@ func parsePipelineSegment(ast *AST, segment string) error {
 		}
 		ast.Limit = limit
 		ast.Operators = append(ast.Operators, model.QueryPipelineOperator{Name: "limit", Limit: limit})
+	case strings.HasPrefix(segment, "entity-call "):
+		if ast.Source != ".entity_set" {
+			return apperrors.New(apperrors.CodeQueryParseError, "entity-call is only supported for .entity_set")
+		}
+		entityCall, err := parseEntityCall(strings.TrimSpace(strings.TrimPrefix(segment, "entity-call")))
+		if err != nil {
+			return err
+		}
+		ast.Operators = append(ast.Operators, model.QueryPipelineOperator{Name: "entity-call:" + entityCall.Name, EntityCall: &entityCall})
 	case strings.HasPrefix(segment, "graph-call "):
 		if ast.Source != ".topo" {
 			return apperrors.New(apperrors.CodeQueryParseError, "graph-call is only supported for .topo")
@@ -329,6 +392,70 @@ func parseSort(expression string) (model.QuerySort, error) {
 		}
 	}
 	return model.QuerySort{Field: parts[0], Desc: desc}, nil
+}
+
+func parseEntityCall(expression string) (model.EntityCallPlan, error) {
+	open := strings.Index(expression, "(")
+	if open < 0 {
+		return model.EntityCallPlan{}, apperrors.New(apperrors.CodeQueryParseError, "entity-call requires a function call")
+	}
+	name := strings.TrimSpace(expression[:open])
+	end := matchingParen(expression, open)
+	if !isValidCallName(name) || end < 0 || strings.TrimSpace(expression[end+1:]) != "" {
+		return model.EntityCallPlan{}, apperrors.New(apperrors.CodeQueryParseError, "entity-call is malformed")
+	}
+
+	rawArgs := strings.TrimSpace(expression[open+1 : end])
+	args := []any{}
+	namedArgs := map[string]any{}
+	if rawArgs != "" {
+		for _, rawArg := range splitTopLevel(rawArgs, ',') {
+			rawArg = strings.TrimSpace(rawArg)
+			if rawArg == "" {
+				return model.EntityCallPlan{}, apperrors.New(apperrors.CodeQueryParseError, "entity-call arguments cannot be empty")
+			}
+			if key, value, ok := cutTopLevel(rawArg, '='); ok && isValidArgumentName(strings.TrimSpace(key)) {
+				key = strings.TrimSpace(key)
+				if _, exists := namedArgs[key]; exists {
+					return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryParseError, "entity-call named argument is duplicated", map[string]string{"argument": key})
+				}
+				namedArgs[key] = parseValue(strings.TrimSpace(value))
+				continue
+			}
+			args = append(args, parseValue(rawArg))
+		}
+	}
+	if len(namedArgs) == 0 {
+		namedArgs = nil
+	}
+	return model.EntityCallPlan{Name: name, Arguments: args, NamedArguments: namedArgs}, nil
+}
+
+func isValidCallName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsSpace(r) || r == '|' || r == '(' || r == ')' {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidArgumentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for idx, r := range name {
+		if idx == 0 && !(unicode.IsLetter(r) || r == '_') {
+			return false
+		}
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 func parseGraphCall(expression string) (model.GraphCallPlan, error) {

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -99,6 +99,44 @@ func TestParseEntityFiltersTopKAndIDs(t *testing.T) {
 	}
 }
 
+func TestParseEntitySetEntityCall(t *testing.T) {
+	plan, err := Parse(model.QueryRequest{
+		Query: ".entity_set with(domain='apm', name='apm.service', ids=['svc-1'], query=$query) | entity-call list_data_set($types, detail=$detail) | limit 10",
+		Params: map[string]any{
+			"query":  "service_id = 'svc-1'",
+			"types":  []string{"metric_set", "log_set"},
+			"detail": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("parse entity-call: %v", err)
+	}
+	if plan.Source != ".entity_set" || plan.Limit != 10 {
+		t.Fatalf("unexpected plan: %+v", plan)
+	}
+	if plan.Filters["domain"] != "apm" || plan.Filters["name"] != "apm.service" || plan.Filters["query"] != "service_id = 'svc-1'" {
+		t.Fatalf("unexpected filters: %+v", plan.Filters)
+	}
+	if !reflect.DeepEqual(plan.Operators, []string{"with", "entity-call:list_data_set", "limit"}) {
+		t.Fatalf("unexpected operators: %+v", plan.Operators)
+	}
+	if plan.EntityCall == nil || plan.EntityCall.Name != "list_data_set" {
+		t.Fatalf("unexpected entity call: %+v", plan.EntityCall)
+	}
+	if !reflect.DeepEqual(plan.EntityCall.Arguments, []any{[]string{"metric_set", "log_set"}}) {
+		t.Fatalf("unexpected entity-call arguments: %#v", plan.EntityCall.Arguments)
+	}
+	if !reflect.DeepEqual(plan.EntityCall.NamedArguments, map[string]any{"detail": true}) {
+		t.Fatalf("unexpected entity-call named arguments: %#v", plan.EntityCall.NamedArguments)
+	}
+	if plan.Pipeline[1].EntityCall == nil || !reflect.DeepEqual(plan.Pipeline[1].EntityCall.Arguments, plan.EntityCall.Arguments) {
+		t.Fatalf("pipeline entity-call should keep resolved arguments: %+v", plan.Pipeline)
+	}
+	if !reflect.DeepEqual(plan.Pipeline[1].EntityCall.NamedArguments, plan.EntityCall.NamedArguments) {
+		t.Fatalf("pipeline entity-call should keep resolved named arguments: %+v", plan.Pipeline)
+	}
+}
+
 func TestParseTopoControlledGraphCalls(t *testing.T) {
 	neighbors, err := Parse(model.QueryRequest{Query: ".topo | graph-call getNeighborNodes('full', 3, [" + cartServiceNode + "]) | limit 10"})
 	if err != nil {
@@ -161,6 +199,10 @@ func TestParseRejectsMalformedWithLimitAndDepth(t *testing.T) {
 		".entity | limit 0",
 		".entity_set",
 		".entity_set with(domain='apm')",
+		".entity_set with(domain='apm', name='apm.service')",
+		".entity_set with(domain='apm', name='apm.service') | entity-call",
+		".entity_set with(domain='apm', name='apm.service') | entity-call get_metric(,)",
+		".entity with(domain='apm', name='apm.service') | entity-call get_log('apm', 'apm.log.app')",
 		".topo | graph-call getNeighborNodes('both', 2, [" + cartServiceNode + "])",
 		".topo | graph-call getNeighborNodes('full', -1, [" + cartServiceNode + "])",
 		".topo | graph-call getNeighborNodes('full', 2, [])",

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -15,25 +15,26 @@ func (Planner) Plan(req model.QueryRequest, caps model.GraphStoreCapabilities) (
 	if err != nil {
 		return model.QueryPlan{}, err
 	}
-	if err := validatePlan(plan, caps); err != nil {
+	plan, err = validatePlan(plan, caps)
+	if err != nil {
 		return model.QueryPlan{}, err
 	}
 	return plan, nil
 }
 
-func validatePlan(plan model.QueryPlan, caps model.GraphStoreCapabilities) error {
+func validatePlan(plan model.QueryPlan, caps model.GraphStoreCapabilities) (model.QueryPlan, error) {
 	maxLimit := caps.MaxLimit
 	if maxLimit <= 0 {
 		maxLimit = 1000
 	}
 	if plan.Limit > maxLimit {
-		return apperrors.WithDetails(apperrors.CodeValidationFailed, "query limit exceeds provider capability", map[string]string{
+		return model.QueryPlan{}, apperrors.WithDetails(apperrors.CodeValidationFailed, "query limit exceeds provider capability", map[string]string{
 			"limit":     fmt.Sprint(plan.Limit),
 			"max_limit": fmt.Sprint(maxLimit),
 		})
 	}
 	if plan.TopK > maxLimit {
-		return apperrors.WithDetails(apperrors.CodeValidationFailed, "query topk exceeds provider capability", map[string]string{
+		return model.QueryPlan{}, apperrors.WithDetails(apperrors.CodeValidationFailed, "query topk exceeds provider capability", map[string]string{
 			"topk":      fmt.Sprint(plan.TopK),
 			"max_limit": fmt.Sprint(maxLimit),
 		})
@@ -44,40 +45,183 @@ func validatePlan(plan model.QueryPlan, caps model.GraphStoreCapabilities) error
 		maxDepth = 1
 	}
 	if plan.Depth > maxDepth {
-		return apperrors.WithDetails(apperrors.CodeValidationFailed, "query depth exceeds provider capability", map[string]string{
+		return model.QueryPlan{}, apperrors.WithDetails(apperrors.CodeValidationFailed, "query depth exceeds provider capability", map[string]string{
 			"depth":     fmt.Sprint(plan.Depth),
 			"max_depth": fmt.Sprint(maxDepth),
 		})
 	}
 
-	for _, operator := range plan.Operators {
+	for idx, operator := range plan.Operators {
 		switch {
+		case strings.HasPrefix(operator, "entity-call:"):
+			if plan.Source != ".entity_set" {
+				return model.QueryPlan{}, apperrors.New(apperrors.CodeQueryPlanError, "entity-call is only supported for .entity_set")
+			}
+			if plan.EntityCall == nil || plan.EntityCall.Name == "" {
+				return model.QueryPlan{}, apperrors.New(apperrors.CodeQueryPlanError, "entity-call requires a method name")
+			}
+			entityCall, err := normalizeEntityCall(*plan.EntityCall)
+			if err != nil {
+				return model.QueryPlan{}, err
+			}
+			plan.EntityCall = &entityCall
+			if idx < len(plan.Pipeline) && plan.Pipeline[idx].EntityCall != nil {
+				plan.Pipeline[idx].EntityCall = &entityCall
+			}
 		case operator == "graph-match" && !caps.GraphMatch:
-			return apperrors.New(apperrors.CodeProviderUnsupported, "graph-match is not supported by provider")
+			return model.QueryPlan{}, apperrors.New(apperrors.CodeProviderUnsupported, "graph-match is not supported by provider")
 		case strings.HasPrefix(operator, "graph-call:"):
 			if plan.Source != ".topo" {
-				return apperrors.New(apperrors.CodeQueryPlanError, "graph-call is only supported for .topo")
+				return model.QueryPlan{}, apperrors.New(apperrors.CodeQueryPlanError, "graph-call is only supported for .topo")
 			}
 			if plan.GraphCall == nil || !isAllowedGraphCall(plan.GraphCall.Name) {
-				return apperrors.WithDetails(apperrors.CodeQueryPlanError, "unsupported graph-call", map[string]string{"name": graphCallName(plan.GraphCall)})
+				return model.QueryPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "unsupported graph-call", map[string]string{"name": graphCallName(plan.GraphCall)})
 			}
 			if plan.GraphCall.Name == "cypher" {
 				if !caps.ControlledCypher {
-					return apperrors.New(apperrors.CodeProviderUnsupported, "controlled cypher is not supported by provider")
+					return model.QueryPlan{}, apperrors.New(apperrors.CodeProviderUnsupported, "controlled cypher is not supported by provider")
 				}
 				continue
 			}
 			if !caps.GraphCallNeighbors {
-				return apperrors.New(apperrors.CodeProviderUnsupported, "graph-call is not supported by provider")
+				return model.QueryPlan{}, apperrors.New(apperrors.CodeProviderUnsupported, "graph-call is not supported by provider")
 			}
 		}
 	}
 
-	return nil
+	if plan.Source == ".entity_set" && plan.EntityCall == nil {
+		return model.QueryPlan{}, apperrors.New(apperrors.CodeQueryPlanError, ".entity_set requires entity-call")
+	}
+
+	return plan, nil
 }
 
 func isAllowedGraphCall(name string) bool {
 	return name == "getNeighborNodes" || name == "getDirectRelations" || name == "cypher"
+}
+
+type entityCallMethodSpec struct {
+	Name   string
+	Params []model.EntityCallParam
+}
+
+func normalizeEntityCall(call model.EntityCallPlan) (model.EntityCallPlan, error) {
+	spec, ok := entityCallMethodSpecFor(call.Name)
+	if !ok {
+		return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "unsupported entity-call method", map[string]string{"name": call.Name})
+	}
+	if len(call.Arguments) > len(spec.Params) {
+		return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "entity-call has too many arguments", map[string]string{
+			"method": call.Name,
+			"max":    fmt.Sprint(len(spec.Params)),
+		})
+	}
+
+	paramIndex := map[string]int{}
+	for idx, param := range spec.Params {
+		paramIndex[param.Key] = idx
+	}
+	for key := range call.NamedArguments {
+		if _, exists := paramIndex[key]; !exists {
+			return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "entity-call named argument is not supported", map[string]string{
+				"method":   call.Name,
+				"argument": key,
+			})
+		}
+	}
+
+	parameters := make(map[string]any, len(spec.Params))
+	for idx, value := range call.Arguments {
+		param := spec.Params[idx]
+		if _, exists := call.NamedArguments[param.Key]; exists {
+			return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "entity-call argument is provided twice", map[string]string{
+				"method":   call.Name,
+				"argument": param.Key,
+			})
+		}
+		if err := validateEntityCallArgument(call.Name, param, value); err != nil {
+			return model.EntityCallPlan{}, err
+		}
+		parameters[param.Key] = value
+	}
+	for key, value := range call.NamedArguments {
+		param := spec.Params[paramIndex[key]]
+		if err := validateEntityCallArgument(call.Name, param, value); err != nil {
+			return model.EntityCallPlan{}, err
+		}
+		parameters[param.Key] = value
+	}
+	for _, param := range spec.Params {
+		if _, exists := parameters[param.Key]; exists {
+			continue
+		}
+		if param.Required {
+			return model.EntityCallPlan{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "entity-call required argument is missing", map[string]string{
+				"method":   call.Name,
+				"argument": param.Key,
+			})
+		}
+		parameters[param.Key] = param.Default
+	}
+
+	call.Signature = append([]model.EntityCallParam(nil), spec.Params...)
+	call.Parameters = parameters
+	call.Name = spec.Name
+	return call, nil
+}
+
+func entityCallMethodSpecFor(name string) (entityCallMethodSpec, bool) {
+	switch name {
+	case "__list_method__":
+		return entityCallMethodSpec{Name: "__list_method__"}, true
+	case "list_dataset", "list_data_set":
+		return entityCallMethodSpec{
+			Name: "list_data_set",
+			Params: []model.EntityCallParam{
+				{Key: "data_set_types", Type: "array<varchar>", DisplayName: "Data Set Types, metric_set, log_set, trace_set, event_set"},
+				{Key: "detail", Type: "boolean", DisplayName: "Detail Info, if true, return all fields of DataSet", Default: false},
+			},
+		}, true
+	default:
+		return entityCallMethodSpec{}, false
+	}
+}
+
+func validateEntityCallArgument(method string, param model.EntityCallParam, value any) error {
+	switch param.Type {
+	case "varchar":
+		if _, ok := value.(string); ok {
+			return nil
+		}
+	case "boolean":
+		if _, ok := value.(bool); ok {
+			return nil
+		}
+	case "array<varchar>":
+		if _, ok := value.([]string); ok {
+			return nil
+		}
+		if values, ok := value.([]any); ok {
+			for _, item := range values {
+				if _, ok := item.(string); !ok {
+					return entityCallTypeError(method, param, value)
+				}
+			}
+			return nil
+		}
+	default:
+		return nil
+	}
+	return entityCallTypeError(method, param, value)
+}
+
+func entityCallTypeError(method string, param model.EntityCallParam, value any) error {
+	return apperrors.WithDetails(apperrors.CodeQueryPlanError, "entity-call argument has invalid type", map[string]string{
+		"method":   method,
+		"argument": param.Key,
+		"expected": param.Type,
+		"actual":   fmt.Sprintf("%T", value),
+	})
 }
 
 func graphCallName(call *model.GraphCallPlan) string {

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -87,6 +87,8 @@ func (s *Service) Examples(ctx context.Context) ([]string, error) {
 		".entity with(domain='k8s', name='k8s.workload', query='checkout', topk=20)",
 		".entity with(domain='apm', name='apm.service', query='payment latency spikes', mode='vector', topk=20)",
 		".entity with(domain='apm', name='apm.service', query='checkout failure', mode='hyper', topk=20, hybrid_k=60)",
+		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()",
+		".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
 		".runbook_set with(domain='apm', type='knowledge', query='how to mitigate slow request', mode='hyper', topk=5)",
 		".runbook_set with(domain='apm', type='observations', query='cache miss spike', mode='vector', topk=10)",
 		".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",

--- a/internal/query/service_test.go
+++ b/internal/query/service_test.go
@@ -133,6 +133,73 @@ func TestExecuteEntityQueryUsesGraphStoreRows(t *testing.T) {
 	}
 }
 
+func TestExecuteEntitySetListMethodsReturnsAssistantRawData(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(graphstore.NewMemoryStore())
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call __list_method__()"})
+	if err != nil {
+		t.Fatalf("execute __list_method__: %v", err)
+	}
+	row := result.Rows[0]
+	if row["responseType"] != 2 || row["query"] != "" {
+		t.Fatalf("expected assistant raw data response, got %+v", row)
+	}
+	header, ok := row["header"].([]string)
+	if !ok || !containsString(header, "name") || !containsString(header, "params") || !containsString(header, "returns") {
+		t.Fatalf("unexpected __list_method__ header: %#v", row["header"])
+	}
+	data, ok := row["data"].([]map[string]any)
+	if !ok || len(data) != 2 {
+		t.Fatalf("unexpected __list_method__ data: %#v", row["data"])
+	}
+	values, ok := data[1]["values"].([]string)
+	if !ok || len(values) == 0 || values[0] != "list_data_set" {
+		t.Fatalf("expected assistant canonical list_data_set method row, got %#v", data[1])
+	}
+}
+
+func TestExecuteEntitySetListDataSetAliasReturnsAssistantRawData(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(graphstore.NewMemoryStore())
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call list_dataset(['metric_set'], true)"})
+	if err != nil {
+		t.Fatalf("execute list_dataset alias: %v", err)
+	}
+	row := result.Rows[0]
+	if row["responseType"] != 2 || row["query"] != "" {
+		t.Fatalf("expected assistant raw data response, got %+v", row)
+	}
+	header, ok := row["header"].([]string)
+	if !ok || !containsString(header, "data_set_id") || !containsString(header, "storage_link_detail") {
+		t.Fatalf("unexpected list_data_set header: %#v", row["header"])
+	}
+	data, ok := row["data"].([]map[string]any)
+	if !ok || len(data) != 0 {
+		t.Fatalf("memory quickstart has no data links; expected empty data, got %#v", row["data"])
+	}
+	if result.Explain == nil || result.Explain.EntityCall == nil || result.Explain.EntityCall.Name != "list_data_set" {
+		t.Fatalf("expected canonical list_data_set in explain, got %+v", result.Explain)
+	}
+}
+
+func TestExecuteEntitySetRejectsPlaceholderMethod(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call METHOD()"})
+	if !apperrors.IsCode(err, apperrors.CodeQueryPlanError) {
+		t.Fatalf("expected query plan error for placeholder method, got %v", err)
+	}
+}
+
+func TestExecuteEntitySetRejectsUnsupportedMethod(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call get_metric('apm', 'devops.metric.service', 'request_count')"})
+	if !apperrors.IsCode(err, apperrors.CodeQueryPlanError) {
+		t.Fatalf("expected query plan error for unsupported method, got %v", err)
+	}
+}
+
 func TestExecuteEntityTopKAndProject(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()

--- a/internal/sampledata/service_test.go
+++ b/internal/sampledata/service_test.go
@@ -68,15 +68,42 @@ func TestImportMultiDomainQuickStartWritesSchemaEntitiesAndTopology(t *testing.T
 	}
 
 	querySvc := query.NewService(graph)
-	for _, kind := range []string{"metric_set", "log_set", "trace_set", "event_set", "profile_set", "runbook_set", "data_link", "storage_link"} {
+	for _, kind := range []string{"metric_set", "log_set", "event_set", "data_link", "storage_link", "prometheus", "elasticsearch", "mysql"} {
 		rows, err := querySvc.Execute(ctx, "demo", model.QueryRequest{
 			Query: ".umodel with(kind='" + kind + "') | limit 1",
 		})
 		if err != nil {
-			t.Fatalf("query excluded kind %s: %v", kind, err)
+			t.Fatalf("query imported kind %s: %v", kind, err)
 		}
-		if len(rows.Rows) != 0 {
-			t.Fatalf("quickstart should not import %s definitions, got %+v", kind, rows)
+		if len(rows.Rows) == 0 {
+			t.Fatalf("quickstart should import %s definitions, got %+v", kind, rows)
+		}
+	}
+
+	dataSetRows, err := querySvc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
+	})
+	if err != nil {
+		t.Fatalf("list quickstart data sets: %v", err)
+	}
+	if len(dataSetRows.Rows) != 1 {
+		t.Fatalf("expected assistant response row, got %+v", dataSetRows.Rows)
+	}
+	data, ok := dataSetRows.Rows[0]["data"].([]map[string]any)
+	if !ok || len(data) != 3 {
+		t.Fatalf("expected metric, log, and event data sets, got %#v", dataSetRows.Rows[0]["data"])
+	}
+	joinedData := ""
+	for _, item := range data {
+		values, ok := item["values"].([]string)
+		if !ok {
+			t.Fatalf("unexpected list_data_set row: %#v", item)
+		}
+		joinedData += strings.Join(values, "\n")
+	}
+	for _, want := range []string{"devops.metric.service", "devops.log.service", "devops.event.deployment", "prometheus", "devops.prometheus.core", "elasticsearch", "devops.elasticsearch.logs", "mysql", "devops.mysql.events", "\"id\":\"service_id\""} {
+		if !strings.Contains(joinedData, want) {
+			t.Fatalf("expected list_data_set output to contain %q, got %s", want, joinedData)
 		}
 	}
 

--- a/internal/umodel/schemaspec/data/elasticsearch.expanded.yaml
+++ b/internal/umodel/schemaspec/data/elasticsearch.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: ElasticSearch 存储，用于描述 ElasticSearch 实例的配置和连接信息。
+  zh_cn: Elasticsearch 存储，用于描述 Elasticsearch 集群、索引以及查询规划所需的连接信息。
   en_us: >-
-    ElasticSearch storage, used to define the ElasticSearch instance configuration and connection details.
+    Elasticsearch storage, used to define the Elasticsearch cluster, index, and connection metadata required for query planning.
 name: elasticsearch
 versions:
 - name: v1.0.0
@@ -191,34 +191,106 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+          zh_cn: Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
           en_us: >-
-            The specification section containing ElasticSearch configuration, including connection and index parameters.
+            The specification section for Elasticsearch. UModel uses these fields to generate Elasticsearch query plans only;
+            it does not execute queries or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: ElasticSearch 实例的访问地址（URL）。
-              en_us: The endpoint URL of the ElasticSearch instance.
+              zh_cn: Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
+              en_us: The Elasticsearch cluster endpoint, for example https://es.example.com:9200.
             type: string
             constraint:
               required: true
           index:
             description:
-              zh_cn: ElasticSearch 索引名称。
-              en_us: The name of the ElasticSearch index.
+              zh_cn: 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
+              en_us: >-
+                The default index name to query. It may also be an Elasticsearch-supported index wildcard expression.
             type: string
             constraint:
               required: true
+          index_pattern:
+            description:
+              zh_cn: 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+              en_us: >-
+                Index pattern for time-rolled indices, for example logs-${yyyy.MM.dd}. When empty, query planning uses the
+                index field.
+            type: string
           version:
             description:
-              zh_cn: ElasticSearch 的版本号（如 7.x、8.x）。
-              en_us: The version of the ElasticSearch instance (e.g. 7.x, 8.x).
+              zh_cn: Elasticsearch 版本号或版本族，例如 7.x、8.x。
+              en_us: The Elasticsearch version or version family, for example 7.x or 8.x.
             type: string
+          query_dialect:
+            description:
+              zh_cn: 查询生成方言。默认生成 Elasticsearch Query DSL。
+              en_us: Query generation dialect. Elasticsearch Query DSL is used by default.
+            type: string
+            constraint:
+              enum:
+                values:
+                - elasticsearch_dsl
+                - lucene
+                - eql
+              default_value: elasticsearch_dsl
+          time_field:
+            description:
+              zh_cn: 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+              en_us: Time field used to push request time ranges into Elasticsearch queries.
+            type: string
+          default_size:
+            description:
+              zh_cn: 未显式指定 limit 时生成查询的默认 size。
+              en_us: Default query size when no explicit limit is provided.
+            type: integer
+            constraint:
+              default_value: 1000
+          max_size:
+            description:
+              zh_cn: 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+              en_us: >-
+                Maximum query size allowed by the planner to avoid producing excessively large query plans.
+            type: integer
+            constraint:
+              default_value: 10000
+          routing:
+            description:
+              zh_cn: 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+              en_us: >-
+                Optional Elasticsearch routing value for queries that should target a fixed routing key.
+            type: string
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://es-prod-readonly. Plaintext usernames, passwords, or tokens must
+                not be stored in UModel.
+            type: string
+          tls_verify:
+            description:
+              zh_cn: 是否校验 TLS 证书。默认值为 true。
+              en_us: Whether TLS certificates should be verified. Defaults to true.
+            type: boolean
+            constraint:
+              default_value: true
+          headers:
+            description:
+              zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+              en_us: >-
+                Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
           properties:
             description:
-              zh_cn: ElasticSearch 的额外配置信息，以键值对形式存储。
-              en_us: >-
-                Additional configuration of the ElasticSearch instance, stored as key-value pairs.
+              zh_cn: Elasticsearch 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive Elasticsearch configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -228,8 +300,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 ElasticSearch 存储的标签。
-              en_us: This field is used to represent the tags of the ElasticSearch storage.
+              zh_cn: 用于标注该 Elasticsearch 存储的标签。
+              en_us: Tags used to describe this Elasticsearch storage.
             type: map
             constraint:
               map:

--- a/internal/umodel/schemaspec/data/mysql.expanded.yaml
+++ b/internal/umodel/schemaspec/data/mysql.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: MySQL 存储，用于描述 MySQL 数据库实例的配置和连接信息。
+  zh_cn: MySQL 存储，用于描述 MySQL 实例、数据库、表以及查询规划所需的连接信息。
   en_us: >-
-    MySQL storage, used to define the MySQL database instance configuration and connection details.
+    MySQL storage, used to define the MySQL instance, database, table, and connection metadata required for query planning.
 name: mysql
 versions:
 - name: v1.0.0
@@ -191,38 +191,117 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+          zh_cn: MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
           en_us: >-
-            The specification section containing MySQL configuration, including connection and query parameters.
+            The specification section for MySQL. UModel uses these fields to generate read-only SQL query plans only; it does
+            not connect to databases or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: MySQL 实例的访问地址（host:port）。
-              en_us: The endpoint address of the MySQL instance (host:port).
+              zh_cn: MySQL 实例访问地址，格式通常为 host:port。
+              en_us: The MySQL instance endpoint, usually in host:port format.
             type: string
             constraint:
               required: true
           database:
             description:
-              zh_cn: MySQL 数据库名称。
-              en_us: The name of the MySQL database.
+              zh_cn: 默认查询数据库名称。
+              en_us: The default database name to query.
             type: string
             constraint:
               required: true
           table:
             description:
-              zh_cn: MySQL 表名称。
-              en_us: The name of the MySQL table.
+              zh_cn: 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
+              en_us: >-
+                The default table name to query. It can be overridden by the DataSet or query parameters.
             type: string
-          sql:
+          sql_template:
             description:
-              zh_cn: SQL 查询语句，用于从 MySQL 中提取数据。
-              en_us: SQL query statement for extracting data from MySQL.
+              zh_cn: 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
+              en_us: >-
+                Optional SQL template for special query planning scenarios. The template must keep read-only semantics and
+                should not contain INSERT, UPDATE, DELETE, DDL, or similar statements.
             type: string
+          sql_dialect:
+            description:
+              zh_cn: SQL 方言。MySQL 存储默认使用 mysql。
+              en_us: SQL dialect. MySQL storage uses mysql by default.
+            type: string
+            constraint:
+              enum:
+                values:
+                - mysql
+                - ansi
+              default_value: mysql
+          time_field:
+            description:
+              zh_cn: 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+              en_us: Time field used to push request time ranges into SQL WHERE conditions.
+            type: string
+          time_unit:
+            description:
+              zh_cn: time_field 的时间单位。默认值为 second。
+              en_us: Time unit of time_field. Defaults to second.
+            type: string
+            constraint:
+              enum:
+                values:
+                - second
+                - millisecond
+                - microsecond
+                - nanosecond
+                - datetime
+              default_value: second
+          default_limit:
+            description:
+              zh_cn: 未显式指定 limit 时生成查询的默认 LIMIT。
+              en_us: Default SQL LIMIT when no explicit limit is provided.
+            type: integer
+            constraint:
+              default_value: 1000
+          max_limit:
+            description:
+              zh_cn: 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+              en_us: >-
+                Maximum SQL LIMIT allowed by the planner to avoid producing excessively large query plans.
+            type: integer
+            constraint:
+              default_value: 10000
+          read_only:
+            description:
+              zh_cn: 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+              en_us: >-
+                Indicates whether this storage should only plan read-only queries. Defaults to true; UModel PaaS query planning
+                should not generate write statements.
+            type: boolean
+            constraint:
+              default_value: true
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://mysql-prod-readonly. Plaintext usernames, passwords, or tokens
+                must not be stored in UModel.
+            type: string
+          tls_mode:
+            description:
+              zh_cn: MySQL TLS 模式。默认值为 preferred。
+              en_us: MySQL TLS mode. Defaults to preferred.
+            type: string
+            constraint:
+              enum:
+                values:
+                - disabled
+                - preferred
+                - required
+                - verify_ca
+                - verify_identity
+              default_value: preferred
           properties:
             description:
-              zh_cn: MySQL 的额外配置信息，以键值对形式存储。
-              en_us: Additional configuration of the MySQL instance, stored as key-value pairs.
+              zh_cn: MySQL 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive MySQL configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -232,8 +311,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 MySQL 存储的标签。
-              en_us: This field is used to represent the tags of the MySQL storage.
+              zh_cn: 用于标注该 MySQL 存储的标签。
+              en_us: Tags used to describe this MySQL storage.
             type: map
             constraint:
               map:

--- a/internal/umodel/schemaspec/data/prometheus.expanded.yaml
+++ b/internal/umodel/schemaspec/data/prometheus.expanded.yaml
@@ -1,7 +1,7 @@
 description:
-  zh_cn: Prometheus 存储，用于描述开源 Prometheus 实例的配置和连接信息。
+  zh_cn: Prometheus 存储，用于描述开源 Prometheus 或 Prometheus 兼容接口的配置和查询规划信息。
   en_us: >-
-    Prometheus storage, used to define the open-source Prometheus instance configuration and connection details.
+    Prometheus storage, used to define open-source Prometheus or Prometheus-compatible endpoint metadata for query planning.
 name: prometheus
 versions:
 - name: v1.0.0
@@ -191,21 +191,100 @@ versions:
         constraint:
           required: true
         description:
-          zh_cn: Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+          zh_cn: Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
           en_us: >-
-            The specification section containing Prometheus configuration, including connection and query parameters.
+            The specification section for Prometheus. UModel uses these fields to generate PromQL query plans only; it does
+            not execute queries or store plaintext credentials.
         properties:
           endpoint:
             description:
-              zh_cn: Prometheus 实例的访问地址（URL）。
-              en_us: The endpoint URL of the Prometheus instance.
+              zh_cn: Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
+              en_us: >-
+                The endpoint URL of Prometheus or a Prometheus-compatible service, for example http://prometheus:9090.
             type: string
             constraint:
               required: true
+          api_prefix:
+            description:
+              zh_cn: Prometheus HTTP API 前缀。默认值为 /api/v1。
+              en_us: Prometheus HTTP API prefix. Defaults to /api/v1.
+            type: string
+            constraint:
+              default_value: /api/v1
+          default_query_type:
+            description:
+              zh_cn: 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+              en_us: >-
+                Default PromQL query type. instant means instant query and range means range query.
+            type: string
+            constraint:
+              enum:
+                values:
+                - instant
+                - range
+              default_value: instant
+          default_step:
+            description:
+              zh_cn: 区间查询的默认 step，例如 60s、1m。
+              en_us: Default step for range queries, for example 60s or 1m.
+            type: string
+          lookback_delta:
+            description:
+              zh_cn: PromQL 查询规划使用的默认回看窗口，例如 5m。
+              en_us: Default PromQL lookback window used by query planning, for example 5m.
+            type: string
+          tenant:
+            description:
+              zh_cn: 可选租户标识，用于多租户 Prometheus 兼容系统。
+              en_us: Optional tenant identifier for multi-tenant Prometheus-compatible systems.
+            type: string
+          tenant_header:
+            description:
+              zh_cn: 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+              en_us: Tenant HTTP header name used by multi-tenant systems, for example X-Scope-OrgID.
+            type: string
+          credential_ref:
+            description:
+              zh_cn: 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+              en_us: >-
+                Credential reference, for example secret://prometheus-prod-readonly. Plaintext usernames, passwords, or tokens
+                must not be stored in UModel.
+            type: string
+          tls_verify:
+            description:
+              zh_cn: 是否校验 TLS 证书。默认值为 true。
+              en_us: Whether TLS certificates should be verified. Defaults to true.
+            type: boolean
+            constraint:
+              default_value: true
+          external_labels:
+            description:
+              zh_cn: Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+              en_us: >-
+                Prometheus external labels used to enrich query-planning context or describe result origin.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
+          headers:
+            description:
+              zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+              en_us: >-
+                Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+            type: map
+            constraint:
+              map:
+                key:
+                  type: string
+                value:
+                  type: string
           properties:
             description:
-              zh_cn: Prometheus 的额外配置信息，以键值对形式存储。
-              en_us: Additional configuration of the Prometheus instance, stored as key-value pairs.
+              zh_cn: Prometheus 的额外非敏感配置，以键值对形式存储。
+              en_us: Additional non-sensitive Prometheus configuration, stored as key-value pairs.
             type: map
             constraint:
               map:
@@ -215,8 +294,8 @@ versions:
                   type: string
           tags:
             description:
-              zh_cn: 用于表示该 Prometheus 存储的标签。
-              en_us: This field is used to represent the tags of the Prometheus storage.
+              zh_cn: 用于标注该 Prometheus 存储的标签。
+              en_us: Tags used to describe this Prometheus storage.
             type: map
             constraint:
               map:

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -353,21 +353,22 @@ func queryRowsAsMatrix(columns []string, rows []map[string]any) [][]any {
 }
 
 type QueryExplain struct {
-	Source           string   `json:"source"`
-	Provider         string   `json:"provider,omitempty"`
-	StorageProvider  string   `json:"storage_provider,omitempty"`
-	SearchProvider   string   `json:"search_provider,omitempty"`
-	EmbedModel       string   `json:"embed_model,omitempty"`
-	SearchMode       string   `json:"search_mode,omitempty"`
-	CypherDialect    string   `json:"cypher_dialect,omitempty"`
-	CypherEngine     string   `json:"cypher_engine,omitempty"`
-	Pushdown         []string `json:"pushdown,omitempty"`
-	Fallback         []string `json:"fallback,omitempty"`
-	Operators        []string `json:"operators,omitempty"`
-	Depth            int      `json:"depth,omitempty"`
-	Limit            int      `json:"limit,omitempty"`
-	TimeoutMS        int      `json:"timeout_ms,omitempty"`
-	TimeRangeApplied bool     `json:"time_range_applied"`
+	Source           string          `json:"source"`
+	Provider         string          `json:"provider,omitempty"`
+	StorageProvider  string          `json:"storage_provider,omitempty"`
+	SearchProvider   string          `json:"search_provider,omitempty"`
+	EmbedModel       string          `json:"embed_model,omitempty"`
+	SearchMode       string          `json:"search_mode,omitempty"`
+	CypherDialect    string          `json:"cypher_dialect,omitempty"`
+	CypherEngine     string          `json:"cypher_engine,omitempty"`
+	EntityCall       *EntityCallPlan `json:"entity_call,omitempty"`
+	Pushdown         []string        `json:"pushdown,omitempty"`
+	Fallback         []string        `json:"fallback,omitempty"`
+	Operators        []string        `json:"operators,omitempty"`
+	Depth            int             `json:"depth,omitempty"`
+	Limit            int             `json:"limit,omitempty"`
+	TimeoutMS        int             `json:"timeout_ms,omitempty"`
+	TimeRangeApplied bool            `json:"time_range_applied"`
 }
 
 type QueryPredicate struct {
@@ -398,6 +399,23 @@ type GraphCallPlan struct {
 	Cypher    string              `json:"cypher,omitempty"`
 }
 
+type EntityCallParam struct {
+	Key         string `json:"key,omitempty"`
+	Type        string `json:"type,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Default     any    `json:"default,omitempty"`
+}
+
+type EntityCallPlan struct {
+	Name           string            `json:"name,omitempty"`
+	Arguments      []any             `json:"arguments,omitempty"`
+	NamedArguments map[string]any    `json:"named_arguments,omitempty"`
+	Parameters     map[string]any    `json:"parameters,omitempty"`
+	Signature      []EntityCallParam `json:"signature,omitempty"`
+}
+
 type QueryPipelineOperator struct {
 	Name       string          `json:"name,omitempty"`
 	Expression string          `json:"expression,omitempty"`
@@ -405,6 +423,7 @@ type QueryPipelineOperator struct {
 	Project    []string        `json:"project,omitempty"`
 	Sort       *QuerySort      `json:"sort,omitempty"`
 	GraphCall  *GraphCallPlan  `json:"graph_call,omitempty"`
+	EntityCall *EntityCallPlan `json:"entity_call,omitempty"`
 	Limit      int             `json:"limit,omitempty"`
 }
 
@@ -419,6 +438,7 @@ type QueryPlan struct {
 	Project    []string
 	Sort       []QuerySort
 	GraphCall  *GraphCallPlan
+	EntityCall *EntityCallPlan
 	TopK       int
 	TimeRange  TimeRange
 	Params     map[string]any

--- a/schemas/README.en.md
+++ b/schemas/README.en.md
@@ -20,7 +20,7 @@ UModel schemas define the syntax and validation rules for model elements. They a
 - Entity: `entity_set`.
 - Datasets: `metric_set`, `log_set`, `trace_set`, `event_set`, `profile_set`, `runbook_set`.
 - Links: `data_link`, `entity_set_link`, `storage_link`, `runbook_link`, and related link kinds.
-- Storage: `sls_logstore`, `sls_metricstore`, `sls_entitystore`, `aliyun_prometheus`, `external_storage`.
+- Storage: `sls_logstore`, `sls_metricstore`, `sls_entitystore`, `aliyun_prometheus`, `prometheus`, `mysql`, `elasticsearch`, `external_storage`.
 
 ## Workflows
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -32,7 +32,10 @@ schemas/
         ├── sls_logstore.schema.yaml     # SLS日志存储定义
         ├── sls_metricstore.schema.yaml  # SLS指标存储定义
         ├── sls_entitystore.schema.yaml  # SLS实体存储定义
-        └── aliyun_prometheus.schema.yaml # 阿里云Prometheus存储定义
+        ├── aliyun_prometheus.schema.yaml # 阿里云Prometheus存储定义
+        ├── prometheus.schema.yaml        # 开源Prometheus存储定义
+        ├── mysql.schema.yaml             # MySQL存储定义
+        └── elasticsearch.schema.yaml     # Elasticsearch存储定义
 ```
 
 ## 🎯 核心概念
@@ -64,6 +67,9 @@ UModel Schema采用分层设计，包含以下几个层次：
 - **SLS MetricStore**: 阿里云SLS指标存储
 - **SLS EntityStore**: 阿里云SLS实体存储
 - **Aliyun Prometheus**: 阿里云Prometheus存储
+- **Prometheus**: 开源 Prometheus 或 Prometheus 兼容存储
+- **MySQL**: MySQL 数据库存储
+- **Elasticsearch**: Elasticsearch 索引存储
 
 ## 🔧 Schema语法特性
 
@@ -151,6 +157,5 @@ models:
 
 > 💡 **提示**: 如需了解具体模型的详细定义，请查看对应的`.schema.yaml`文件。每个文件都包含完整的字段定义、约束条件和使用示例。
 > 💡 **提示**: 完整展开后的模型定义在 `expanded_schemas` 目录。
-
 
 

--- a/schemas/core/storage/elasticsearch.schema.yaml
+++ b/schemas/core/storage/elasticsearch.schema.yaml
@@ -1,6 +1,6 @@
 description:
-  zh_cn: ElasticSearch 存储，用于描述 ElasticSearch 实例的配置和连接信息。
-  en_us: ElasticSearch storage, used to define the ElasticSearch instance configuration and connection details.
+  zh_cn: Elasticsearch 存储，用于描述 Elasticsearch 集群、索引以及查询规划所需的连接信息。
+  en_us: Elasticsearch storage, used to define the Elasticsearch cluster, index, and connection metadata required for query planning.
 name: elasticsearch
 versions:
   - name: v1.0.0
@@ -31,32 +31,96 @@ versions:
           constraint:
             required: true
           description:
-            zh_cn: ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
-            en_us: The specification section containing ElasticSearch configuration, including connection and index parameters.
+            zh_cn: Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
+            en_us: The specification section for Elasticsearch. UModel uses these fields to generate Elasticsearch query plans only; it does not execute queries or store plaintext credentials.
           properties:
             endpoint:
               description:
-                zh_cn: ElasticSearch 实例的访问地址（URL）。
-                en_us: The endpoint URL of the ElasticSearch instance.
+                zh_cn: Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
+                en_us: The Elasticsearch cluster endpoint, for example https://es.example.com:9200.
               type: string
               constraint:
                 required: true
             index:
               description:
-                zh_cn: ElasticSearch 索引名称。
-                en_us: The name of the ElasticSearch index.
+                zh_cn: 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
+                en_us: The default index name to query. It may also be an Elasticsearch-supported index wildcard expression.
               type: string
               constraint:
                 required: true
+            index_pattern:
+              description:
+                zh_cn: 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+                en_us: Index pattern for time-rolled indices, for example logs-${yyyy.MM.dd}. When empty, query planning uses the index field.
+              type: string
             version:
               description:
-                zh_cn: ElasticSearch 的版本号（如 7.x、8.x）。
-                en_us: The version of the ElasticSearch instance (e.g. 7.x, 8.x).
+                zh_cn: Elasticsearch 版本号或版本族，例如 7.x、8.x。
+                en_us: The Elasticsearch version or version family, for example 7.x or 8.x.
               type: string
+            query_dialect:
+              description:
+                zh_cn: 查询生成方言。默认生成 Elasticsearch Query DSL。
+                en_us: Query generation dialect. Elasticsearch Query DSL is used by default.
+              type: string
+              constraint:
+                enum:
+                  values:
+                    - elasticsearch_dsl
+                    - lucene
+                    - eql
+                default_value: elasticsearch_dsl
+            time_field:
+              description:
+                zh_cn: 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+                en_us: Time field used to push request time ranges into Elasticsearch queries.
+              type: string
+            default_size:
+              description:
+                zh_cn: 未显式指定 limit 时生成查询的默认 size。
+                en_us: Default query size when no explicit limit is provided.
+              type: integer
+              constraint:
+                default_value: 1000
+            max_size:
+              description:
+                zh_cn: 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+                en_us: Maximum query size allowed by the planner to avoid producing excessively large query plans.
+              type: integer
+              constraint:
+                default_value: 10000
+            routing:
+              description:
+                zh_cn: 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+                en_us: Optional Elasticsearch routing value for queries that should target a fixed routing key.
+              type: string
+            credential_ref:
+              description:
+                zh_cn: 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+                en_us: Credential reference, for example secret://es-prod-readonly. Plaintext usernames, passwords, or tokens must not be stored in UModel.
+              type: string
+            tls_verify:
+              description:
+                zh_cn: 是否校验 TLS 证书。默认值为 true。
+                en_us: Whether TLS certificates should be verified. Defaults to true.
+              type: boolean
+              constraint:
+                default_value: true
+            headers:
+              description:
+                zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+                en_us: Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+              type: map
+              constraint:
+                map:
+                  key:
+                    type: string
+                  value:
+                    type: string
             properties:
               description:
-                zh_cn: ElasticSearch 的额外配置信息，以键值对形式存储。
-                en_us: Additional configuration of the ElasticSearch instance, stored as key-value pairs.
+                zh_cn: Elasticsearch 的额外非敏感配置，以键值对形式存储。
+                en_us: Additional non-sensitive Elasticsearch configuration, stored as key-value pairs.
               type: map
               constraint:
                 map:
@@ -66,8 +130,8 @@ versions:
                     type: string
             tags:
               description:
-                zh_cn: 用于表示该 ElasticSearch 存储的标签。
-                en_us: This field is used to represent the tags of the ElasticSearch storage.
+                zh_cn: 用于标注该 Elasticsearch 存储的标签。
+                en_us: Tags used to describe this Elasticsearch storage.
               type: map
               constraint:
                 map:

--- a/schemas/core/storage/mysql.schema.yaml
+++ b/schemas/core/storage/mysql.schema.yaml
@@ -1,6 +1,6 @@
 description:
-  zh_cn: MySQL 存储，用于描述 MySQL 数据库实例的配置和连接信息。
-  en_us: MySQL storage, used to define the MySQL database instance configuration and connection details.
+  zh_cn: MySQL 存储，用于描述 MySQL 实例、数据库、表以及查询规划所需的连接信息。
+  en_us: MySQL storage, used to define the MySQL instance, database, table, and connection metadata required for query planning.
 name: mysql
 versions:
   - name: v1.0.0
@@ -31,37 +31,107 @@ versions:
           constraint:
             required: true
           description:
-            zh_cn: MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
-            en_us: The specification section containing MySQL configuration, including connection and query parameters.
+            zh_cn: MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
+            en_us: The specification section for MySQL. UModel uses these fields to generate read-only SQL query plans only; it does not connect to databases or store plaintext credentials.
           properties:
             endpoint:
               description:
-                zh_cn: MySQL 实例的访问地址（host:port）。
-                en_us: The endpoint address of the MySQL instance (host:port).
+                zh_cn: MySQL 实例访问地址，格式通常为 host:port。
+                en_us: The MySQL instance endpoint, usually in host:port format.
               type: string
               constraint:
                 required: true
             database:
               description:
-                zh_cn: MySQL 数据库名称。
-                en_us: The name of the MySQL database.
+                zh_cn: 默认查询数据库名称。
+                en_us: The default database name to query.
               type: string
               constraint:
                 required: true
             table:
               description:
-                zh_cn: MySQL 表名称。
-                en_us: The name of the MySQL table.
+                zh_cn: 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
+                en_us: The default table name to query. It can be overridden by the DataSet or query parameters.
               type: string
-            sql:
+            sql_template:
               description:
-                zh_cn: SQL 查询语句，用于从 MySQL 中提取数据。
-                en_us: SQL query statement for extracting data from MySQL.
+                zh_cn: 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
+                en_us: Optional SQL template for special query planning scenarios. The template must keep read-only semantics and should not contain INSERT, UPDATE, DELETE, DDL, or similar statements.
               type: string
+            sql_dialect:
+              description:
+                zh_cn: SQL 方言。MySQL 存储默认使用 mysql。
+                en_us: SQL dialect. MySQL storage uses mysql by default.
+              type: string
+              constraint:
+                enum:
+                  values:
+                    - mysql
+                    - ansi
+                default_value: mysql
+            time_field:
+              description:
+                zh_cn: 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+                en_us: Time field used to push request time ranges into SQL WHERE conditions.
+              type: string
+            time_unit:
+              description:
+                zh_cn: time_field 的时间单位。默认值为 second。
+                en_us: Time unit of time_field. Defaults to second.
+              type: string
+              constraint:
+                enum:
+                  values:
+                    - second
+                    - millisecond
+                    - microsecond
+                    - nanosecond
+                    - datetime
+                default_value: second
+            default_limit:
+              description:
+                zh_cn: 未显式指定 limit 时生成查询的默认 LIMIT。
+                en_us: Default SQL LIMIT when no explicit limit is provided.
+              type: integer
+              constraint:
+                default_value: 1000
+            max_limit:
+              description:
+                zh_cn: 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+                en_us: Maximum SQL LIMIT allowed by the planner to avoid producing excessively large query plans.
+              type: integer
+              constraint:
+                default_value: 10000
+            read_only:
+              description:
+                zh_cn: 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+                en_us: Indicates whether this storage should only plan read-only queries. Defaults to true; UModel PaaS query planning should not generate write statements.
+              type: boolean
+              constraint:
+                default_value: true
+            credential_ref:
+              description:
+                zh_cn: 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+                en_us: Credential reference, for example secret://mysql-prod-readonly. Plaintext usernames, passwords, or tokens must not be stored in UModel.
+              type: string
+            tls_mode:
+              description:
+                zh_cn: MySQL TLS 模式。默认值为 preferred。
+                en_us: MySQL TLS mode. Defaults to preferred.
+              type: string
+              constraint:
+                enum:
+                  values:
+                    - disabled
+                    - preferred
+                    - required
+                    - verify_ca
+                    - verify_identity
+                default_value: preferred
             properties:
               description:
-                zh_cn: MySQL 的额外配置信息，以键值对形式存储。
-                en_us: Additional configuration of the MySQL instance, stored as key-value pairs.
+                zh_cn: MySQL 的额外非敏感配置，以键值对形式存储。
+                en_us: Additional non-sensitive MySQL configuration, stored as key-value pairs.
               type: map
               constraint:
                 map:
@@ -71,8 +141,8 @@ versions:
                     type: string
             tags:
               description:
-                zh_cn: 用于表示该 MySQL 存储的标签。
-                en_us: This field is used to represent the tags of the MySQL storage.
+                zh_cn: 用于标注该 MySQL 存储的标签。
+                en_us: Tags used to describe this MySQL storage.
               type: map
               constraint:
                 map:

--- a/schemas/core/storage/prometheus.schema.yaml
+++ b/schemas/core/storage/prometheus.schema.yaml
@@ -1,6 +1,6 @@
 description:
-  zh_cn: Prometheus 存储，用于描述开源 Prometheus 实例的配置和连接信息。
-  en_us: Prometheus storage, used to define the open-source Prometheus instance configuration and connection details.
+  zh_cn: Prometheus 存储，用于描述开源 Prometheus 或 Prometheus 兼容接口的配置和查询规划信息。
+  en_us: Prometheus storage, used to define open-source Prometheus or Prometheus-compatible endpoint metadata for query planning.
 name: prometheus
 versions:
   - name: v1.0.0
@@ -31,20 +31,92 @@ versions:
           constraint:
             required: true
           description:
-            zh_cn: Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
-            en_us: The specification section containing Prometheus configuration, including connection and query parameters.
+            zh_cn: Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
+            en_us: The specification section for Prometheus. UModel uses these fields to generate PromQL query plans only; it does not execute queries or store plaintext credentials.
           properties:
             endpoint:
               description:
-                zh_cn: Prometheus 实例的访问地址（URL）。
-                en_us: The endpoint URL of the Prometheus instance.
+                zh_cn: Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
+                en_us: The endpoint URL of Prometheus or a Prometheus-compatible service, for example http://prometheus:9090.
               type: string
               constraint:
                 required: true
+            api_prefix:
+              description:
+                zh_cn: Prometheus HTTP API 前缀。默认值为 /api/v1。
+                en_us: Prometheus HTTP API prefix. Defaults to /api/v1.
+              type: string
+              constraint:
+                default_value: /api/v1
+            default_query_type:
+              description:
+                zh_cn: 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+                en_us: Default PromQL query type. instant means instant query and range means range query.
+              type: string
+              constraint:
+                enum:
+                  values:
+                    - instant
+                    - range
+                default_value: instant
+            default_step:
+              description:
+                zh_cn: 区间查询的默认 step，例如 60s、1m。
+                en_us: Default step for range queries, for example 60s or 1m.
+              type: string
+            lookback_delta:
+              description:
+                zh_cn: PromQL 查询规划使用的默认回看窗口，例如 5m。
+                en_us: Default PromQL lookback window used by query planning, for example 5m.
+              type: string
+            tenant:
+              description:
+                zh_cn: 可选租户标识，用于多租户 Prometheus 兼容系统。
+                en_us: Optional tenant identifier for multi-tenant Prometheus-compatible systems.
+              type: string
+            tenant_header:
+              description:
+                zh_cn: 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+                en_us: Tenant HTTP header name used by multi-tenant systems, for example X-Scope-OrgID.
+              type: string
+            credential_ref:
+              description:
+                zh_cn: 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+                en_us: Credential reference, for example secret://prometheus-prod-readonly. Plaintext usernames, passwords, or tokens must not be stored in UModel.
+              type: string
+            tls_verify:
+              description:
+                zh_cn: 是否校验 TLS 证书。默认值为 true。
+                en_us: Whether TLS certificates should be verified. Defaults to true.
+              type: boolean
+              constraint:
+                default_value: true
+            external_labels:
+              description:
+                zh_cn: Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+                en_us: Prometheus external labels used to enrich query-planning context or describe result origin.
+              type: map
+              constraint:
+                map:
+                  key:
+                    type: string
+                  value:
+                    type: string
+            headers:
+              description:
+                zh_cn: 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+                en_us: Non-sensitive HTTP headers for tenant or routing context. Authentication secrets must not be stored here.
+              type: map
+              constraint:
+                map:
+                  key:
+                    type: string
+                  value:
+                    type: string
             properties:
               description:
-                zh_cn: Prometheus 的额外配置信息，以键值对形式存储。
-                en_us: Additional configuration of the Prometheus instance, stored as key-value pairs.
+                zh_cn: Prometheus 的额外非敏感配置，以键值对形式存储。
+                en_us: Additional non-sensitive Prometheus configuration, stored as key-value pairs.
               type: map
               constraint:
                 map:
@@ -54,8 +126,8 @@ versions:
                     type: string
             tags:
               description:
-                zh_cn: 用于表示该 Prometheus 存储的标签。
-                en_us: This field is used to represent the tags of the Prometheus storage.
+                zh_cn: 用于标注该 Prometheus 存储的标签。
+                en_us: Tags used to describe this Prometheus storage.
               type: map
               constraint:
                 map:

--- a/sdk/go/umodel/elasticsearch.go
+++ b/sdk/go/umodel/elasticsearch.go
@@ -12,7 +12,7 @@ type ElasticsearchV100 struct {
 	Kind     string      `json:"kind" yaml:"kind"`
 	Schema   *SchemaV1   `json:"schema" yaml:"schema"`
 	Metadata *MetadataV1 `json:"metadata" yaml:"metadata"`
-	// Spec ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+	// Spec Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
 	Spec *ElasticsearchV100Spec `json:"spec" yaml:"spec"`
 }
 
@@ -43,17 +43,35 @@ func (s *ElasticsearchV100) GetMetadata() *MetadataV1 {
 	return s.Metadata
 }
 
-// ElasticsearchV100Spec ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+// ElasticsearchV100Spec Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
 type ElasticsearchV100Spec struct {
-	// Endpoint ElasticSearch 实例的访问地址（URL）。
+	// Endpoint Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
 	Endpoint string `json:"endpoint" yaml:"endpoint"`
-	// Index ElasticSearch 索引名称。
+	// Index 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
 	Index string `json:"index" yaml:"index"`
-	// Version ElasticSearch 的版本号（如 7.x、8.x）。
+	// IndexPattern 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+	IndexPattern string `json:"index_pattern,omitempty" yaml:"index_pattern,omitempty"`
+	// Version Elasticsearch 版本号或版本族，例如 7.x、8.x。
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
-	// Properties ElasticSearch 的额外配置信息，以键值对形式存储。
+	// QueryDialect 查询生成方言。默认生成 Elasticsearch Query DSL。
+	QueryDialect string `json:"query_dialect,omitempty" yaml:"query_dialect,omitempty"`
+	// TimeField 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+	TimeField string `json:"time_field,omitempty" yaml:"time_field,omitempty"`
+	// DefaultSize 未显式指定 limit 时生成查询的默认 size。
+	DefaultSize int64 `json:"default_size,omitempty" yaml:"default_size,omitempty"`
+	// MaxSize 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+	MaxSize int64 `json:"max_size,omitempty" yaml:"max_size,omitempty"`
+	// Routing 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+	Routing string `json:"routing,omitempty" yaml:"routing,omitempty"`
+	// CredentialRef 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+	CredentialRef string `json:"credential_ref,omitempty" yaml:"credential_ref,omitempty"`
+	// TlsVerify 是否校验 TLS 证书。默认值为 true。
+	TlsVerify bool `json:"tls_verify,omitempty" yaml:"tls_verify,omitempty"`
+	// Headers 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	// Properties Elasticsearch 的额外非敏感配置，以键值对形式存储。
 	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
-	// Tags 用于表示该 ElasticSearch 存储的标签。
+	// Tags 用于标注该 Elasticsearch 存储的标签。
 	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 

--- a/sdk/go/umodel/mysql.go
+++ b/sdk/go/umodel/mysql.go
@@ -12,7 +12,7 @@ type MysqlV100 struct {
 	Kind     string      `json:"kind" yaml:"kind"`
 	Schema   *SchemaV1   `json:"schema" yaml:"schema"`
 	Metadata *MetadataV1 `json:"metadata" yaml:"metadata"`
-	// Spec MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+	// Spec MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
 	Spec *MysqlV100Spec `json:"spec" yaml:"spec"`
 }
 
@@ -43,19 +43,35 @@ func (s *MysqlV100) GetMetadata() *MetadataV1 {
 	return s.Metadata
 }
 
-// MysqlV100Spec MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+// MysqlV100Spec MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
 type MysqlV100Spec struct {
-	// Endpoint MySQL 实例的访问地址（host:port）。
+	// Endpoint MySQL 实例访问地址，格式通常为 host:port。
 	Endpoint string `json:"endpoint" yaml:"endpoint"`
-	// Database MySQL 数据库名称。
+	// Database 默认查询数据库名称。
 	Database string `json:"database" yaml:"database"`
-	// Table MySQL 表名称。
+	// Table 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
 	Table string `json:"table,omitempty" yaml:"table,omitempty"`
-	// Sql SQL 查询语句，用于从 MySQL 中提取数据。
-	Sql string `json:"sql,omitempty" yaml:"sql,omitempty"`
-	// Properties MySQL 的额外配置信息，以键值对形式存储。
+	// SqlTemplate 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
+	SqlTemplate string `json:"sql_template,omitempty" yaml:"sql_template,omitempty"`
+	// SqlDialect SQL 方言。MySQL 存储默认使用 mysql。
+	SqlDialect string `json:"sql_dialect,omitempty" yaml:"sql_dialect,omitempty"`
+	// TimeField 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+	TimeField string `json:"time_field,omitempty" yaml:"time_field,omitempty"`
+	// TimeUnit time_field 的时间单位。默认值为 second。
+	TimeUnit string `json:"time_unit,omitempty" yaml:"time_unit,omitempty"`
+	// DefaultLimit 未显式指定 limit 时生成查询的默认 LIMIT。
+	DefaultLimit int64 `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
+	// MaxLimit 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+	MaxLimit int64 `json:"max_limit,omitempty" yaml:"max_limit,omitempty"`
+	// ReadOnly 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+	ReadOnly bool `json:"read_only,omitempty" yaml:"read_only,omitempty"`
+	// CredentialRef 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+	CredentialRef string `json:"credential_ref,omitempty" yaml:"credential_ref,omitempty"`
+	// TlsMode MySQL TLS 模式。默认值为 preferred。
+	TlsMode string `json:"tls_mode,omitempty" yaml:"tls_mode,omitempty"`
+	// Properties MySQL 的额外非敏感配置，以键值对形式存储。
 	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
-	// Tags 用于表示该 MySQL 存储的标签。
+	// Tags 用于标注该 MySQL 存储的标签。
 	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 

--- a/sdk/go/umodel/prometheus.go
+++ b/sdk/go/umodel/prometheus.go
@@ -12,7 +12,7 @@ type PrometheusV100 struct {
 	Kind     string      `json:"kind" yaml:"kind"`
 	Schema   *SchemaV1   `json:"schema" yaml:"schema"`
 	Metadata *MetadataV1 `json:"metadata" yaml:"metadata"`
-	// Spec Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+	// Spec Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
 	Spec *PrometheusV100Spec `json:"spec" yaml:"spec"`
 }
 
@@ -43,13 +43,33 @@ func (s *PrometheusV100) GetMetadata() *MetadataV1 {
 	return s.Metadata
 }
 
-// PrometheusV100Spec Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+// PrometheusV100Spec Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
 type PrometheusV100Spec struct {
-	// Endpoint Prometheus 实例的访问地址（URL）。
+	// Endpoint Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
 	Endpoint string `json:"endpoint" yaml:"endpoint"`
-	// Properties Prometheus 的额外配置信息，以键值对形式存储。
+	// ApiPrefix Prometheus HTTP API 前缀。默认值为 /api/v1。
+	ApiPrefix string `json:"api_prefix,omitempty" yaml:"api_prefix,omitempty"`
+	// DefaultQueryType 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+	DefaultQueryType string `json:"default_query_type,omitempty" yaml:"default_query_type,omitempty"`
+	// DefaultStep 区间查询的默认 step，例如 60s、1m。
+	DefaultStep string `json:"default_step,omitempty" yaml:"default_step,omitempty"`
+	// LookbackDelta PromQL 查询规划使用的默认回看窗口，例如 5m。
+	LookbackDelta string `json:"lookback_delta,omitempty" yaml:"lookback_delta,omitempty"`
+	// Tenant 可选租户标识，用于多租户 Prometheus 兼容系统。
+	Tenant string `json:"tenant,omitempty" yaml:"tenant,omitempty"`
+	// TenantHeader 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+	TenantHeader string `json:"tenant_header,omitempty" yaml:"tenant_header,omitempty"`
+	// CredentialRef 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+	CredentialRef string `json:"credential_ref,omitempty" yaml:"credential_ref,omitempty"`
+	// TlsVerify 是否校验 TLS 证书。默认值为 true。
+	TlsVerify bool `json:"tls_verify,omitempty" yaml:"tls_verify,omitempty"`
+	// ExternalLabels Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+	ExternalLabels map[string]string `json:"external_labels,omitempty" yaml:"external_labels,omitempty"`
+	// Headers 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	// Properties Prometheus 的额外非敏感配置，以键值对形式存储。
 	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
-	// Tags 用于表示该 Prometheus 存储的标签。
+	// Tags 用于标注该 Prometheus 存储的标签。
 	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 

--- a/sdk/python/umodel/elasticsearch.py
+++ b/sdk/python/umodel/elasticsearch.py
@@ -26,7 +26,7 @@ class ElasticsearchV100(UModelCoreObject):
     kind: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
     metadata: Optional[Dict[str, Any]] = None
-    # ElasticSearch 的核心配置部分，定义实例的连接和索引参数。
+    # Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。
     spec: Optional['ElasticsearchV100Spec'] = None
 
     def get_kind(self) -> str:
@@ -40,14 +40,32 @@ class ElasticsearchV100(UModelCoreObject):
 
 @dataclass
 class ElasticsearchV100Spec:
-    """ElasticSearch 的核心配置部分，定义实例的连接和索引参数。"""
-    # ElasticSearch 实例的访问地址（URL）。
+    """Elasticsearch 的核心配置部分。UModel 只使用这些字段生成 Elasticsearch 查询计划，不直接执行查询，也不保存明文凭据。"""
+    # Elasticsearch 集群访问地址，例如 https://es.example.com:9200。
     endpoint: Optional[str] = None
-    # ElasticSearch 索引名称。
+    # 默认查询索引名称，也可以是 Elasticsearch 支持的索引通配表达式。
     index: Optional[str] = None
-    # ElasticSearch 的版本号（如 7.x、8.x）。
+    # 面向按时间滚动索引的索引模式，例如 logs-${yyyy.MM.dd}。如果为空，查询规划使用 index 字段。
+    index_pattern: Optional[str] = None
+    # Elasticsearch 版本号或版本族，例如 7.x、8.x。
     version: Optional[str] = None
-    # ElasticSearch 的额外配置信息，以键值对形式存储。
+    # 查询生成方言。默认生成 Elasticsearch Query DSL。
+    query_dialect: Optional[str] = None
+    # 时间过滤字段名，用于将请求时间范围下推到 Elasticsearch 查询中。
+    time_field: Optional[str] = None
+    # 未显式指定 limit 时生成查询的默认 size。
+    default_size: Optional[int] = None
+    # 查询规划允许生成的最大 size，用于避免生成过大的查询计划。
+    max_size: Optional[int] = None
+    # 可选的 Elasticsearch routing 值。用于规划需要固定 routing 的查询。
+    routing: Optional[str] = None
+    # 凭据引用标识，例如 secret://es-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+    credential_ref: Optional[str] = None
+    # 是否校验 TLS 证书。默认值为 true。
+    tls_verify: Optional[bool] = None
+    # 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+    headers: Optional[Dict[str, str]] = None
+    # Elasticsearch 的额外非敏感配置，以键值对形式存储。
     properties: Optional[Dict[str, str]] = None
-    # 用于表示该 ElasticSearch 存储的标签。
+    # 用于标注该 Elasticsearch 存储的标签。
     tags: Optional[Dict[str, str]] = None

--- a/sdk/python/umodel/mysql.py
+++ b/sdk/python/umodel/mysql.py
@@ -26,7 +26,7 @@ class MysqlV100(UModelCoreObject):
     kind: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
     metadata: Optional[Dict[str, Any]] = None
-    # MySQL 的核心配置部分，定义数据库实例的连接和查询参数。
+    # MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。
     spec: Optional['MysqlV100Spec'] = None
 
     def get_kind(self) -> str:
@@ -40,16 +40,32 @@ class MysqlV100(UModelCoreObject):
 
 @dataclass
 class MysqlV100Spec:
-    """MySQL 的核心配置部分，定义数据库实例的连接和查询参数。"""
-    # MySQL 实例的访问地址（host:port）。
+    """MySQL 的核心配置部分。UModel 只使用这些字段生成只读 SQL 查询计划，不直接连接数据库，也不保存明文凭据。"""
+    # MySQL 实例访问地址，格式通常为 host:port。
     endpoint: Optional[str] = None
-    # MySQL 数据库名称。
+    # 默认查询数据库名称。
     database: Optional[str] = None
-    # MySQL 表名称。
+    # 默认查询表名。若 DataSet 或查询参数中指定表名，可覆盖此字段。
     table: Optional[str] = None
-    # SQL 查询语句，用于从 MySQL 中提取数据。
-    sql: Optional[str] = None
-    # MySQL 的额外配置信息，以键值对形式存储。
+    # 可选 SQL 模板，用于特殊查询规划场景。模板必须保持只读语义，不应包含 INSERT、UPDATE、DELETE、DDL 等语句。
+    sql_template: Optional[str] = None
+    # SQL 方言。MySQL 存储默认使用 mysql。
+    sql_dialect: Optional[str] = None
+    # 时间过滤字段名，用于将请求时间范围下推到 SQL WHERE 条件中。
+    time_field: Optional[str] = None
+    # time_field 的时间单位。默认值为 second。
+    time_unit: Optional[str] = None
+    # 未显式指定 limit 时生成查询的默认 LIMIT。
+    default_limit: Optional[int] = None
+    # 查询规划允许生成的最大 LIMIT，用于避免生成过大的查询计划。
+    max_limit: Optional[int] = None
+    # 标识该存储是否只能规划只读查询。默认值为 true；UModel PaaS 查询规划不应生成写入语句。
+    read_only: Optional[bool] = None
+    # 凭据引用标识，例如 secret://mysql-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+    credential_ref: Optional[str] = None
+    # MySQL TLS 模式。默认值为 preferred。
+    tls_mode: Optional[str] = None
+    # MySQL 的额外非敏感配置，以键值对形式存储。
     properties: Optional[Dict[str, str]] = None
-    # 用于表示该 MySQL 存储的标签。
+    # 用于标注该 MySQL 存储的标签。
     tags: Optional[Dict[str, str]] = None

--- a/sdk/python/umodel/prometheus.py
+++ b/sdk/python/umodel/prometheus.py
@@ -26,7 +26,7 @@ class PrometheusV100(UModelCoreObject):
     kind: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
     metadata: Optional[Dict[str, Any]] = None
-    # Prometheus 的核心配置部分，定义监控实例的连接和查询参数。
+    # Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。
     spec: Optional['PrometheusV100Spec'] = None
 
     def get_kind(self) -> str:
@@ -40,10 +40,30 @@ class PrometheusV100(UModelCoreObject):
 
 @dataclass
 class PrometheusV100Spec:
-    """Prometheus 的核心配置部分，定义监控实例的连接和查询参数。"""
-    # Prometheus 实例的访问地址（URL）。
+    """Prometheus 的核心配置部分。UModel 只使用这些字段生成 PromQL 查询计划，不直接执行查询，也不保存明文凭据。"""
+    # Prometheus 或 Prometheus 兼容服务的访问地址，例如 http://prometheus:9090。
     endpoint: Optional[str] = None
-    # Prometheus 的额外配置信息，以键值对形式存储。
+    # Prometheus HTTP API 前缀。默认值为 /api/v1。
+    api_prefix: Optional[str] = None
+    # 默认 PromQL 查询类型。instant 表示即时查询，range 表示区间查询。
+    default_query_type: Optional[str] = None
+    # 区间查询的默认 step，例如 60s、1m。
+    default_step: Optional[str] = None
+    # PromQL 查询规划使用的默认回看窗口，例如 5m。
+    lookback_delta: Optional[str] = None
+    # 可选租户标识，用于多租户 Prometheus 兼容系统。
+    tenant: Optional[str] = None
+    # 多租户系统使用的租户 HTTP 头名称，例如 X-Scope-OrgID。
+    tenant_header: Optional[str] = None
+    # 凭据引用标识，例如 secret://prometheus-prod-readonly。不得在 UModel 中保存明文用户名、密码或 Token。
+    credential_ref: Optional[str] = None
+    # 是否校验 TLS 证书。默认值为 true。
+    tls_verify: Optional[bool] = None
+    # Prometheus 外部标签，用于 query planning 时补充查询上下文或结果来源说明。
+    external_labels: Optional[Dict[str, str]] = None
+    # 非敏感 HTTP 头，用于租户、路由等查询上下文。不得存放认证密钥。
+    headers: Optional[Dict[str, str]] = None
+    # Prometheus 的额外非敏感配置，以键值对形式存储。
     properties: Optional[Dict[str, str]] = None
-    # 用于表示该 Prometheus 存储的标签。
+    # 用于标注该 Prometheus 存储的标签。
     tags: Optional[Dict[str, str]] = None

--- a/web/src/features/query/QueryPage.tsx
+++ b/web/src/features/query/QueryPage.tsx
@@ -58,6 +58,14 @@ const examples = [
     query:
       ".topo | graph-call cypher(`MATCH (src:``devops@devops.service`` {__entity_id__: '10000000000000000000000000000101'})-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`) | limit 20",
   },
+  {
+    labelKey: 'query.examples.entitySetMethods',
+    query: ".entity_set with(domain='devops', name='devops.service') | entity-call __list_method__()",
+  },
+  {
+    labelKey: 'query.examples.entitySetDatasets',
+    query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
+  },
 ] as const satisfies ReadonlyArray<{ labelKey: MessageKey; query: string }>
 
 export function QueryPage({ api, workspaceId }: { api: UModelApi; workspaceId: string }) {

--- a/web/src/i18n/locales/en-US/query.ts
+++ b/web/src/i18n/locales/en-US/query.ts
@@ -23,6 +23,8 @@ export const enUSQuery = {
   'query.examples.cypher': 'Cypher',
   'query.examples.direct': 'Direct',
   'query.examples.entity': '.entity',
+  'query.examples.entitySetDatasets': 'EntitySet DataSets',
+  'query.examples.entitySetMethods': 'EntitySet Methods',
   'query.examples.neighbors': 'Neighbors',
   'query.examples.title': 'Examples',
   'query.examples.topo': '.topo',

--- a/web/src/i18n/locales/en-US/query.ts
+++ b/web/src/i18n/locales/en-US/query.ts
@@ -23,7 +23,7 @@ export const enUSQuery = {
   'query.examples.cypher': 'Cypher',
   'query.examples.direct': 'Direct',
   'query.examples.entity': '.entity',
-  'query.examples.entitySetDatasets': 'EntitySet DataSets',
+'query.examples.entitySetDatasets': 'EntitySet Datasets',
   'query.examples.entitySetMethods': 'EntitySet Methods',
   'query.examples.neighbors': 'Neighbors',
   'query.examples.title': 'Examples',

--- a/web/src/i18n/locales/zh-CN/query.ts
+++ b/web/src/i18n/locales/zh-CN/query.ts
@@ -25,6 +25,8 @@ export const zhCNQuery = {
   'query.examples.cypher': 'Cypher',
   'query.examples.direct': 'direct',
   'query.examples.entity': '.entity',
+  'query.examples.entitySetDatasets': 'EntitySet 数据集',
+  'query.examples.entitySetMethods': 'EntitySet 方法',
   'query.examples.neighbors': 'neighbors',
   'query.examples.title': '示例',
   'query.examples.topo': '.topo',


### PR DESCRIPTION
## What changed

- Added complete core storage schemas for Elasticsearch, MySQL, and Prometheus, including generated SDK and expanded schema outputs.
- Implemented `.entity_set ... | entity-call __list_method__()` and `list_data_set(...)` query support with UModel Assistant-compatible response shape.
- Enriched the quickstart demo with real MetricSet, LogSet, EventSet, DataLink, StorageLink, and Storage definitions across Prometheus, Elasticsearch, and MySQL.
- Updated Web UI examples, MCP/query docs, and service/query tests for the supported EntitySet methods.

## Notes

- This PR intentionally supports only `__list_method__` and `list_data_set` / `list_dataset`.
- `get_metric` and `get_log` remain unsupported in this iteration and return query plan errors.

## Validation

- `go test ./internal/sampledata`
- `go test ./internal/query`
- `npm run build`
- `make guard`
- `make test-service`
- `git diff --check`
