### PR TITLE
Add get_metrics query planning with entity filters

### DIFF
--- a/cmd/umctl/main.go
+++ b/cmd/umctl/main.go
@@ -261,6 +261,7 @@ func (c cli) query(args []string) error {
 		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()`)
 		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)`)
 		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = "ERROR"')`)
+		fmt.Fprintln(c.out, `.entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')`)
 		fmt.Fprintln(c.out, `.entity with(domain='devops', name='devops.service', query='checkout') | limit 20`)
 		fmt.Fprintln(c.out, `.topo | graph-call getDirectRelations([(:"devops@devops.service" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20`)
 		return nil

--- a/docs/en/guides/query-service.md
+++ b/docs/en/guides/query-service.md
@@ -77,9 +77,10 @@ Agent and REST callers can bind named parameters into `with(...)` filters and `w
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
 ```
 
-The required filters are `domain` and `name`; `ids` is accepted as EntitySet call context. The currently supported methods are `__list_method__`, `list_data_set` (`list_dataset` alias), and `get_logs` (`get_log` alias); method parameters are validated against the UModel Assistant signatures. `get_logs` parses basic SPL where syntax, maps EntitySet fields through `data_link.fields_mapping`, maps LogSet fields through `storage_link.fields_mapping`, and returns the translated storage query plan without querying the storage itself.
+The required filters are `domain` and `name`; `ids` is accepted as EntitySet call context. The currently supported methods are `__list_method__`, `list_data_set` (`list_dataset` alias), `get_logs` (`get_log` alias), and `get_metrics` (`get_metric` alias); method parameters are validated against the UModel Assistant signatures. `get_logs` and `get_metrics` parse basic SPL where syntax, map EntitySet fields through `data_link.fields_mapping`, map DataSet fields through `storage_link.fields_mapping`, and return translated storage query plans without querying the storage itself.
 
 ## `.topo`
 

--- a/docs/zh/guides/query-service.md
+++ b/docs/zh/guides/query-service.md
@@ -72,9 +72,10 @@ Agent 和 REST 调用方可以把命名参数绑定到 `with(...)` filters 和 `
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
 ```
 
-`domain` 和 `name` 是必填 filter；`ids` 可作为 EntitySet 调用上下文。当前支持的方法是 `__list_method__`、`list_data_set`（兼容 `list_dataset` 别名）和 `get_logs`（兼容 `get_log` 别名）；方法参数按 UModel Assistant 的签名校验。`get_logs` 会解析基础 SPL where 语法，按 `data_link.fields_mapping` 映射 EntitySet 字段，按 `storage_link.fields_mapping` 映射 LogSet 字段，并只返回翻译后的存储查询计划，不直接查询存储。
+`domain` 和 `name` 是必填 filter；`ids` 可作为 EntitySet 调用上下文。当前支持的方法是 `__list_method__`、`list_data_set`（兼容 `list_dataset` 别名）、`get_logs`（兼容 `get_log` 别名）和 `get_metrics`（兼容 `get_metric` 别名）；方法参数按 UModel Assistant 的签名校验。`get_logs` 和 `get_metrics` 会解析基础 SPL where 语法，按 `data_link.fields_mapping` 映射 EntitySet 字段，按 `storage_link.fields_mapping` 映射 DataSet 字段，并只返回翻译后的存储查询计划，不直接查询存储。
 
 ## `.topo`
 

--- a/examples/quickstart-multidomain/README.md
+++ b/examples/quickstart-multidomain/README.md
@@ -47,6 +47,8 @@ go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with
 
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
 
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
+
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
 ```
 

--- a/examples/quickstart-multidomain/README.zh-CN.md
+++ b/examples/quickstart-multidomain/README.zh-CN.md
@@ -49,6 +49,8 @@ go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with
 
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
 
+go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
+
 go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
 ```
 

--- a/internal/agentgateway/service.go
+++ b/internal/agentgateway/service.go
@@ -116,6 +116,7 @@ func (s *Service) ReadResource(ctx context.Context, workspace string, req model.
 				{"id": "entity-set-methods", "query": ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()"},
 				{"id": "entity-set-data-sets", "query": ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"},
 				{"id": "entity-set-logs", "query": ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"},
+				{"id": "entity-set-metrics", "query": ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"},
 				{"id": "find-entity", "query": ".entity with(domain='devops', name='devops.service', query=$query) | limit 20", "parameters": map[string]any{"query": "checkout"}},
 				{"id": "topology-neighbors", "query": ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"},
 				{"id": "topology-cypher", "query": ".topo | graph-call cypher(`MATCH (src)-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`)"},
@@ -275,6 +276,24 @@ func (s *Service) queryRequest(args map[string]any) (model.QueryRequest, error) 
 			return model.QueryRequest{}, apperrors.New(apperrors.CodeInvalidArgument, "time_range argument is invalid")
 		}
 	}
+	for _, key := range []string{"filterByEntities", "entityData", "entity_data"} {
+		raw, ok := args[key]
+		if !ok {
+			continue
+		}
+		var entityData model.EntityData
+		if err := decodeValue(raw, &entityData); err != nil {
+			return model.QueryRequest{}, apperrors.New(apperrors.CodeInvalidArgument, key+" argument is invalid")
+		}
+		switch key {
+		case "filterByEntities":
+			req.FilterByEntities = &entityData
+		case "entityData":
+			req.EntityDataCamel = &entityData
+		default:
+			req.EntityData = &entityData
+		}
+	}
 	return req, nil
 }
 
@@ -421,6 +440,7 @@ func defaultExamples() []string {
 		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()",
 		".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
 		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')",
+		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
 		".entity with(domain='devops', name='devops.service', query='checkout') | limit 20",
 		".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",
 		".topo | graph-call cypher(`MATCH (src)-[r]->(dest) RETURN properties(src) AS src, properties(r) AS relation, properties(dest) AS dest LIMIT 20`)",
@@ -437,6 +457,17 @@ func toolSchemas() map[string]any {
 			"timeout_ms": map[string]any{"type": "integer", "minimum": 1},
 			"parameters": map[string]any{"type": "object", "additionalProperties": true},
 			"time_range": map[string]any{"type": "object"},
+			"entity_data": map[string]any{
+				"type":        "object",
+				"description": "EntityData table used to map EntitySet fields into DataSet/storage filters.",
+				"properties": map[string]any{
+					"version": map[string]any{"type": "integer"},
+					"header":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"data":    map[string]any{"type": "array"},
+				},
+			},
+			"entityData":       map[string]any{"type": "object"},
+			"filterByEntities": map[string]any{"type": "object"},
 		},
 	}
 	return map[string]any{

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -118,31 +118,11 @@ func (e *Executor) executeEntitySetListDataSet(ctx context.Context, workspace st
 	if err != nil {
 		return model.QueryResult{}, err
 	}
-	dataSetTypes := stringSet(stringSliceValue(plan.EntityCall.Parameters["data_set_types"]))
+	dataSetTypes := dataSetTypeSet(stringSliceValue(plan.EntityCall.Parameters["data_set_types"]))
 	detail := boolValue(plan.EntityCall.Parameters["detail"])
 	rows := make([]map[string]any, 0)
-	for _, link := range snapshot.Elements {
-		if link.Kind != "data_link" {
-			continue
-		}
-		src := refFromSpec(link.Spec, "src")
-		dest := refFromSpec(link.Spec, "dest")
-		if src.Kind != "entity_set" || src.Domain != stringFilter(plan.Filters["domain"]) || src.Name != stringFilter(plan.Filters["name"]) {
-			continue
-		}
-		if len(dataSetTypes) > 0 {
-			if _, ok := dataSetTypes[dest.Kind]; !ok {
-				continue
-			}
-		}
-		dataSet, ok := findUModelElement(snapshot.Elements, dest.Kind, dest.Domain, dest.Name)
-		if !ok {
-			continue
-		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), plan.EntityData) {
-			continue
-		}
-		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, link, dataSet, detail, plan.EntityData)))
+	for _, related := range relatedDataSetsForEntitySet(snapshot.Elements, stringFilter(plan.Filters["domain"]), stringFilter(plan.Filters["name"]), dataSetTypes, plan.EntityData) {
+		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, related, detail, plan.EntityData)))
 	}
 	return entitySetAssistantRawResponse(listDataSetHeader(), rows), nil
 }
