### PR TITLE
Align list_data_set discovery with assistant

### DIFF
--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -118,31 +118,11 @@ func (e *Executor) executeEntitySetListDataSet(ctx context.Context, workspace st
 	if err != nil {
 		return model.QueryResult{}, err
 	}
-	dataSetTypes := stringSet(stringSliceValue(plan.EntityCall.Parameters["data_set_types"]))
+	dataSetTypes := dataSetTypeSet(stringSliceValue(plan.EntityCall.Parameters["data_set_types"]))
 	detail := boolValue(plan.EntityCall.Parameters["detail"])
 	rows := make([]map[string]any, 0)
-	for _, link := range snapshot.Elements {
-		if link.Kind != "data_link" {
-			continue
-		}
-		src := refFromSpec(link.Spec, "src")
-		dest := refFromSpec(link.Spec, "dest")
-		if src.Kind != "entity_set" || src.Domain != stringFilter(plan.Filters["domain"]) || src.Name != stringFilter(plan.Filters["name"]) {
-			continue
-		}
-		if len(dataSetTypes) > 0 {
-			if _, ok := dataSetTypes[dest.Kind]; !ok {
-				continue
-			}
-		}
-		dataSet, ok := findUModelElement(snapshot.Elements, dest.Kind, dest.Domain, dest.Name)
-		if !ok {
-			continue
-		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), plan.EntityData) {
-			continue
-		}
-		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, link, dataSet, detail, plan.EntityData)))
+	for _, related := range relatedDataSetsForEntitySet(snapshot.Elements, stringFilter(plan.Filters["domain"]), stringFilter(plan.Filters["name"]), dataSetTypes, plan.EntityData) {
+		rows = append(rows, entityCallRowValues(listDataSetValues(snapshot.Elements, related, detail, plan.EntityData)))
 	}
 	return entitySetAssistantRawResponse(listDataSetHeader(), rows), nil
 }
