### PR TITLE
Fix local.ladybug workspace metadata recovery

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -64,10 +64,15 @@ func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig) (*A
 	if config.DataRoot == "" {
 		config.DataRoot = dataRoot
 	}
+	providerType := config.Type
+	if providerType == "" {
+		providerType = graphstore.DefaultProviderType
+		config.Type = providerType
+	}
 	workspaceSvc := workspace.NewService(dataRoot, nil)
-	if config.Type == graphstore.ProviderTypeFileMemory {
+	if providerType == graphstore.ProviderTypeFileMemory || providerType == graphstore.ProviderTypeLadybug {
 		var err error
-		workspaceSvc, err = workspace.NewPersistentService(dataRoot, nil)
+		workspaceSvc, err = workspace.NewPersistentServiceForProvider(dataRoot, nil, providerType)
 		if err != nil {
 			return nil, fmt.Errorf("create workspace metadata store: %w", err)
 		}

--- a/internal/bootstrap/workspace_persistence_test.go
+++ b/internal/bootstrap/workspace_persistence_test.go
@@ -2,8 +2,11 @@ package bootstrap
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
 	"github.com/alibaba/UnifiedModel/pkg/model"
 )
 
@@ -23,5 +26,50 @@ func TestFileMemoryAppPersistsWorkspaceMetadata(t *testing.T) {
 	}
 	if len(page.Items) != 1 || page.Items[0].ID != "demo" || page.Items[0].Name != "Demo" {
 		t.Fatalf("expected persisted demo workspace, got %+v", page.Items)
+	}
+}
+
+func TestLadybugAppPersistsWorkspaceMetadata(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	first, err := NewAppWithGraphStore(root, graphstore.ProviderConfig{Type: graphstore.ProviderTypeLadybug, DataRoot: root})
+	if err != nil {
+		t.Fatalf("new ladybug app: %v", err)
+	}
+	if _, err := first.Workspace.CreateWorkspace(ctx, model.CreateWorkspaceRequest{ID: "demo", Name: "Demo"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	second, err := NewAppWithGraphStore(root, graphstore.ProviderConfig{Type: graphstore.ProviderTypeLadybug, DataRoot: root})
+	if err != nil {
+		t.Fatalf("reopen ladybug app: %v", err)
+	}
+	page, err := second.Workspace.ListWorkspaces(ctx, model.WorkspaceListRequest{})
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(page.Items) != 1 || page.Items[0].ID != "demo" || page.Items[0].Name != "Demo" {
+		t.Fatalf("expected persisted demo workspace, got %+v", page.Items)
+	}
+}
+
+func TestLadybugAppRecoversWorkspaceMetadataFromDataRoot(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "instances", "demo", "storage", "graph", "local", "ladybug"), 0o755); err != nil {
+		t.Fatalf("create ladybug workspace dir: %v", err)
+	}
+
+	app, err := NewAppWithGraphStore(root, graphstore.ProviderConfig{Type: graphstore.ProviderTypeLadybug, DataRoot: root})
+	if err != nil {
+		t.Fatalf("new ladybug app: %v", err)
+	}
+	page, err := app.Workspace.ListWorkspaces(ctx, model.WorkspaceListRequest{})
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(page.Items) != 1 || page.Items[0].ID != "demo" || page.Items[0].Name != "demo" {
+		t.Fatalf("expected recovered demo workspace, got %+v", page.Items)
 	}
 }

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -19,6 +19,11 @@ import (
 
 var workspaceIDPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$`)
 
+const (
+	providerTypeFileMemory = "file.memory"
+	providerTypeLadybug    = "local.ladybug"
+)
+
 type Service struct {
 	mu          sync.RWMutex
 	root        string
@@ -45,12 +50,18 @@ func NewService(root string, configRules WorkspaceConfigValidator) *Service {
 }
 
 func NewPersistentService(root string, configRules WorkspaceConfigValidator) (*Service, error) {
+	return NewPersistentServiceForProvider(root, configRules, providerTypeFileMemory)
+}
+
+// NewPersistentServiceForProvider creates a persistent workspace metadata
+// service and recovers missing metadata from provider-specific storage paths.
+func NewPersistentServiceForProvider(root string, configRules WorkspaceConfigValidator, providerType string) (*Service, error) {
 	s := NewService(root, configRules)
 	s.statePath = filepath.Join(s.rootOrDefault(), "workspaces.json")
 	if err := s.loadLocked(); err != nil {
 		return nil, err
 	}
-	recovered, err := s.recoverFileMemoryWorkspaceDirsLocked()
+	recovered, err := s.recoverProviderWorkspaceDirsLocked(providerType)
 	if err != nil {
 		return nil, err
 	}
@@ -331,14 +342,32 @@ func (s *Service) loadLocked() error {
 	return nil
 }
 
+func (s *Service) recoverProviderWorkspaceDirsLocked(providerType string) (bool, error) {
+	switch providerType {
+	case "", providerTypeFileMemory:
+		return s.recoverFileMemoryWorkspaceDirsLocked()
+	case providerTypeLadybug:
+		return s.recoverLadybugWorkspaceDirsLocked()
+	default:
+		return false, nil
+	}
+}
+
 func (s *Service) recoverFileMemoryWorkspaceDirsLocked() (bool, error) {
-	root := filepath.Join(s.rootOrDefault(), "graphstore", "file-memory", "workspaces")
+	return s.recoverWorkspaceDirsLocked(
+		filepath.Join(s.rootOrDefault(), "graphstore", "file-memory", "workspaces"),
+		"file memory workspace directories",
+	)
+}
+
+func (s *Service) recoverLadybugWorkspaceDirsLocked() (bool, error) {
+	root := filepath.Join(s.rootOrDefault(), "instances")
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("read file memory workspace directories: %w", err)
+		return false, fmt.Errorf("read ladybug workspace root: %w", err)
 	}
 
 	recovered := false
@@ -347,32 +376,74 @@ func (s *Service) recoverFileMemoryWorkspaceDirsLocked() (bool, error) {
 			continue
 		}
 		id := entry.Name()
-		if _, exists := s.workspaces[id]; exists {
+		graphPath := filepath.Join(root, id, "storage", "graph", "local", "ladybug")
+		info, err := os.Stat(graphPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("stat ladybug workspace directory: %w", err)
+		}
+		if !info.IsDir() {
 			continue
 		}
-		if err := validateWorkspaceID(id); err != nil {
+		didRecover, err := s.recoverWorkspaceDirLocked(id, info)
+		if err != nil {
 			return false, err
+		}
+		recovered = recovered || didRecover
+	}
+	return recovered, nil
+}
+
+func (s *Service) recoverWorkspaceDirsLocked(root string, description string) (bool, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", description, err)
+	}
+
+	recovered := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
 		}
 		info, err := entry.Info()
 		if err != nil {
-			return false, fmt.Errorf("read file memory workspace directory info: %w", err)
+			return false, fmt.Errorf("read %s info: %w", description, err)
 		}
-		now := info.ModTime().UTC()
-		if now.IsZero() {
-			now = time.Now().UTC()
+		didRecover, err := s.recoverWorkspaceDirLocked(entry.Name(), info)
+		if err != nil {
+			return false, err
 		}
-		s.workspaces[id] = model.WorkspaceMetadata{
-			ID:              id,
-			Name:            id,
-			Paths:           model.WorkspacePaths{Root: s.workspaceRoot(id), Tmp: s.workspaceRoot(id) + "/tmp"},
-			Status:          model.WorkspaceStatusActive,
-			ResourceVersion: 1,
-			CreatedAt:       now,
-			UpdatedAt:       now,
-		}
-		recovered = true
+		recovered = recovered || didRecover
 	}
 	return recovered, nil
+}
+
+func (s *Service) recoverWorkspaceDirLocked(id string, info os.FileInfo) (bool, error) {
+	if _, exists := s.workspaces[id]; exists {
+		return false, nil
+	}
+	if err := validateWorkspaceID(id); err != nil {
+		return false, err
+	}
+	now := info.ModTime().UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	s.workspaces[id] = model.WorkspaceMetadata{
+		ID:              id,
+		Name:            id,
+		Paths:           model.WorkspacePaths{Root: s.workspaceRoot(id), Tmp: s.workspaceRoot(id) + "/tmp"},
+		Status:          model.WorkspaceStatusActive,
+		ResourceVersion: 1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	return true, nil
 }
 
 func (s *Service) normalizeMetadata(metadata *model.WorkspaceMetadata) {

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -144,3 +144,61 @@ func TestPersistentWorkspaceMetadataRecoversFileMemoryDirectories(t *testing.T) 
 		t.Fatalf("expected recovered demo workspace, got %+v", page.Items)
 	}
 }
+
+func TestPersistentWorkspaceMetadataRecoversLadybugDirectories(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "instances", "demo", "storage", "graph", "local", "ladybug"), 0o755); err != nil {
+		t.Fatalf("create ladybug workspace dir: %v", err)
+	}
+
+	svc, err := NewPersistentServiceForProvider(root, nil, providerTypeLadybug)
+	if err != nil {
+		t.Fatalf("new persistent service: %v", err)
+	}
+	page, err := svc.ListWorkspaces(ctx, model.WorkspaceListRequest{})
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(page.Items) != 1 || page.Items[0].ID != "demo" || page.Items[0].Status != model.WorkspaceStatusActive {
+		t.Fatalf("expected recovered demo workspace, got %+v", page.Items)
+	}
+}
+
+func TestPersistentWorkspaceMetadataDoesNotReviveDeletedLadybugWorkspace(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	first, err := NewPersistentServiceForProvider(root, nil, providerTypeLadybug)
+	if err != nil {
+		t.Fatalf("new persistent service: %v", err)
+	}
+	if _, err := first.CreateWorkspace(ctx, model.CreateWorkspaceRequest{ID: "demo"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "instances", "demo", "storage", "graph", "local", "ladybug"), 0o755); err != nil {
+		t.Fatalf("create ladybug workspace dir: %v", err)
+	}
+	if _, err := first.DeleteWorkspace(ctx, "demo"); err != nil {
+		t.Fatalf("delete workspace: %v", err)
+	}
+
+	second, err := NewPersistentServiceForProvider(root, nil, providerTypeLadybug)
+	if err != nil {
+		t.Fatalf("reopen persistent service: %v", err)
+	}
+	activeOnly, err := second.ListWorkspaces(ctx, model.WorkspaceListRequest{})
+	if err != nil {
+		t.Fatalf("list active workspaces: %v", err)
+	}
+	if len(activeOnly.Items) != 0 {
+		t.Fatalf("deleted workspace should not be revived, got %+v", activeOnly.Items)
+	}
+	withDeleted, err := second.ListWorkspaces(ctx, model.WorkspaceListRequest{IncludeDeleted: true})
+	if err != nil {
+		t.Fatalf("list deleted workspaces: %v", err)
+	}
+	if len(withDeleted.Items) != 1 || withDeleted.Items[0].Status != model.WorkspaceStatusDeleted {
+		t.Fatalf("expected persisted tombstone, got %+v", withDeleted.Items)
+	}
+}

--- a/tests/e2e/ladybug_optional_test.go
+++ b/tests/e2e/ladybug_optional_test.go
@@ -52,6 +52,19 @@ func TestLadybugOptionalBusinessFlowPersistsAcrossRestart(t *testing.T) {
 		}
 	}()
 
+	workspacePage := e2eGet(t, reopenedServer.URL+"/api/v1/workspaces")
+	workspaces, ok := workspacePage["items"].([]any)
+	if !ok {
+		t.Fatalf("workspace list has no items: %+v", workspacePage)
+	}
+	if len(workspaces) != 1 {
+		t.Fatalf("expected persisted ladybug workspace metadata after restart, got %+v", workspacePage)
+	}
+	workspace, ok := workspaces[0].(map[string]any)
+	if !ok || workspace["id"] != "ladybug-demo" {
+		t.Fatalf("expected ladybug-demo workspace metadata after restart, got %+v", workspacePage)
+	}
+
 	umodelRows := e2eRows(t, e2ePost(t, reopenedServer.URL+"/api/v1/query/ladybug-demo/execute", map[string]any{
 		"query": ".umodel with(kind='entity_set', domain='devops', name='devops.service') | limit 5",
 	}))


### PR DESCRIPTION
## Summary
- Persist workspace metadata when UModel runs with the `local.ladybug` GraphStore provider.
- Recover missing workspace metadata from existing Ladybug data directories under `data/instances/<workspace>/storage/graph/local/ladybug`.
- Preserve existing tombstones so deleted workspaces are not revived by directory recovery.
- Extend bootstrap, workspace, and Ladybug E2E coverage for restart recovery.

## Root Cause
`local.ladybug` persisted graph data across restarts, but bootstrap only enabled persistent workspace metadata for `file.memory`. As a result, the graph directory survived while `/api/v1/workspaces` and the Web UI lost the workspace catalog after restart.

## Verification
- `go test ./internal/bootstrap ./internal/workspace ./internal/graphstore ./internal/graphstore/provider/ladybug ./tests/e2e`
- `go test ./tests/contract ./tests/integration ./cmd/umodel-server ./cmd/umodel-mcp`
- `make verify-go`
- `UMODEL_TEST_LADYBUG=1 go test -tags ladybug ./tests/e2e -run Ladybug -count=1 -v`
- `git diff --check`

Fixes #19