@@ -212,6 +192,13 @@ type setRef struct {
 type storageBinding struct {
 	Link    model.UModelElement
 	Storage model.UModelElement
+}
+
+type relatedDataSet struct {
+	Link                  model.UModelElement
+	HasLink               bool
+	DataSet               model.UModelElement
+	FilterStorageByEntity bool
 }
 
 func entityCallRowValues(values []string) map[string]any {
@@ -355,12 +342,18 @@ func listDataSetHeader() []string {
 	return []string{"data_set_id", "type", "domain", "name", "fields_mapping", "filterable_fields", "fields", "storage_info", "storage_link_info", "data_link_detail", "data_set_detail", "storage_detail", "storage_link_detail"}
 }
 
-func listDataSetValues(elements []model.UModelElement, link model.UModelElement, dataSet model.UModelElement, detail bool, entityData *model.EntityData) []string {
-	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet, entityData)
+func listDataSetValues(elements []model.UModelElement, related relatedDataSet, detail bool, entityData *model.EntityData) []string {
+	link := related.Link
+	dataSet := related.DataSet
+	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet, entityData, related.FilterStorageByEntity)
 	dataLinkDetail := "{}"
 	dataSetDetail := "{}"
 	if detail {
-		dataLinkDetail = mustJSON(link)
+		if related.HasLink {
+			dataLinkDetail = mustJSON(link)
+		} else {
+			dataLinkDetail = "null"
+		}
 		dataSetDetail = mustJSON(dataSet)
 	} else {
 		storageDetail = []model.UModelElement{}
@@ -374,7 +367,7 @@ func listDataSetValues(elements []model.UModelElement, link model.UModelElement,
 		dataSet.Name,
 		mustJSON(fieldsMapping),
 		mustJSON(filterableFields(dataSet)),
-		mustJSON(dataSet.Spec["fields"]),
+		mustJSON(dataSetFields(dataSet)),
 		mustJSON(storageInfo),
 		mustJSON(storageLinkInfo),
 		dataLinkDetail,
@@ -384,7 +377,47 @@ func listDataSetValues(elements []model.UModelElement, link model.UModelElement,
 	}
 }
 
-func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
+func relatedDataSetsForEntitySet(elements []model.UModelElement, entityDomain, entityName string, dataSetTypes map[string]struct{}, entityData *model.EntityData) []relatedDataSet {
+	out := []relatedDataSet{}
+	seen := map[string]struct{}{}
+	for _, link := range elements {
+		if link.Kind != "data_link" {
+			continue
+		}
+		src := refFromSpec(link.Spec, "src")
+		dest := refFromSpec(link.Spec, "dest")
+		if src.Kind != "entity_set" || src.Domain != entityDomain || src.Name != entityName {
+			continue
+		}
+		if !dataSetTypeAllowed(dataSetTypes, dest.Kind) {
+			continue
+		}
+		dataSet, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name)
+		if !ok {
+			continue
+		}
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
+			continue
+		}
+		out = append(out, relatedDataSet{Link: link, HasLink: true, DataSet: dataSet, FilterStorageByEntity: true})
+		seen[uniqueID(dataSet.Domain, dataSet.Kind, dataSet.Name)] = struct{}{}
+	}
+
+	for _, dataSet := range elements {
+		if dataSet.Domain != "default" || !dataSetTypeAllowed(dataSetTypes, dataSet.Kind) {
+			continue
+		}
+		id := uniqueID(dataSet.Domain, dataSet.Kind, dataSet.Name)
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		out = append(out, relatedDataSet{DataSet: dataSet})
+		seen[id] = struct{}{}
+	}
+	return out
+}
+
+func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData, filterByEntity bool) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
 	storageInfo := []map[string]any{}
 	storageLinkInfo := []map[string]any{}
 	storageDetail := []model.UModelElement{}
@@ -397,7 +430,7 @@ func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UMod
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if filterByEntity && !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -433,7 +466,7 @@ func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName
 		if dest.Kind != dataSetKind || dest.Domain != dataSetDomain || dest.Name != dataSetName {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dataSet, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name)
@@ -455,7 +488,7 @@ func storageBindingsForDataSet(elements []model.UModelElement, dataSet model.UMo
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -1063,6 +1096,21 @@ func filterByEntityAllows(raw string, entityData *model.EntityData) bool {
 	return false
 }
 
+func filterByEntityExpression(spec map[string]any) string {
+	for _, key := range []string{"filter_by_entity", "filterByEntity", "FilterByEntity"} {
+		if raw := strings.TrimSpace(stringValue(spec[key])); raw != "" {
+			return raw
+		}
+	}
+	src := mapValue(spec["src"])
+	for _, key := range []string{"filter", "Filter"} {
+		if raw := strings.TrimSpace(stringValue(src[key])); raw != "" {
+			return raw
+		}
+	}
+	return ""
+}
+
 func evalFilterByEntity(node *logFilterNode, row map[string]string) bool {
 	if node == nil {
 		return true
@@ -1092,7 +1140,10 @@ func evalFilterByEntity(node *logFilterNode, row map[string]string) bool {
 }
 
 func evalFilterByEntityComparison(node *logFilterNode, row map[string]string) bool {
-	value := row[node.Field]
+	value, ok := row[node.Field]
+	if !ok {
+		return false
+	}
 	expected := stringValue(node.Value)
 	switch node.Operator {
 	case "=", "==", ":":
@@ -1187,6 +1238,24 @@ func findUModelElement(elements []model.UModelElement, kind, domain, name string
 }
 
 func filterableFields(element model.UModelElement) []string {
+	if element.Kind == "metric_set" {
+		labels := mapValue(element.Spec["labels"])
+		keys, ok := labels["keys"].([]any)
+		if !ok {
+			return []string{}
+		}
+		out := []string{}
+		for _, field := range keys {
+			item, ok := field.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name := stringValue(item["name"]); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	}
 	fields, ok := element.Spec["fields"].([]any)
 	if !ok {
 		return []string{}
@@ -1204,6 +1273,55 @@ func filterableFields(element model.UModelElement) []string {
 	return out
 }
 
+func dataSetFields(element model.UModelElement) any {
+	if element.Kind == "metric_set" {
+		metrics, ok := element.Spec["metrics"].([]any)
+		if !ok {
+			return nil
+		}
+		out := make([]map[string]any, 0, len(metrics))
+		for _, metric := range metrics {
+			item, ok := metric.(map[string]any)
+			if !ok {
+				continue
+			}
+			field := map[string]any{
+				"name": stringValue(item["name"]),
+				"type": "metric",
+			}
+			copyFieldInfo(field, item)
+			out = append(out, field)
+		}
+		return out
+	}
+	fields, ok := element.Spec["fields"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(fields))
+	for _, raw := range fields {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		field := map[string]any{
+			"name": stringValue(item["name"]),
+			"type": stringValue(item["type"]),
+		}
+		copyFieldInfo(field, item)
+		out = append(out, field)
+	}
+	return out
+}
+
+func copyFieldInfo(dst, src map[string]any) {
+	for _, key := range []string{"display_name", "description", "data_format", "unit"} {
+		if value, ok := src[key]; ok && stringValue(value) != "" {
+			dst[key] = value
+		}
+	}
+}
+
 func mapValue(value any) map[string]any {
 	if typed, ok := value.(map[string]any); ok {
 		return typed
@@ -1217,6 +1335,18 @@ func stringSet(values []string) map[string]struct{} {
 		out[value] = struct{}{}
 	}
 	return out
+}
+
+func dataSetTypeSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return stringSet([]string{"metric_set", "log_set", "trace_set", "event_set", "profile_set"})
+	}
+	return stringSet(values)
+}
+
+func dataSetTypeAllowed(typeFilter map[string]struct{}, kind string) bool {
+	_, ok := typeFilter[kind]
+	return ok
 }
 
 func uniqueID(domain, kind, name string) string {

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -81,6 +82,8 @@ func (e *Executor) executeEntitySetCall(ctx context.Context, workspace string, p
 		return e.executeEntitySetListDataSet(ctx, workspace, plan)
 	case "get_logs":
 		return e.executeEntitySetGetLogs(ctx, workspace, plan)
+	case "get_metrics":
+		return e.executeEntitySetGetMetrics(ctx, workspace, plan)
 	default:
 		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "unsupported entity-call method", map[string]string{"name": plan.EntityCall.Name})
 	}
@@ -136,7 +139,10 @@ func (e *Executor) executeEntitySetListDataSet(ctx context.Context, workspace st
 		if !ok {
 			continue
 		}
-		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, link, dataSet, detail)))
+		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), plan.EntityData) {
+			continue
+		}
+		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, link, dataSet, detail, plan.EntityData)))
 	}
 	return entitySetAssistantRawResponse(listDataSetHeader(), rows), nil
 }
@@ -148,14 +154,14 @@ func (e *Executor) executeEntitySetGetLogs(ctx context.Context, workspace string
 	}
 	domain := stringFilter(plan.EntityCall.Parameters["domain"])
 	name := stringFilter(plan.EntityCall.Parameters["name"])
-	dataLink, logSet, ok := findRelatedDataSet(snapshot.Elements, stringFilter(plan.Filters["domain"]), stringFilter(plan.Filters["name"]), "log_set", domain, name)
+	dataLink, logSet, ok := findRelatedDataSet(snapshot.Elements, stringFilter(plan.Filters["domain"]), stringFilter(plan.Filters["name"]), "log_set", domain, name, plan.EntityData)
 	if !ok {
 		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "related log_set not found", map[string]string{
 			"domain": domain,
 			"name":   name,
 		})
 	}
-	bindings := storageBindingsForDataSet(snapshot.Elements, logSet)
+	bindings := storageBindingsForDataSet(snapshot.Elements, logSet, plan.EntityData)
 	if len(bindings) == 0 {
 		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "log_set storage not found", map[string]string{
 			"domain": domain,
@@ -164,6 +170,36 @@ func (e *Executor) executeEntitySetGetLogs(ctx context.Context, workspace string
 	}
 
 	queryPlan := logQueryPlan(plan, dataLink, logSet, bindings[0])
+	return entitySetAssistantQueryResponse(mustJSON(queryPlan)), nil
+}
+
+func (e *Executor) executeEntitySetGetMetrics(ctx context.Context, workspace string, plan model.QueryPlan) (model.QueryResult, error) {
+	snapshot, err := e.graph.GetUModelSnapshot(ctx, model.UModelSnapshotRequest{Workspace: workspace})
+	if err != nil {
+		return model.QueryResult{}, err
+	}
+	domain := stringFilter(plan.EntityCall.Parameters["domain"])
+	name := stringFilter(plan.EntityCall.Parameters["name"])
+	dataLink, metricSet, ok := findRelatedDataSet(snapshot.Elements, stringFilter(plan.Filters["domain"]), stringFilter(plan.Filters["name"]), "metric_set", domain, name, plan.EntityData)
+	if !ok {
+		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "related metric_set not found", map[string]string{
+			"domain": domain,
+			"name":   name,
+		})
+	}
+	bindings := storageBindingsForDataSet(snapshot.Elements, metricSet, plan.EntityData)
+	if len(bindings) == 0 {
+		return model.QueryResult{}, apperrors.WithDetails(apperrors.CodeQueryPlanError, "metric_set storage not found", map[string]string{
+			"domain": domain,
+			"name":   name,
+		})
+	}
+	metrics, err := selectedMetricSpecs(metricSet, stringFilter(plan.EntityCall.Parameters["metric"]))
+	if err != nil {
+		return model.QueryResult{}, err
+	}
+
+	queryPlan := metricQueryPlan(plan, dataLink, metricSet, bindings[0], metrics)
 	return entitySetAssistantQueryResponse(mustJSON(queryPlan)), nil
 }
 