@@ -212,6 +192,13 @@ type setRef struct {
 type storageBinding struct {
 	Link    model.UModelElement
 	Storage model.UModelElement
+}
+
+type relatedDataSet struct {
+	Link                  model.UModelElement
+	HasLink               bool
+	DataSet               model.UModelElement
+	FilterStorageByEntity bool
 }
 
 func entityCallRowValues(values []string) map[string]any {
@@ -355,12 +342,18 @@ func listDataSetHeader() []string {
 	return []string{"data_set_id", "type", "domain", "name", "fields_mapping", "filterable_fields", "fields", "storage_info", "storage_link_info", "data_link_detail", "data_set_detail", "storage_detail", "storage_link_detail"}
 }
 
-func listDataSetValues(elements []model.UModelElement, link model.UModelElement, dataSet model.UModelElement, detail bool, entityData *model.EntityData) []string {
-	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet, entityData)
+func listDataSetValues(elements []model.UModelElement, related relatedDataSet, detail bool, entityData *model.EntityData) []string {
+	link := related.Link
+	dataSet := related.DataSet
+	storageInfo, storageLinkInfo, storageDetail, storageLinkDetail := storageDetailsForDataSet(elements, dataSet, entityData, related.FilterStorageByEntity)
 	dataLinkDetail := "{}"
 	dataSetDetail := "{}"
 	if detail {
-		dataLinkDetail = mustJSON(link)
+		if related.HasLink {
+			dataLinkDetail = mustJSON(link)
+		} else {
+			dataLinkDetail = "null"
+		}
 		dataSetDetail = mustJSON(dataSet)
 	} else {
 		storageDetail = []model.UModelElement{}
@@ -374,7 +367,7 @@ func listDataSetValues(elements []model.UModelElement, link model.UModelElement,
 		dataSet.Name,
 		mustJSON(fieldsMapping),
 		mustJSON(filterableFields(dataSet)),
-		mustJSON(dataSet.Spec["fields"]),
+		mustJSON(dataSetFields(dataSet)),
 		mustJSON(storageInfo),
 		mustJSON(storageLinkInfo),
 		dataLinkDetail,
@@ -384,7 +377,47 @@ func listDataSetValues(elements []model.UModelElement, link model.UModelElement,
 	}
 }
 
-func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
+func relatedDataSetsForEntitySet(elements []model.UModelElement, entityDomain, entityName string, dataSetTypes map[string]struct{}, entityData *model.EntityData) []relatedDataSet {
+	out := []relatedDataSet{}
+	seen := map[string]struct{}{}
+	for _, link := range elements {
+		if link.Kind != "data_link" {
+			continue
+		}
+		src := refFromSpec(link.Spec, "src")
+		dest := refFromSpec(link.Spec, "dest")
+		if src.Kind != "entity_set" || src.Domain != entityDomain || src.Name != entityName {
+			continue
+		}
+		if !dataSetTypeAllowed(dataSetTypes, dest.Kind) {
+			continue
+		}
+		dataSet, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name)
+		if !ok {
+			continue
+		}
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
+			continue
+		}
+		out = append(out, relatedDataSet{Link: link, HasLink: true, DataSet: dataSet, FilterStorageByEntity: true})
+		seen[uniqueID(dataSet.Domain, dataSet.Kind, dataSet.Name)] = struct{}{}
+	}
+
+	for _, dataSet := range elements {
+		if dataSet.Domain != "default" || !dataSetTypeAllowed(dataSetTypes, dataSet.Kind) {
+			continue
+		}
+		id := uniqueID(dataSet.Domain, dataSet.Kind, dataSet.Name)
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		out = append(out, relatedDataSet{DataSet: dataSet})
+		seen[id] = struct{}{}
+	}
+	return out
+}
+
+func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UModelElement, entityData *model.EntityData, filterByEntity bool) ([]map[string]any, []map[string]any, []model.UModelElement, []model.UModelElement) {
 	storageInfo := []map[string]any{}
 	storageLinkInfo := []map[string]any{}
 	storageDetail := []model.UModelElement{}
@@ -397,7 +430,7 @@ func storageDetailsForDataSet(elements []model.UModelElement, dataSet model.UMod
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if filterByEntity && !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -433,7 +466,7 @@ func findRelatedDataSet(elements []model.UModelElement, entityDomain, entityName
 		if dest.Kind != dataSetKind || dest.Domain != dataSetDomain || dest.Name != dataSetName {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dataSet, ok := findUModelElement(elements, dest.Kind, dest.Domain, dest.Name)
@@ -455,7 +488,7 @@ func storageBindingsForDataSet(elements []model.UModelElement, dataSet model.UMo
 		if src.Domain != dataSet.Domain || src.Kind != dataSet.Kind || src.Name != dataSet.Name {
 			continue
 		}
-		if !filterByEntityAllows(stringValue(link.Spec["filter_by_entity"]), entityData) {
+		if !filterByEntityAllows(filterByEntityExpression(link.Spec), entityData) {
 			continue
 		}
 		dest := refFromSpec(link.Spec, "dest")
@@ -1063,6 +1096,21 @@ func filterByEntityAllows(raw string, entityData *model.EntityData) bool {
 	return false
 }
 
+func filterByEntityExpression(spec map[string]any) string {
+	for _, key := range []string{"filter_by_entity", "filterByEntity", "FilterByEntity"} {
+		if raw := strings.TrimSpace(stringValue(spec[key])); raw != "" {
+			return raw
+		}
+	}
+	src := mapValue(spec["src"])
+	for _, key := range []string{"filter", "Filter"} {
+		if raw := strings.TrimSpace(stringValue(src[key])); raw != "" {
+			return raw
+		}
+	}
+	return ""
+}
+
 func evalFilterByEntity(node *logFilterNode, row map[string]string) bool {
 	if node == nil {
 		return true
@@ -1092,7 +1140,10 @@ func evalFilterByEntity(node *logFilterNode, row map[string]string) bool {
 }
 
 func evalFilterByEntityComparison(node *logFilterNode, row map[string]string) bool {
-	value := row[node.Field]
+	value, ok := row[node.Field]
+	if !ok {
+		return false
+	}
 	expected := stringValue(node.Value)
 	switch node.Operator {
 	case "=", "==", ":":
@@ -1187,6 +1238,24 @@ func findUModelElement(elements []model.UModelElement, kind, domain, name string
 }
 
 func filterableFields(element model.UModelElement) []string {
+	if element.Kind == "metric_set" {
+		labels := mapValue(element.Spec["labels"])
+		keys, ok := labels["keys"].([]any)
+		if !ok {
+			return []string{}
+		}
+		out := []string{}
+		for _, field := range keys {
+			item, ok := field.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name := stringValue(item["name"]); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	}
 	fields, ok := element.Spec["fields"].([]any)
 	if !ok {
 		return []string{}
@@ -1204,6 +1273,55 @@ func filterableFields(element model.UModelElement) []string {
 	return out
 }
 
+func dataSetFields(element model.UModelElement) any {
+	if element.Kind == "metric_set" {
+		metrics, ok := element.Spec["metrics"].([]any)
+		if !ok {
+			return nil
+		}
+		out := make([]map[string]any, 0, len(metrics))
+		for _, metric := range metrics {
+			item, ok := metric.(map[string]any)
+			if !ok {
+				continue
+			}
+			field := map[string]any{
+				"name": stringValue(item["name"]),
+				"type": "metric",
+			}
+			copyFieldInfo(field, item)
+			out = append(out, field)
+		}
+		return out
+	}
+	fields, ok := element.Spec["fields"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(fields))
+	for _, raw := range fields {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		field := map[string]any{
+			"name": stringValue(item["name"]),
+			"type": stringValue(item["type"]),
+		}
+		copyFieldInfo(field, item)
+		out = append(out, field)
+	}
+	return out
+}
+
+func copyFieldInfo(dst, src map[string]any) {
+	for _, key := range []string{"display_name", "description", "data_format", "unit"} {
+		if value, ok := src[key]; ok && stringValue(value) != "" {
+			dst[key] = value
+		}
+	}
+}
+
 func mapValue(value any) map[string]any {
 	if typed, ok := value.(map[string]any); ok {
 		return typed
@@ -1217,6 +1335,18 @@ func stringSet(values []string) map[string]struct{} {
 		out[value] = struct{}{}
 	}
 	return out
+}
+
+func dataSetTypeSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return stringSet([]string{"metric_set", "log_set", "trace_set", "event_set", "profile_set"})
+	}
+	return stringSet(values)
+}
+
+func dataSetTypeAllowed(typeFilter map[string]struct{}, kind string) bool {
+	_, ok := typeFilter[kind]
+	return ok
 }
 
 func uniqueID(domain, kind, name string) string {

--- a/internal/query/service_test.go
+++ b/internal/query/service_test.go
@@ -192,6 +192,178 @@ func TestExecuteEntitySetListDataSetAliasReturnsAssistantRawData(t *testing.T) {
 	}
 }
 
+func TestExecuteEntitySetListDataSetUsesFilterByEntityAndSrcFilter(t *testing.T) {
+	ctx := context.Background()
+	elements := append(metricQueryPlanElements(),
+		testMetricSetElement("devops.metric.premium", "latency"),
+		model.UModelElement{
+			Kind:   "data_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.metric.premium",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service"},
+				"dest":             map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.premium"},
+				"fields_mapping":   map[string]any{"id": "service_id", "environment": "environment"},
+				"filter_by_entity": "environment = 'prod'",
+			},
+		},
+		testMetricSetElement("devops.metric.legacy", "throughput"),
+		model.UModelElement{
+			Kind:   "data_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.metric.legacy",
+			Spec: map[string]any{
+				"src":            map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service", "filter": "environment = 'prod'"},
+				"dest":           map[string]any{"domain": "devops", "kind": "metric_set", "name": "devops.metric.legacy"},
+				"fields_mapping": map[string]any{"id": "service_id", "environment": "environment"},
+			},
+		},
+	)
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	staging, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "staging"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with non-matching entity data: %v", err)
+	}
+	stagingRows := listDataSetRowsByName(t, staging)
+	if _, ok := stagingRows["devops.metric.service"]; !ok {
+		t.Fatalf("unfiltered metric_set should still be listed, got %+v", stagingRows)
+	}
+	if _, ok := stagingRows["devops.metric.premium"]; ok {
+		t.Fatalf("top-level filter_by_entity metric_set should be filtered out, got %+v", stagingRows)
+	}
+	if _, ok := stagingRows["devops.metric.legacy"]; ok {
+		t.Fatalf("src.filter metric_set should be filtered out, got %+v", stagingRows)
+	}
+
+	prod, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id", "environment"},
+			Data:   [][]string{{"svc-1", "prod"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with matching entity data: %v", err)
+	}
+	prodRows := listDataSetRowsByName(t, prod)
+	for _, name := range []string{"devops.metric.service", "devops.metric.premium", "devops.metric.legacy"} {
+		if _, ok := prodRows[name]; !ok {
+			t.Fatalf("expected %s to be listed for matching entity data, got %+v", name, prodRows)
+		}
+	}
+	if got := prodRows["devops.metric.service"][5]; !strings.Contains(got, "service_id") || !strings.Contains(got, "environment") {
+		t.Fatalf("metric_set filterable_fields should come from labels, got %s", got)
+	}
+	if got := prodRows["devops.metric.service"][6]; !strings.Contains(got, `"type":"metric"`) || !strings.Contains(got, "request_count") {
+		t.Fatalf("metric_set fields should come from metrics, got %s", got)
+	}
+
+	noEntityData, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set without entity data: %v", err)
+	}
+	noEntityRows := listDataSetRowsByName(t, noEntityData)
+	for _, name := range []string{"devops.metric.premium", "devops.metric.legacy"} {
+		if _, ok := noEntityRows[name]; !ok {
+			t.Fatalf("expected %s to be listed when entity_data is absent, got %+v", name, noEntityRows)
+		}
+	}
+}
+
+func TestExecuteEntitySetListDataSetKeepsDataSetWhenStorageFilterMisses(t *testing.T) {
+	ctx := context.Background()
+	elements := metricQueryPlanElements()
+	for i := range elements {
+		if elements[i].Kind == "storage_link" {
+			elements[i].Spec["filter_by_entity"] = "region = 'cn-hangzhou'"
+		}
+	}
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], true)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id"},
+			Data:   [][]string{{"svc-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with storage filter miss: %v", err)
+	}
+	rows := listDataSetRowsByName(t, result)
+	values, ok := rows["devops.metric.service"]
+	if !ok {
+		t.Fatalf("data_set should remain visible when only storage filter misses, got %+v", rows)
+	}
+	for _, idx := range []int{7, 8, 11, 12} {
+		if values[idx] != "[]" {
+			t.Fatalf("expected storage field %d to be empty array, got %s", idx, values[idx])
+		}
+	}
+}
+
+func TestExecuteEntitySetListDataSetIncludesDefaultDomainDataSets(t *testing.T) {
+	ctx := context.Background()
+	elements := append(metricQueryPlanElements(),
+		testMetricSetElementWithDomain("default", "default.metric.common", "health_score"),
+		model.UModelElement{
+			Kind:   "storage_link",
+			Domain: "default",
+			Name:   "default.metric.common_to_prometheus",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "default", "kind": "metric_set", "name": "default.metric.common"},
+				"dest":             map[string]any{"domain": "devops", "kind": "prometheus", "name": "devops.prometheus.core"},
+				"fields_mapping":   map[string]any{"service_id": "service_id"},
+				"filter_by_entity": "region = 'cn-hangzhou'",
+			},
+		},
+	)
+	store := graphstore.NewMemoryStore()
+	_, err := store.PutUModelElements(ctx, model.UModelElementBatch{Workspace: "demo", Elements: elements})
+	if err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set'], false)",
+		FilterByEntities: &model.EntityData{
+			Header: []string{"id"},
+			Data:   [][]string{{"svc-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute list_data_set with default data_set: %v", err)
+	}
+	rows := listDataSetRowsByName(t, result)
+	values, ok := rows["default.metric.common"]
+	if !ok {
+		t.Fatalf("expected default domain metric_set to be listed, got %+v", rows)
+	}
+	if values[2] != "default" || values[9] != "{}" || !strings.Contains(values[7], "devops.prometheus.core") {
+		t.Fatalf("unexpected default domain metric_set row: %#v", values)
+	}
+}
+
 func TestExecuteEntitySetGetLogsReturnsQueryPlan(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()
@@ -714,6 +886,53 @@ func entityPayload(id, displayName string) model.EntityPayload {
 		"__first_observed_time__": int64(100),
 		"__last_observed_time__":  int64(200),
 		"display_name":            displayName,
+	}
+}
+
+func listDataSetRowsByName(t *testing.T, result model.QueryResult) map[string][]string {
+	t.Helper()
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected one assistant raw response row, got %+v", result.Rows)
+	}
+	row := result.Rows[0]
+	if row["responseType"] != 2 || row["query"] != "" {
+		t.Fatalf("expected assistant raw data response, got %+v", row)
+	}
+	data, ok := row["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("unexpected list_data_set data: %#v", row["data"])
+	}
+	out := map[string][]string{}
+	for _, item := range data {
+		values, ok := item["values"].([]string)
+		if !ok || len(values) != len(listDataSetHeader()) {
+			t.Fatalf("unexpected list_data_set row: %#v", item)
+		}
+		out[values[3]] = values
+	}
+	return out
+}
+
+func testMetricSetElement(name, metricName string) model.UModelElement {
+	return testMetricSetElementWithDomain("devops", name, metricName)
+}
+
+func testMetricSetElementWithDomain(domain, name, metricName string) model.UModelElement {
+	return model.UModelElement{
+		Kind:   "metric_set",
+		Domain: domain,
+		Name:   name,
+		Spec: map[string]any{
+			"labels": map[string]any{
+				"keys": []any{
+					map[string]any{"name": "service_id", "type": "string"},
+					map[string]any{"name": "environment", "type": "string"},
+				},
+			},
+			"metrics": []any{
+				map[string]any{"name": metricName, "unit": "count"},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- align entity_set list_data_set discovery with umodel-assistant behavior
- support DataLink and StorageLink filter_by_entity plus legacy src.filter fallback
- include default-domain data sets and return MetricSet labels/metrics in assistant-compatible columns

## Validation
- go test ./internal/query
- go test ./...
- Browser: executed list_data_set on http://localhost:5173/workspaces/demo/query and confirmed 3 rows / 13 columns for devops.service