@@ -192,6 +228,7 @@ func entityCallListMethodRows() []map[string]any {
 		methodInfoListMethods(),
 		methodInfoListDataSet(),
 		methodInfoGetLogs(),
+		methodInfoGetMetrics(),
 	} {
 		rows = append(rows, entityCallRowValues([]string{
 			method.Name,
@@ -264,6 +301,35 @@ func methodInfoGetLogs() entityCallMethodInfo {
 	}
 }
 
+func methodInfoGetMetrics() entityCallMethodInfo {
+	return entityCallMethodInfo{
+		Name:        "get_metrics",
+		DisplayName: "Get Metrics",
+		Description: "Get metric query plan from a MetricSet",
+		Params: []assistantParamInfo{
+			{Key: "domain", Type: "varchar", DisplayName: "metric_set Domain", Required: true},
+			{Key: "name", Type: "varchar", DisplayName: "metric_set Name", Required: true},
+			{
+				Key:         "metric",
+				Type:        "varchar",
+				DisplayName: "Metric name",
+				Description: "Optional metric name. When omitted, all metrics in the MetricSet are planned.",
+			},
+			{
+				Key:         "query",
+				Type:        "varchar",
+				DisplayName: "Query expression for metric labels",
+				Description: "Basic SPL where syntax, for example service_id = 'service_a' and environment = 'prod'.",
+			},
+			{Key: "query_type", Type: "varchar", DisplayName: "Prometheus query type", Description: "range or instant. Defaults to the MetricSet/storage preference."},
+			{Key: "step", Type: "varchar", DisplayName: "Range query step", Description: "Range query step, for example 1m."},
+		},
+		Returns: []assistantReturnInfo{
+			{Key: "query", Type: "varchar", DisplayName: "Metric query plan"},
+		},
+	}
+}
+
 func methodInfoListDataSet() entityCallMethodInfo {
 	return entityCallMethodInfo{
 		Name:        "list_data_set",
@@ -289,8 +355,8 @@ func listDataSetHeader() []string {
 	return []string{"data_set_id", "type", "domain", "name", "fields_mapping", "filterable_fields", "fields", "storage_info", "storage_link_info", "data_link_detail", "data_set_detail", "storage_detail", "storage_link_detail"}
 }
 
-func listDataSetValues(elements []model.UModelElement, link model.UModelElement, dataSet model.UModelElement, detail bool) []string {
-	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet)
+func listDataSetValues(elements []model.UModelElement, link model.UModelElement, dataSet model.UModelElement, detail bool, entityData *model.EntityData) []string {
+	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet, entityData)
 	dataLinkDetail := "{}"
 	dataSetDetail := "{}"
 	if detail {
@@ -318,7 +384,7 @@ func listDataSetValues(elements []model.UModelElement, link model.UModelElement,
 	}
 }
 
-func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
+func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
 	storageInfo := []map[string]any{}
 	storageLinkInfo := []map[string]any{}
 	storageDetail := []model.UModelElement{}
@@ -329,6 +395,9 @@ func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UMod
 		}
 		src := refFromSpec(link.Spec, "src")
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
+			continue
+		}
+		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -351,7 +420,7 @@ func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UMod
 	return storageInfo, storageLinkInfo, storageDetail, storageLinkDetail
 }
 
-func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName, dataSetKind, dataSetDomain, dataSetName string) (model.UModelElement, model.UModelElement, bool) {
+func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName, dataSetKind, dataSetDomain, dataSetName string, entityData *model.EntityData) (model.UModelElement, model.UModelElement, bool) {
 	for _, link := range elements {
 		if link.Kind != "data_link" {
 			continue
@@ -364,6 +433,9 @@ func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName
 		if dest.Kind != dataSetKind || dest.Domain != dataSetDomain || dest.Name != dataSetName {
 			continue
 		}
+		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+			continue
+		}
 		dataSet, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name)
 		if !ok {
 			continue
@@ -373,7 +445,7 @@ func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName
 	return model.UModelElement{}, model.UModelElement{}, false
 }
 
-func storageBindingsForDataSet(elements []model.UModelElement, dataSet model.UModelElement) []storageBinding {
+func storageBindingsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData) []storageBinding {
 	out := []storageBinding{}
 	for _, link := range elements {
 		if link.Kind != "storage_link" {
@@ -381,6 +453,9 @@ func storageBindingsForDataSet(elements []model.UModelElement, dataSet model.UMo
 		}
 		src := refFromSpec(link.Spec, "src")
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
+			continue
+		}
+		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -426,19 +501,385 @@ func logQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, logSet mod
 				"spec":   binding.Link.Spec,
 			},
 		},
-		"query": buildLogStorageQuery(logSet, binding.Storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, plan.Limit),
+		"query": buildLogStorageQuery(logSet, binding.Storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, plan.Limit),
 	}
 	return queryPlan
 }
 
-func buildLogStorageQuery(logSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, limit int) map[string]any {
+func metricQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, metricSet model.UModelElement, binding storageBinding, metrics []map[string]any) map[string]any {
+	dataLinkMapping := mapValue(dataLink.Spec["fields_mapping"])
+	storageLinkMapping := mapValue(binding.Link.Spec["fields_mapping"])
+	entityIDs := stringSliceValue(plan.Filters["ids"])
+	entityQuery := stringFilter(plan.Filters["query"])
+	dataFilter := stringValue(dataLink.Spec["data_filter"])
+	methodQuery := stringFilter(plan.EntityCall.Parameters["query"])
+	queryType := stringFilter(plan.EntityCall.Parameters["query_type"])
+	step := stringFilter(plan.EntityCall.Parameters["step"])
+
+	queryPlan := map[string]any{
+		"operation": "get_metrics",
+		"data_source": map[string]any{
+			"data_set": map[string]any{
+				"domain": metricSet.Domain,
+				"kind":   metricSet.Kind,
+				"name":   metricSet.Name,
+			},
+			"storage": map[string]any{
+				"domain": binding.Storage.Domain,
+				"type":   binding.Storage.Kind,
+				"name":   binding.Storage.Name,
+				"config": binding.Storage.Spec,
+			},
+			"data_link": map[string]any{
+				"domain": dataLink.Domain,
+				"name":   dataLink.Name,
+				"spec":   dataLink.Spec,
+			},
+			"storage_link": map[string]any{
+				"domain": binding.Link.Domain,
+				"name":   binding.Link.Name,
+				"spec":   binding.Link.Spec,
+			},
+		},
+		"query": buildMetricStorageQuery(metricSet, binding.Storage, dataLinkMapping, storageLinkMapping, metrics, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, queryType, step, plan.Limit),
+	}
+	if plan.TimeRange.From != nil || plan.TimeRange.To != nil {
+		queryPlan["time_range"] = plan.TimeRange
+	}
+	return queryPlan
+}
+
+func selectedMetricSpecs(metricSet model.UModelElement, metricName string) ([]map[string]any, error) {
+	items, ok := metricSet.Spec["metrics"].([]any)
+	if !ok || len(items) == 0 {
+		return nil, apperrors.WithDetails(apperrors.CodeQueryPlanError, "metric_set metrics not found", map[string]string{
+			"domain": metricSet.Domain,
+			"name":   metricSet.Name,
+		})
+	}
+	out := []map[string]any{}
+	for _, item := range items {
+		metric, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if metricName != "" && stringValue(metric["name"]) != metricName {
+			continue
+		}
+		out = append(out, metric)
+	}
+	if len(out) == 0 {
+		return nil, apperrors.WithDetails(apperrors.CodeQueryPlanError, "metric not found in metric_set", map[string]string{
+			"domain": metricSet.Domain,
+			"name":   metricSet.Name,
+			"metric": metricName,
+		})
+	}
+	return out, nil
+}
+
+func buildMetricStorageQuery(metricSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, metrics []map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, entityData *model.EntityData, queryType, step string, limit int) map[string]any {
+	switch storage.Kind {
+	case "prometheus", "aliyun_prometheus":
+		return prometheusMetricQuery(metricSet, storage, dataLinkMapping, storageLinkMapping, metrics, entityIDs, entityQuery, dataFilter, methodQuery, entityData, queryType, step, limit)
+	default:
+		return map[string]any{
+			"dialect":      storage.Kind,
+			"metrics":      metricQueryItems(metrics),
+			"entity_ids":   entityIDs,
+			"entity_data":  entityDataSummary(entityData),
+			"entity_query": entityQuery,
+			"data_filter":  dataFilter,
+			"query":        methodQuery,
+			"query_type":   firstNonEmpty(queryType, defaultMetricQueryMode(metrics), stringValue(storage.Spec["default_query_type"])),
+			"step":         firstNonEmpty(step, stringValue(storage.Spec["default_step"])),
+			"limit":        limit,
+		}
+	}
+}
+
+type prometheusLabelMatcher struct {
+	Label    string `json:"label"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
+func prometheusMetricQuery(metricSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, metrics []map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, entityData *model.EntityData, queryType, step string, limit int) map[string]any {
+	matchers, rawFilters := prometheusQueryMatchers(storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, entityData)
+	queries := []map[string]any{}
+	for _, metric := range metrics {
+		name := stringValue(metric["name"])
+		promQL := firstNonEmpty(stringValue(metric["generator"]), name)
+		item := metricQueryItem(metric)
+		item["promql"] = renderPromQL(promQL, matchers)
+		queries = append(queries, item)
+	}
+	out := map[string]any{
+		"dialect":        "prometheus_promql",
+		"endpoint":       storage.Spec["endpoint"],
+		"api_prefix":     firstNonEmpty(stringValue(storage.Spec["api_prefix"]), "/api/v1"),
+		"query_type":     firstNonEmpty(queryType, defaultMetricQueryMode(metrics), stringValue(storage.Spec["default_query_type"]), "range"),
+		"step":           firstNonEmpty(step, stringValue(storage.Spec["default_step"])),
+		"lookback_delta": storage.Spec["lookback_delta"],
+		"metrics":        metricQueryItems(metrics),
+		"queries":        queries,
+		"label_matchers": matchers,
+		"limit":          limit,
+	}
+	if len(rawFilters) > 0 {
+		out["raw_filters"] = rawFilters
+	}
+	if tenant := stringValue(storage.Spec["tenant"]); tenant != "" {
+		out["tenant"] = tenant
+	}
+	if tenantHeader := stringValue(storage.Spec["tenant_header"]); tenantHeader != "" {
+		out["tenant_header"] = tenantHeader
+	}
+	if externalLabels, ok := storage.Spec["external_labels"].(map[string]any); ok && len(externalLabels) > 0 {
+		out["external_labels"] = externalLabels
+	}
+	if queryFamily := stringValue(metricSet.Spec["query_type"]); queryFamily != "" {
+		out["query_family"] = queryFamily
+	}
+	return out
+}
+
+func metricQueryItems(metrics []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(metrics))
+	for _, metric := range metrics {
+		out = append(out, metricQueryItem(metric))
+	}
+	return out
+}
+
+func metricQueryItem(metric map[string]any) map[string]any {
+	item := map[string]any{
+		"name": stringValue(metric["name"]),
+	}
+	for _, key := range []string{"unit", "data_format", "type", "query_mode", "aggregator", "display_type"} {
+		if value := stringValue(metric[key]); value != "" {
+			item[key] = value
+		}
+	}
+	if value, ok := metric["golden_metric"].(bool); ok {
+		item["golden_metric"] = value
+	}
+	return item
+}
+
+func defaultMetricQueryMode(metrics []map[string]any) string {
+	for _, metric := range metrics {
+		mode := stringValue(metric["query_mode"])
+		if mode != "" && mode != "both" {
+			return mode
+		}
+	}
+	for _, metric := range metrics {
+		if stringValue(metric["query_mode"]) == "both" {
+			return "range"
+		}
+	}
+	return ""
+}
+
+func prometheusQueryMatchers(storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, entityData *model.EntityData) ([]prometheusLabelMatcher, []string) {
+	matchers := []prometheusLabelMatcher{}
+	rawFilters := []string{}
+	if idField := mappedStorageField(dataLinkMapping, storageLinkMapping, "id"); idField != "" && len(entityIDs) > 0 {
+		matchers = append(matchers, prometheusValuesMatcher(idField, entityIDs, false))
+	}
+	matchers = append(matchers, entityDataPrometheusMatchers(entityData, dataLinkMapping, storageLinkMapping)...)
+	for _, item := range []struct {
+		raw    string
+		mapper func(string) string
+	}{
+		{firstNonEmpty(stringValue(storage.Spec["search_filter"]), stringValue(storage.Spec["default_filter"]), stringValue(storage.Spec["query_filter"])), storageFieldMapper()},
+		{dataFilter, dataSetToStorageFieldMapper(storageLinkMapping)},
+		{entityQuery, entityToStorageFieldMapper(dataLinkMapping, storageLinkMapping)},
+		{methodQuery, dataSetToStorageFieldMapper(storageLinkMapping)},
+	} {
+		filterMatchers, unsupported := prometheusMatchersFromFilter(item.raw, item.mapper)
+		matchers = append(matchers, filterMatchers...)
+		rawFilters = append(rawFilters, unsupported...)
+	}
+	return dedupePrometheusMatchers(matchers), rawFilters
+}
+
+func prometheusMatchersFromFilter(raw string, fieldMapper func(string) string) ([]prometheusLabelMatcher, []string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "*" {
+		return nil, nil
+	}
+	expr, err := parseLogFilterExpression(raw)
+	if err != nil {
+		return nil, []string{raw}
+	}
+	matchers, ok := logFilterToPrometheusMatchers(expr, fieldMapper)
+	if !ok {
+		return nil, []string{raw}
+	}
+	return matchers, nil
+}
+
+func logFilterToPrometheusMatchers(node *logFilterNode, fieldMapper func(string) string) ([]prometheusLabelMatcher, bool) {
+	if node == nil {
+		return nil, true
+	}
+	switch node.Kind {
+	case "and":
+		out := []prometheusLabelMatcher{}
+		for _, child := range node.Children {
+			matchers, ok := logFilterToPrometheusMatchers(child, fieldMapper)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, matchers...)
+		}
+		return out, true
+	case "comparison":
+		field := node.Field
+		if fieldMapper != nil {
+			field = fieldMapper(field)
+		}
+		switch node.Operator {
+		case "=", ":", "==":
+			return []prometheusLabelMatcher{{Label: field, Operator: "=", Value: stringValue(node.Value)}}, true
+		case "!=":
+			return []prometheusLabelMatcher{{Label: field, Operator: "!=", Value: stringValue(node.Value)}}, true
+		case "in":
+			return []prometheusLabelMatcher{prometheusValuesMatcher(field, stringSliceValue(node.Value), false)}, true
+		case "not in":
+			return []prometheusLabelMatcher{prometheusValuesMatcher(field, stringSliceValue(node.Value), true)}, true
+		default:
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+}
+
+func prometheusValuesMatcher(label string, values []string, negative bool) prometheusLabelMatcher {
+	if len(values) == 1 {
+		operator := "="
+		if negative {
+			operator = "!="
+		}
+		return prometheusLabelMatcher{Label: label, Operator: operator, Value: values[0]}
+	}
+	escaped := make([]string, 0, len(values))
+	for _, value := range values {
+		escaped = append(escaped, regexp.QuoteMeta(value))
+	}
+	operator := "=~"
+	if negative {
+		operator = "!~"
+	}
+	return prometheusLabelMatcher{Label: label, Operator: operator, Value: strings.Join(escaped, "|")}
+}
+
+func entityDataPrometheusMatchers(entityData *model.EntityData, dataLinkMapping, storageLinkMapping map[string]any) []prometheusLabelMatcher {
+	valuesByField := entityDataStorageValues(entityData, dataLinkMapping, storageLinkMapping)
+	if len(valuesByField) == 0 {
+		return nil
+	}
+	fields := make([]string, 0, len(valuesByField))
+	for field := range valuesByField {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	matchers := make([]prometheusLabelMatcher, 0, len(fields))
+	for _, field := range fields {
+		matchers = append(matchers, prometheusValuesMatcher(field, valuesByField[field], false))
+	}
+	return matchers
+}
+
+func dedupePrometheusMatchers(matchers []prometheusLabelMatcher) []prometheusLabelMatcher {
+	out := []prometheusLabelMatcher{}
+	seen := map[string]struct{}{}
+	for _, matcher := range matchers {
+		if matcher.Label == "" || matcher.Value == "" {
+			continue
+		}
+		key := matcher.Label + "\x00" + matcher.Operator + "\x00" + matcher.Value
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, matcher)
+	}
+	return out
+}
+
+func renderPromQL(promQL string, matchers []prometheusLabelMatcher) string {
+	remaining := []prometheusLabelMatcher{}
+	for _, matcher := range matchers {
+		placeholder := "$" + matcher.Label
+		if strings.Contains(promQL, placeholder) {
+			if matcher.Operator == "=" {
+				promQL = strings.ReplaceAll(promQL, placeholder, escapePromQLStringContent(matcher.Value))
+				continue
+			}
+			pattern := matcher.Label + `="` + placeholder + `"`
+			if strings.Contains(promQL, pattern) {
+				promQL = strings.ReplaceAll(promQL, pattern, matcher.Label+matcher.Operator+strconv.Quote(matcher.Value))
+				continue
+			}
+		}
+		if promQLSelectorHasLabel(promQL, matcher.Label) {
+			continue
+		}
+		remaining = append(remaining, matcher)
+	}
+	return injectPromQLMatchers(promQL, remaining)
+}
+
+func promQLSelectorHasLabel(promQL, label string) bool {
+	for _, op := range []string{"=~", "!~", "!=", "="} {
+		if strings.Contains(promQL, label+op) {
+			return true
+		}
+	}
+	return false
+}
+
+func injectPromQLMatchers(promQL string, matchers []prometheusLabelMatcher) string {
+	if len(matchers) == 0 {
+		return promQL
+	}
+	matcherText := prometheusMatcherText(matchers)
+	open := strings.Index(promQL, "{")
+	if open < 0 {
+		return promQL
+	}
+	if open+1 < len(promQL) && promQL[open+1] == '}' {
+		return promQL[:open+1] + matcherText + promQL[open+1:]
+	}
+	return promQL[:open+1] + matcherText + "," + promQL[open+1:]
+}
+
+func prometheusMatcherText(matchers []prometheusLabelMatcher) string {
+	parts := make([]string, 0, len(matchers))
+	for _, matcher := range matchers {
+		parts = append(parts, matcher.Label+matcher.Operator+strconv.Quote(matcher.Value))
+	}
+	return strings.Join(parts, ",")
+}
+
+func escapePromQLStringContent(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
+	return replacer.Replace(value)
+}
+
+func buildLogStorageQuery(logSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, entityData *model.EntityData, limit int) map[string]any {
 	switch storage.Kind {
 	case "elasticsearch":
-		return elasticsearchLogQuery(logSet, storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, limit)
+		return elasticsearchLogQuery(logSet, storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, entityData, limit)
 	default:
 		return map[string]any{
 			"dialect":      storage.Kind,
 			"entity_ids":   entityIDs,
+			"entity_data":  entityDataSummary(entityData),
 			"entity_query": entityQuery,
 			"data_filter":  dataFilter,
 			"query":        methodQuery,
@@ -447,7 +888,7 @@ func buildLogStorageQuery(logSet model.UModelElement, storage model.UModelElemen
 	}
 }
 
-func elasticsearchLogQuery(logSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, limit int) map[string]any {
+func elasticsearchLogQuery(logSet model.UModelElement, storage model.UModelElement, dataLinkMapping, storageLinkMapping map[string]any, entityIDs []string, entityQuery, dataFilter, methodQuery string, entityData *model.EntityData, limit int) map[string]any {
 	dataSetMapper := dataSetToStorageFieldMapper(storageLinkMapping)
 	timeField := stringValue(storage.Spec["time_field"])
 	if timeField == "" {
@@ -471,6 +912,9 @@ func elasticsearchLogQuery(logSet model.UModelElement, storage model.UModelEleme
 		} else {
 			filters = append(filters, map[string]any{"terms": map[string]any{idField: entityIDs}})
 		}
+	}
+	if entityFilter := entityDataElasticsearchFilter(entityData, dataLinkMapping, storageLinkMapping); entityFilter != nil {
+		filters = append(filters, entityFilter)
 	}
 	filters = appendLogQueryFilter(filters, firstNonEmpty(stringValue(storage.Spec["search_filter"]), stringValue(storage.Spec["default_filter"]), stringValue(storage.Spec["query_filter"])), storageMapper)
 	filters = appendLogQueryFilter(filters, dataFilter, dataSetMapper)
@@ -506,6 +950,162 @@ func mappedStorageField(dataLinkMapping, storageLinkMapping map[string]any, enti
 		return dataSetField
 	}
 	return storageField
+}
+
+func mappedStorageFieldForEntityData(dataLinkMapping, storageLinkMapping map[string]any, entityField string) string {
+	if stringValue(dataLinkMapping[entityField]) == "" {
+		return ""
+	}
+	return mappedStorageField(dataLinkMapping, storageLinkMapping, entityField)
+}
+
+func entityDataStorageValues(entityData *model.EntityData, dataLinkMapping, storageLinkMapping map[string]any) map[string][]string {
+	if entityData == nil || entityData.Empty() {
+		return nil
+	}
+	valuesByField := map[string]map[string]struct{}{}
+	for idx, entityField := range entityData.Header {
+		storageField := mappedStorageFieldForEntityData(dataLinkMapping, storageLinkMapping, entityField)
+		if storageField == "" {
+			continue
+		}
+		if _, ok := valuesByField[storageField]; !ok {
+			valuesByField[storageField] = map[string]struct{}{}
+		}
+		for _, row := range entityData.Data {
+			if idx >= len(row) || row[idx] == "" {
+				continue
+			}
+			valuesByField[storageField][row[idx]] = struct{}{}
+		}
+	}
+	out := make(map[string][]string, len(valuesByField))
+	for field, set := range valuesByField {
+		values := make([]string, 0, len(set))
+		for value := range set {
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		out[field] = values
+	}
+	return out
+}
+
+func entityDataElasticsearchFilter(entityData *model.EntityData, dataLinkMapping, storageLinkMapping map[string]any) map[string]any {
+	if entityData == nil || entityData.Empty() {
+		return nil
+	}
+	fieldMappings := entityDataFieldMappings(entityData.Header, dataLinkMapping, storageLinkMapping)
+	if len(fieldMappings) == 0 {
+		return nil
+	}
+	rowFilters := []map[string]any{}
+	for _, row := range entityData.Data {
+		fieldFilters := []map[string]any{}
+		for idx, storageField := range fieldMappings {
+			if idx >= len(row) || row[idx] == "" {
+				continue
+			}
+			fieldFilters = append(fieldFilters, map[string]any{"term": map[string]any{storageField: row[idx]}})
+		}
+		if len(fieldFilters) == 0 {
+			continue
+		}
+		if len(fieldFilters) == 1 {
+			rowFilters = append(rowFilters, fieldFilters[0])
+			continue
+		}
+		rowFilters = append(rowFilters, map[string]any{"bool": map[string]any{"filter": fieldFilters}})
+	}
+	if len(rowFilters) == 0 {
+		return nil
+	}
+	if len(rowFilters) == 1 {
+		return rowFilters[0]
+	}
+	return map[string]any{"bool": map[string]any{"should": rowFilters, "minimum_should_match": 1}}
+}
+
+func entityDataFieldMappings(header []string, dataLinkMapping, storageLinkMapping map[string]any) map[int]string {
+	out := map[int]string{}
+	for idx, entityField := range header {
+		if storageField := mappedStorageFieldForEntityData(dataLinkMapping, storageLinkMapping, entityField); storageField != "" {
+			out[idx] = storageField
+		}
+	}
+	return out
+}
+
+func entityDataSummary(entityData *model.EntityData) map[string]any {
+	if entityData == nil || entityData.Empty() {
+		return nil
+	}
+	return map[string]any{
+		"header": entityData.Header,
+		"rows":   len(entityData.Data),
+	}
+}
+
+func filterByEntityAllows(raw string, entityData *model.EntityData) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || entityData == nil || entityData.Empty() {
+		return true
+	}
+	expr, err := parseLogFilterExpression(raw)
+	if err != nil {
+		return false
+	}
+	for _, row := range entityData.ToArrayMap() {
+		if evalFilterByEntity(expr, row) {
+			return true
+		}
+	}
+	return false
+}
+
+func evalFilterByEntity(node *logFilterNode, row map[string]string) bool {
+	if node == nil {
+		return true
+	}
+	switch node.Kind {
+	case "and":
+		for _, child := range node.Children {
+			if !evalFilterByEntity(child, row) {
+				return false
+			}
+		}
+		return true
+	case "or":
+		for _, child := range node.Children {
+			if evalFilterByEntity(child, row) {
+				return true
+			}
+		}
+		return false
+	case "not":
+		return len(node.Children) == 0 || !evalFilterByEntity(node.Children[0], row)
+	case "comparison":
+		return evalFilterByEntityComparison(node, row)
+	default:
+		return false
+	}
+}
+
+func evalFilterByEntityComparison(node *logFilterNode, row map[string]string) bool {
+	value := row[node.Field]
+	expected := stringValue(node.Value)
+	switch node.Operator {
+	case "=", "==", ":":
+		return value == expected
+	case "!=":
+		return value != expected
+	case "in":
+		return containsString(stringSliceValue(node.Value), value)
+	case "not in":
+		return !containsString(stringSliceValue(node.Value), value)
+	default:
+		return false
+	}
 }
 
 func appendLogQueryFilter(filters []map[string]any, raw string, fieldMapper func(string) string) []map[string]any {

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -133,6 +133,7 @@ func planFromAST(req model.QueryRequest, ast AST) model.QueryPlan {
 		TopK:       topk,
 		TimeRange:  req.TimeRange,
 		Params:     req.Params,
+		EntityData: req.EntityFilterData(),
 		Limit:      limit,
 		Depth:      depth,
 		TimeoutMS:  req.TimeoutMS,
@@ -231,7 +232,7 @@ func validateAST(ast AST) error {
 			return nil
 		}
 	}
-	return apperrors.New(apperrors.CodeQueryParseError, ".entity_set requires entity-call __list_method__(), list_data_set(...), or get_logs(...)")
+	return apperrors.New(apperrors.CodeQueryParseError, ".entity_set requires entity-call __list_method__(), list_data_set(...), get_logs(...), or get_metrics(...)")
 }
 
 func hasSourceBoundary(queryText string, pos int) bool {

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -196,6 +196,28 @@ func entityCallMethodSpecFor(name string) (entityCallMethodSpec, bool) {
 				},
 			},
 		}, true
+	case "get_metric", "get_metrics":
+		return entityCallMethodSpec{
+			Name: "get_metrics",
+			Params: []model.EntityCallParam{
+				{Key: "domain", Type: "varchar", DisplayName: "metric_set Domain", Required: true},
+				{Key: "name", Type: "varchar", DisplayName: "metric_set Name", Required: true},
+				{
+					Key:         "metric",
+					Type:        "varchar",
+					DisplayName: "Metric name",
+					Description: "Optional metric name. When omitted, all metrics in the MetricSet are planned.",
+				},
+				{
+					Key:         "query",
+					Type:        "varchar",
+					DisplayName: "Query expression for metric labels",
+					Description: "Basic SPL where syntax, for example service_id = 'service_a' and environment = 'prod'.",
+				},
+				{Key: "query_type", Type: "varchar", DisplayName: "Prometheus query type", Description: "range or instant. Defaults to the MetricSet/storage preference."},
+				{Key: "step", Type: "varchar", DisplayName: "Range query step", Description: "Range query step, for example 1m."},
+			},
+		}, true
 	default:
 		return entityCallMethodSpec{}, false
 	}

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -90,6 +90,7 @@ func (s *Service) Examples(ctx context.Context) ([]string, error) {
 		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()",
 		".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)",
 		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')",
+		".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
 		".runbook_set with(domain='apm', type='knowledge', query='how to mitigate slow request', mode='hyper', topk=5)",
 		".runbook_set with(domain='apm', type='observations', query='cache miss spike', mode='vector', topk=10)",
 		".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20",

--- a/internal/query/service_test.go
+++ b/internal/query/service_test.go
@@ -192,6 +192,178 @@ func TestExecuteEntitySetListDataSetAliasReturnsAssistantRawData(t *testing.T) {
 	}
 }
 
+func TestExecuteEntitySetListDataSetUsesFilterByEntityAndSrcFilter(t *testing.T) {
+	ctx := context.Background()
+	elements := append(metricQueryPlanElements(),
+		testMetricSetElement("devops.metric.premium", "latency"),
+		model.UModelElement{
+			Kind:   "data_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.metric.premium",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service"},
+				"dest":             map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.premium"},
+				"fields_mapping":   map[string]any{"id": "service_id", "environment": "environment"},
+				"filter_by_entity": "environment = 'prod'",
+			},
+		},
+		testMetricSetElement("devops.metric.legacy", "throughput"),
+		model.UModelElement{
+			Kind:   "data_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.metric.legacy",
+			Spec: map[string]any{
+				"src":            map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service", "filter": "environment = 'prod'"},
+				"dest":           map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.legacy"},
+				"fields_mapping": map[string]any{"id": "service_id", "environment": "environment"},
+			},
+		},
+	)
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	staging, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "staging"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with non-matching entity data: %v", err)
+	}
+	stagingRows := listDataSetRowsByName(t, staging)
+	if _, ok := stagingRows["devops.metric.service"]; !ok {
+		t.Fatalf("unfiltered metric_set should still be listed, got %+v", stagingRows)
+	}
+	if _, ok := stagingRows["devops.metric.premium"]; ok {
+		t.Fatalf("top-level filter_by_entity metric_set should be filtered out, got %+v", stagingRows)
+	}
+	if _, ok := stagingRows["devops.metric.legacy"]; ok {
+		t.Fatalf("src.filter metric_set should be filtered out, got %+v", stagingRows)
+	}
+
+	prod, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "prod"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with matching entity data: %v", err)
+	}
+	prodRows := listDataSetRowsByName(t, prod)
+	for _, name := range []string{"devops.metric.service", "devops.metric.premium", "devops.metric.legacy"} {
+		if _, ok := prodRows[name]; !ok {
+			t.Fatalf("expected %s to be listed for matching entity data, got %+v", name, prodRows)
+		}
+	}
+	if got := prodRows["devops.metric.service"][5]; !strings.Contains(got, "service_id") || !strings.Contains(got, "environment") {
+		t.Fatalf("metric_set filterable_fields should come from labels, got %s", got)
+	}
+	if got := prodRows["devops.metric.service"][6]; !strings.Contains(got, `"type":"metric"`) || !strings.Contains(got, "request_count") {
+		t.Fatalf("metric_set fields should come from metrics, got %s", got)
+	}
+
+	noEntityData, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set without entity data: %v", err)
+	}
+	noEntityRows := listDataSetRowsByName(t, noEntityData)
+	for _, name := range []string{"devops.metric.premium", "devops.metric.legacy"} {
+		if _, ok := noEntityRows[name]; !ok {
+			t.Fatalf("expected %s to be listed when entity_data is absent, got %+v", name, noEntityRows)
+		}
+	}
+}
+
+func TestExecuteEntitySetListDataSetKeepsDataSetWhenStorageFilterMisses(t *testing.T) {
+	ctx := context.Background()
+	elements := metricQueryPlanElements()
+	for i := range elements {
+		if elements[i].Kind == "storage_link" {
+			elements[i].Spec["filter_by_entity"] = "region = 'cn-hangzhou'"
+		}
+	}
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], true)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id"},
+			Data:   [][]string{{"svc-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with storage filter miss: %v", err)
+	}
+	rows := listDataSetRowsByName(t, result)
+	values, ok := rows["devops.metric.service"]
+	if !ok {
+		t.Fatalf("data_set should remain visible when only storage filter misses, got %+v", rows)
+	}
+	for _, idx := range []int{7, 8, 11, 12} {
+		if values[idx] != "[]" {
+			t.Fatalf("expected storage field %d to be empty array, got %s", idx, values[idx])
+		}
+	}
+}
+
+func TestExecuteEntitySetListDataSetIncludesDefaultDomainDataSets(t *testing.T) {
+	ctx := context.Background()
+	elements := append(metricQueryPlanElements(),
+		testMetricSetElementWithDomain("default", "default.metric.common", "health_score"),
+		model.UModelElement{
+			Kind:   "storage_link",
+			Domain: "default",
+			Name:   "default.metric.common_to_prometheus",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "default", "kind": "metric_set", "name": "default.metric.common"},
+				"dest":             map[string]any{"domain": "devops", "kind": "prometheus", "name": "devops.prometheus.core"},
+				"fields_mapping":   map[string]any{"service_id": "service_id"},
+				"filter_by_entity": "region = 'cn-hangzhou'",
+			},
+		},
+	)
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id"},
+			Data:   [][]string{{"svc-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with default data_set: %v", err)
+	}
+	rows := listDataSetRowsByName(t, result)
+	values, ok := rows["default.metric.common"]
+	if !ok {
+		t.Fatalf("expected default domain metric_set to be listed, got %+v", rows)
+	}
+	if values[2] != "default" || values[9] != "{}" || !strings.Contains(values[7], "devops.prometheus.core") {
+		t.Fatalf("unexpected default domain metric_set row: %#v", values)
+	}
+}
+
 func TestExecuteEntitySetGetLogsReturnsQueryPlan(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()
@@ -714,6 +886,53 @@ func entityPayload(id, displayName string) model.EntityPayload {
 		"__first_observed_time__": int64(100),
 		"__last_observed_time__":  int64(200),
 		"display_name":            displayName,
+	}
+}
+
+func listDataSetRowsByName(t *testing.T, result model.QueryResult) map[string][]string {
+	t.Helper()
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected one assistant raw response row, got %+v", result.Rows)
+	}
+	row := result.Rows[0]
+	if row["responseType"] != 2 || row["query"] != "" {
+		t.Fatalf("expected assistant raw data response, got %+v", row)
+	}
+	data, ok := row["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("unexpected list_data_set data: %#v", row["data"])
+	}
+	out := map[string][]string{}
+	for _, item := range data {
+		values, ok := item["values"].([]string)
+		if !ok || len(values) != len(listDataSetHeader()) {
+			t.Fatalf("unexpected list_data_set row: %#v", item)
+		}
+		out[values[3]] = values
+	}
+	return out
+}
+
+func testMetricSetElement(name, metricName string) model.UModelElement {
+	return testMetricSetElementWithDomain("devops", name, metricName)
+}
+
+func testMetricSetElementWithDomain(domain, name, metricName string) model.UModelElement {
+	return model.UModelElement{
+		Kind:   "metric_set",
+		Domain: domain,
+		Name:   name,
+		Spec: map[string]any{
+			"labels": map[string]any{
+				"keys": []any{
+					map[string]any{"name": "service_id", "type": "string"},
+					map[string]any{"name": "environment", "type": "string"},
+				},
+			},
+			"metrics": []any{
+				map[string]any{"name": metricName, "unit": "count"},
+			},
+		},
 	}
 }
 

--- a/internal/query/service_test.go
+++ b/internal/query/service_test.go
@@ -151,7 +151,7 @@ func TestExecuteEntitySetListMethodsReturnsAssistantRawData(t *testing.T) {
 		t.Fatalf("unexpected __list_method__ header: %#v", row["header"])
 	}
 	data, ok := row["data"].([]map[string]any)
-	if !ok || len(data) != 3 {
+	if !ok || len(data) != 4 {
 		t.Fatalf("unexpected __list_method__ data: %#v", row["data"])
 	}
 	values, ok := data[1]["values"].([]string)
@@ -161,6 +161,10 @@ func TestExecuteEntitySetListMethodsReturnsAssistantRawData(t *testing.T) {
 	values, ok = data[2]["values"].([]string)
 	if !ok || len(values) == 0 || values[0] != "get_logs" {
 		t.Fatalf("expected get_logs method row, got %#v", data[2])
+	}
+	values, ok = data[3]["values"].([]string)
+	if !ok || len(values) == 0 || values[0] != "get_metrics" {
+		t.Fatalf("expected get_metrics method row, got %#v", data[3])
 	}
 }
 
@@ -271,6 +275,222 @@ func TestExecuteEntitySetGetLogAliasReturnsQueryPlan(t *testing.T) {
 	}
 }
 
+func TestExecuteEntitySetGetMetricsReturnsQueryPlan(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service', ids=['svc-1'], query='environment = \"prod\"') | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_metrics: %v", err)
+	}
+	row := result.Rows[0]
+	if row["responseType"] != 1 {
+		t.Fatalf("expected responseType=1 query plan, got %+v", row)
+	}
+	queryText, ok := row["query"].(string)
+	if !ok || queryText == "" {
+		t.Fatalf("expected query string, got %#v", row["query"])
+	}
+	for _, want := range []string{"get_metrics", "devops.metric.service", "devops.prometheus.core", "prometheus_promql", "request_count", "service_id", "svc-1", "environment", "prod", "30s"} {
+		if !strings.Contains(queryText, want) {
+			t.Fatalf("expected get_metrics query plan to contain %q, got %s", want, queryText)
+		}
+	}
+	var queryPlan map[string]any
+	if err := json.Unmarshal([]byte(queryText), &queryPlan); err != nil {
+		t.Fatalf("decode query plan: %v", err)
+	}
+	query, ok := queryPlan["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected query object, got %#v", queryPlan["query"])
+	}
+	if query["dialect"] != "prometheus_promql" || query["query_type"] != "range" || query["step"] != "30s" {
+		t.Fatalf("unexpected metric query metadata: %#v", query)
+	}
+	queries, ok := query["queries"].([]any)
+	if !ok || len(queries) != 1 {
+		t.Fatalf("expected one PromQL query, got %#v", query["queries"])
+	}
+	first, ok := queries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected PromQL query item: %#v", queries[0])
+	}
+	promQL := stringValue(first["promql"])
+	for _, want := range []string{`service_id="svc-1"`, `environment="prod"`, "devops_service_request_total"} {
+		if !strings.Contains(promQL, want) {
+			t.Fatalf("expected rendered PromQL to contain %q, got %s", want, promQL)
+		}
+	}
+	if result.Explain == nil || result.Explain.EntityCall == nil || result.Explain.EntityCall.Name != "get_metrics" {
+		t.Fatalf("expected canonical get_metrics in explain, got %+v", result.Explain)
+	}
+}
+
+func TestExecuteEntitySetGetMetricsUsesFilterByEntities(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
+		FilterByEntities: &model.EntityData{
+			Version: 1,
+			Header:  []string{"id", "environment", "ignored"},
+			Data: [][]string{
+				{"svc-1", "prod", "x"},
+				{"svc-2", "prod", "y"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute get_metrics with filterByEntities: %v", err)
+	}
+	queryText := stringValue(result.Rows[0]["query"])
+	var queryPlan map[string]any
+	if err := json.Unmarshal([]byte(queryText), &queryPlan); err != nil {
+		t.Fatalf("decode query plan: %v", err)
+	}
+	query := queryPlan["query"].(map[string]any)
+	queries := query["queries"].([]any)
+	promQL := stringValue(queries[0].(map[string]any)["promql"])
+	for _, want := range []string{`service_id=~"svc-1|svc-2"`, `environment="prod"`} {
+		if !strings.Contains(promQL, want) {
+			t.Fatalf("expected filterByEntities matcher %q in PromQL, got %s", want, promQL)
+		}
+	}
+	if strings.Contains(promQL, "ignored") {
+		t.Fatalf("unmapped entity_data field should not be pushed down, got %s", promQL)
+	}
+}
+
+func TestExecuteEntitySetGetLogsUsesEntityDataByEntity(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  logQueryPlanElements(),
+	})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_logs('devops', 'devops.log.service')",
+		EntityData: &model.EntityData{
+			Version: 1,
+			Header:  []string{"id", "environment"},
+			Data: [][]string{
+				{"svc-1", "prod"},
+				{"svc-2", "staging"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute get_logs with entity_data: %v", err)
+	}
+	queryText := stringValue(result.Rows[0]["query"])
+	var queryPlan map[string]any
+	if err := json.Unmarshal([]byte(queryText), &queryPlan); err != nil {
+		t.Fatalf("decode query plan: %v", err)
+	}
+	query := queryPlan["query"].(map[string]any)
+	body := query["body"].(map[string]any)
+	bodyQuery := mustJSON(body["query"])
+	for _, want := range []string{"minimum_should_match", "svc_id", "env", "svc-1", "prod", "svc-2", "staging"} {
+		if !strings.Contains(bodyQuery, want) {
+			t.Fatalf("expected entity_data filter to contain %q, got %s", want, bodyQuery)
+		}
+	}
+}
+
+func TestEntitySetFilterByEntitySelectsRelatedDataSet(t *testing.T) {
+	ctx := context.Background()
+	elements := metricQueryPlanElements()
+	elements[1].Spec["filter_by_entity"] = "environment = 'prod'"
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  elements,
+	})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	_, err = svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_metrics('devops', 'devops.metric.service', 'request_count')",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "staging"}},
+		},
+	})
+	if !apperrors.IsCode(err, apperrors.CodeQueryPlanError) {
+		t.Fatalf("expected filter_by_entity mismatch to hide related metric_set, got %v", err)
+	}
+
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_metrics('devops', 'devops.metric.service', 'request_count')",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "prod"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected filter_by_entity match to select metric_set: %v", err)
+	}
+	if result.Rows[0]["responseType"] != 1 {
+		t.Fatalf("expected responseType=1 query plan, got %+v", result.Rows[0])
+	}
+}
+
+func TestExecuteEntitySetGetMetricAliasReturnsQueryPlan(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_metric(domain='devops', name='devops.metric.service', metric='error_count')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_metric alias: %v", err)
+	}
+	if result.Rows[0]["responseType"] != 1 {
+		t.Fatalf("expected responseType=1 alias query plan, got %+v", result.Rows[0])
+	}
+	queryText := stringValue(result.Rows[0]["query"])
+	if !strings.Contains(queryText, "error_count") || strings.Contains(queryText, "request_count") {
+		t.Fatalf("expected get_metric alias to select only error_count, got %s", queryText)
+	}
+	if result.Explain == nil || result.Explain.EntityCall == nil || result.Explain.EntityCall.Name != "get_metrics" {
+		t.Fatalf("expected get_metric alias to normalize to get_metrics, got %+v", result.Explain)
+	}
+}
+
 func TestExecuteEntitySetRejectsPlaceholderMethod(t *testing.T) {
 	ctx := context.Background()
 	svc := NewService(graphstore.NewMemoryStore())
@@ -283,7 +503,7 @@ func TestExecuteEntitySetRejectsPlaceholderMethod(t *testing.T) {
 func TestExecuteEntitySetRejectsUnsupportedMethod(t *testing.T) {
 	ctx := context.Background()
 	svc := NewService(graphstore.NewMemoryStore())
-	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call get_metric('apm', 'devops.metric.service', 'request_count')"})
+	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity_set with(domain='apm', name='apm.service') | entity-call get_metricz('apm', 'devops.metric.service', 'request_count')"})
 	if !apperrors.IsCode(err, apperrors.CodeQueryPlanError) {
 		t.Fatalf("expected query plan error for unsupported method, got %v", err)
 	}
@@ -545,6 +765,76 @@ func logQueryPlanElements() []model.UModelElement {
 				"query_dialect": "elasticsearch_dsl",
 				"time_field":    "event_time",
 				"default_size":  1000,
+			},
+		},
+	}
+}
+
+func metricQueryPlanElements() []model.UModelElement {
+	return []model.UModelElement{
+		{Kind: "entity_set", Domain: "devops", Name: "devops.service"},
+		{
+			Kind:   "data_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.metric.service",
+			Spec: map[string]any{
+				"src":            map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service"},
+				"dest":           map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.service"},
+				"fields_mapping": map[string]any{"id": "service_id", "environment": "environment"},
+			},
+		},
+		{
+			Kind:   "metric_set",
+			Domain: "devops",
+			Name:   "devops.metric.service",
+			Spec: map[string]any{
+				"query_type": "prom",
+				"labels": map[string]any{
+					"keys": []any{
+						map[string]any{"name": "service_id", "type": "string"},
+						map[string]any{"name": "environment", "type": "string"},
+					},
+				},
+				"metrics": []any{
+					map[string]any{
+						"name":          "request_count",
+						"unit":          "count",
+						"query_mode":    "range",
+						"generator":     `sum(rate(devops_service_request_total{service_id="$service_id"}[1m]))`,
+						"aggregator":    "sum",
+						"golden_metric": true,
+					},
+					map[string]any{
+						"name":          "error_count",
+						"unit":          "count",
+						"query_mode":    "range",
+						"generator":     `sum(rate(devops_service_error_total{service_id="$service_id"}[1m]))`,
+						"aggregator":    "sum",
+						"golden_metric": true,
+					},
+				},
+			},
+		},
+		{
+			Kind:   "storage_link",
+			Domain: "devops",
+			Name:   "devops.metric.service_to_prometheus",
+			Spec: map[string]any{
+				"src":            map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.service"},
+				"dest":           map[string]any{"domain": "devops", "kind": "prometheus", "name": "devops.prometheus.core"},
+				"fields_mapping": map[string]any{"service_id": "service_id", "environment": "environment"},
+			},
+		},
+		{
+			Kind:   "prometheus",
+			Domain: "devops",
+			Name:   "devops.prometheus.core",
+			Spec: map[string]any{
+				"endpoint":           "http://prometheus.devops.example:9090",
+				"api_prefix":         "/api/v1",
+				"default_query_type": "range",
+				"default_step":       "1m",
+				"lookback_delta":     "5m",
 			},
 		},
 	}

--- a/internal/sampledata/service_test.go
+++ b/internal/sampledata/service_test.go
@@ -140,6 +140,38 @@ func TestImportMultiDomainQuickStartWritesSchemaEntitiesAndTopology(t *testing.T
 		}
 	}
 
+	metricPlanRows, err := querySvc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101'], query='environment = \"prod\"') | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
+	})
+	if err != nil {
+		t.Fatalf("plan quickstart metrics query: %v", err)
+	}
+	if len(metricPlanRows.Rows) != 1 || metricPlanRows.Rows[0]["responseType"] != 1 {
+		t.Fatalf("expected get_metrics query plan row, got %+v", metricPlanRows.Rows)
+	}
+	metricQuery := ""
+	if text, ok := metricPlanRows.Rows[0]["query"].(string); ok {
+		metricQuery = text
+	}
+	for _, want := range []string{"get_metrics", "devops.metric.service", "devops.prometheus.core", "prometheus_promql", "request_count", "service_id", "environment", "prod", "30s"} {
+		if !strings.Contains(metricQuery, want) {
+			t.Fatalf("expected get_metrics query plan to contain %q, got %s", want, metricQuery)
+		}
+	}
+	var metricPlan map[string]any
+	if err := json.Unmarshal([]byte(metricQuery), &metricPlan); err != nil {
+		t.Fatalf("decode get_metrics query plan: %v", err)
+	}
+	translatedMetricQuery, err := json.Marshal(metricPlan["query"])
+	if err != nil {
+		t.Fatalf("encode translated metrics query: %v", err)
+	}
+	for _, want := range []string{"\"prometheus_promql\"", "devops_service_request_total", "service_id=\\\"10000000000000000000000000000101\\\"", "environment=\\\"prod\\\""} {
+		if !strings.Contains(string(translatedMetricQuery), want) {
+			t.Fatalf("expected translated get_metrics query to contain %q, got %s", want, string(translatedMetricQuery))
+		}
+	}
+
 	entityRows, err := querySvc.Execute(ctx, "demo", model.QueryRequest{
 		Query: ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__,display_name,business_value | limit 10",
 	})

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -263,12 +264,172 @@ type ExpireRequest struct {
 }
 
 type QueryRequest struct {
-	Query     string         `json:"query"`
-	TimeRange TimeRange      `json:"time_range,omitempty"`
-	Format    string         `json:"format,omitempty"`
-	Limit     int            `json:"limit,omitempty"`
-	TimeoutMS int            `json:"timeout_ms,omitempty"`
-	Params    map[string]any `json:"parameters,omitempty"`
+	Query            string         `json:"query"`
+	TimeRange        TimeRange      `json:"time_range,omitempty"`
+	Format           string         `json:"format,omitempty"`
+	Limit            int            `json:"limit,omitempty"`
+	TimeoutMS        int            `json:"timeout_ms,omitempty"`
+	Params           map[string]any `json:"parameters,omitempty"`
+	EntityData       *EntityData    `json:"entity_data,omitempty"`
+	EntityDataCamel  *EntityData    `json:"entityData,omitempty"`
+	FilterByEntities *EntityData    `json:"filterByEntities,omitempty"`
+}
+
+func (r QueryRequest) EntityFilterData() *EntityData {
+	for _, data := range []*EntityData{r.FilterByEntities, r.EntityDataCamel, r.EntityData} {
+		if data != nil && !data.Empty() {
+			return data
+		}
+	}
+	return nil
+}
+
+type EntityData struct {
+	Version int        `json:"version,omitempty"`
+	Header  []string   `json:"header,omitempty"`
+	Data    [][]string `json:"data,omitempty"`
+}
+
+func (e EntityData) Empty() bool {
+	return len(e.Header) == 0 || len(e.Data) == 0
+}
+
+func (e EntityData) ToArrayMap() []map[string]string {
+	if e.Empty() {
+		return nil
+	}
+	rows := make([]map[string]string, 0, len(e.Data))
+	for _, row := range e.Data {
+		item := make(map[string]string, len(e.Header))
+		for idx, field := range e.Header {
+			if field == "" || idx >= len(row) {
+				continue
+			}
+			item[field] = row[idx]
+		}
+		rows = append(rows, item)
+	}
+	return rows
+}
+
+func (e *EntityData) UnmarshalJSON(raw []byte) error {
+	if e == nil {
+		return nil
+	}
+	if string(raw) == "null" {
+		*e = EntityData{}
+		return nil
+	}
+	var table struct {
+		Version int             `json:"version,omitempty"`
+		Header  []string        `json:"header,omitempty"`
+		Data    json.RawMessage `json:"data,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &table); err == nil && (len(table.Header) > 0 || len(table.Data) > 0) {
+		rows, header, err := decodeEntityDataRows(table.Data, table.Header)
+		if err != nil {
+			return err
+		}
+		*e = EntityData{Version: table.Version, Header: header, Data: rows}
+		return nil
+	}
+	rows, header, err := decodeEntityDataRows(raw, nil)
+	if err != nil {
+		return err
+	}
+	*e = EntityData{Header: header, Data: rows}
+	return nil
+}
+
+func decodeEntityDataRows(raw json.RawMessage, header []string) ([][]string, []string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, append([]string(nil), header...), nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, nil, err
+	}
+	outHeader := append([]string(nil), header...)
+	if len(outHeader) == 0 {
+		outHeader = inferEntityDataHeader(items)
+	}
+	rows := make([][]string, 0, len(items))
+	for _, item := range items {
+		row, err := decodeEntityDataRow(item, outHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(row) != len(outHeader) {
+			return nil, nil, fmt.Errorf("entity_data row length %d does not match header length %d", len(row), len(outHeader))
+		}
+		rows = append(rows, row)
+	}
+	return rows, outHeader, nil
+}
+
+func inferEntityDataHeader(items []json.RawMessage) []string {
+	keys := map[string]struct{}{}
+	for _, item := range items {
+		var row map[string]any
+		if err := json.Unmarshal(item, &row); err != nil {
+			continue
+		}
+		if _, ok := row["values"]; ok {
+			continue
+		}
+		for key := range row {
+			keys[key] = struct{}{}
+		}
+	}
+	header := make([]string, 0, len(keys))
+	for key := range keys {
+		header = append(header, key)
+	}
+	sort.Strings(header)
+	return header
+}
+
+func decodeEntityDataRow(raw json.RawMessage, header []string) ([]string, error) {
+	var values []any
+	if err := json.Unmarshal(raw, &values); err == nil {
+		return entityDataValuesToStrings(values), nil
+	}
+	var wrapped struct {
+		Values []any `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Values != nil {
+		return entityDataValuesToStrings(wrapped.Values), nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	row := make([]string, 0, len(header))
+	for _, field := range header {
+		row = append(row, entityDataCellString(object[field]))
+	}
+	return row, nil
+}
+
+func entityDataValuesToStrings(values []any) []string {
+	row := make([]string, 0, len(values))
+	for _, value := range values {
+		row = append(row, entityDataCellString(value))
+	}
+	return row
+}
+
+func entityDataCellString(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(typed)
+	}
 }
 
 type QueryResult struct {
@@ -442,6 +603,7 @@ type QueryPlan struct {
 	TopK       int
 	TimeRange  TimeRange
 	Params     map[string]any
+	EntityData *EntityData
 	Limit      int
 	Depth      int
 	TimeoutMS  int

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestQueryRequestEntityDataAliasesDecode(t *testing.T) {
+	for _, key := range []string{"entity_data", "entityData", "filterByEntities"} {
+		raw := []byte(`{"query":".entity_set with(domain='devops', name='devops.service') | entity-call get_metrics('devops','devops.metric.service')","` + key + `":{"version":1,"header":["id","environment"],"data":[["svc-1","prod"],{"values":["svc-2","staging"]}]}}`)
+		var req QueryRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Fatalf("decode %s: %v", key, err)
+		}
+		entityData := req.EntityFilterData()
+		if entityData == nil || len(entityData.Data) != 2 || entityData.Data[1][1] != "staging" {
+			t.Fatalf("unexpected entity data for %s: %+v", key, entityData)
+		}
+	}
+}
+
+func TestEntityDataDecodesObjectRows(t *testing.T) {
+	var data EntityData
+	if err := json.Unmarshal([]byte(`[{"id":"svc-2","environment":"staging"},{"id":"svc-1","environment":"prod"}]`), &data); err != nil {
+		t.Fatalf("decode row objects: %v", err)
+	}
+	if len(data.Header) != 2 || data.Header[0] != "environment" || data.Header[1] != "id" {
+		t.Fatalf("expected sorted inferred header, got %+v", data.Header)
+	}
+	if data.Data[0][0] != "staging" || data.Data[1][1] != "svc-1" {
+		t.Fatalf("unexpected row data: %+v", data.Data)
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -129,6 +129,15 @@ export interface QueryRequest {
     to?: string
   }
   parameters?: Record<string, unknown>
+  entity_data?: EntityData
+  entityData?: EntityData
+  filterByEntities?: EntityData
+}
+
+export interface EntityData {
+  version?: number
+  header?: string[]
+  data?: Array<string[] | { values: string[] } | Record<string, unknown>>
 }
 
 export interface QueryExplain {

--- a/web/src/features/query/QueryPage.tsx
+++ b/web/src/features/query/QueryPage.tsx
@@ -100,6 +100,11 @@ const examples = [
     query:
       ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')",
   },
+  {
+    labelKey: 'query.examples.entitySetMetrics',
+    query:
+      ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
+  },
 ] as const satisfies ReadonlyArray<{ labelKey: MessageKey; query: string }>
 
 export function QueryPage({ api, workspaceId }: { api: UModelApi; workspaceId: string }) {

--- a/web/src/i18n/locales/en-US/query.ts
+++ b/web/src/i18n/locales/en-US/query.ts
@@ -25,6 +25,7 @@ export const enUSQuery = {
   'query.examples.entity': '.entity',
   'query.examples.entitySetDatasets': 'EntitySet Datasets',
   'query.examples.entitySetLogs': 'EntitySet Logs',
+  'query.examples.entitySetMetrics': 'EntitySet Metrics',
   'query.examples.entitySetMethods': 'EntitySet Methods',
   'query.examples.neighbors': 'Neighbors',
   'query.examples.placeholder': 'Select example',

--- a/web/src/i18n/locales/zh-CN/query.ts
+++ b/web/src/i18n/locales/zh-CN/query.ts
@@ -27,6 +27,7 @@ export const zhCNQuery = {
   'query.examples.entity': '.entity',
   'query.examples.entitySetDatasets': 'EntitySet 数据集',
   'query.examples.entitySetLogs': 'EntitySet 日志',
+  'query.examples.entitySetMetrics': 'EntitySet 指标',
   'query.examples.entitySetMethods': 'EntitySet 方法',
   'query.examples.neighbors': 'neighbors',
   'query.examples.placeholder': '选择示例',


### PR DESCRIPTION
## Summary

- add `get_metrics` / `get_metric` query planning for MetricSet-backed Prometheus queries
- support `entity_data`, `entityData`, and `filterByEntities` request payloads for field-mapped entity filters
- apply `filter_by_entity` when selecting related DataLinks and StorageLinks
- update Query UI examples, docs, agent tool schema, and regression coverage

## Verification

- `go test ./...`
- `web ./node_modules/.bin/tsc --noEmit`
- `web ./node_modules/.bin/vite build`
- Browser UI: executed EntitySet Metrics and verified `prometheus_promql`
- Live API: verified `filterByEntities` generates `environment="prod"` and `service_id=~"...101|...102"` in PromQL
