### PR TITLE
feat(query): introduce plan/data mode protocol and plan JSON v1

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -56,6 +56,12 @@ Documentation root: [docs/README.md](../README.md)
 - [Public Domain Models](../../pkg/model/types.go)
 - [Stable Error Codes](../../pkg/errors/errors.go)
 
+## Specifications
+
+Cross-implementation contracts that bind both `unified-model` (open source) and `umodel-assistant` (commercial). Breaking either is a P0 regression.
+
+- [Plan Schema v1](spec/plan-schema-v1.md) - mode protocol, plan JSON envelope, and aligned method signatures for `get_metrics` / `get_logs`.
+
 ## Generated Schema HTML
 
 - [English generated schema HTML](../html_en/index.html)

--- a/docs/en/spec/plan-schema-v1.md
+++ b/docs/en/spec/plan-schema-v1.md
@@ -1,0 +1,204 @@
+# Plan Schema v1
+
+中文：[Plan Schema v1](../../zh/spec/plan-schema-v1.md)
+
+> Specification status: **v1**, normative.
+> Scope: unified-model (open source) and umodel-assistant (commercial).
+> Owner: UModel maintainers. Breaking changes require a new major version.
+
+This document defines the shared contract between the **plan** mode returned by `unified-model` and the **plan / data** modes supported by `umodel-assistant`. Both projects must conform; either side breaking this contract is treated as a P0 regression.
+
+## Why this exists
+
+UModel runs as two coordinated surfaces:
+
+- **unified-model** (open source) is a *plan provider*. It accepts an SPL query, resolves the EntitySet, DataLink, Storage, and StorageLink involved, and returns a **query plan** — a serialized description of what a downstream executor would need to run.
+- **umodel-assistant** (commercial PaaS) is a *plan executor*. It additionally takes a plan and runs it against real storage (SLS, Prometheus, Elasticsearch, etc.), returning time series, log rows, and other concrete data.
+
+For a user to migrate from open source to PaaS without touching their SPL or client code, both surfaces must share:
+
+1. The same method signatures (parameters a parser accepts).
+2. The same plan JSON shape (what an executor consumes).
+3. The same mode protocol (how clients ask for a plan vs. data).
+
+Plan Schema v1 fixes that contract.
+
+## 1. Mode protocol
+
+### Request
+
+Clients indicate the desired mode either through the HTTP `?mode=` query parameter or via the request body:
+
+```http
+POST /api/v1/query/{workspace}/execute?mode=plan
+Content-Type: application/json
+
+{ "query": ".entity_set with(...) | entity-call get_metrics(...)", "mode": "plan" }
+```
+
+When both the body field and the query parameter are present, the body wins. When neither is present, the server applies its `default_mode`.
+
+### Supported values
+
+| Mode    | Meaning                                    | unified-model | umodel-assistant |
+|---------|--------------------------------------------|---------------|------------------|
+| `plan`  | Return a query plan; do not execute        | supported     | supported        |
+| `data`  | Execute the plan; return rows of data      | rejected      | supported        |
+
+unified-model rejects `mode=data` with HTTP 4xx and error code `NOT_IMPLEMENTED`. The error message must include a pointer to umodel-assistant so clients can migrate.
+
+### Capabilities discovery
+
+Servers expose their capabilities at `GET /api/v1/capabilities`:
+
+```json
+{
+  "service": "unified-model",
+  "version": "<server version>",
+  "modes_supported": ["plan"],
+  "default_mode": "plan"
+}
+```
+
+SDKs and CLIs should call `/api/v1/capabilities` once at startup and adjust their default behavior accordingly. Hard-coding mode assumptions is non-compliant.
+
+## 2. Plan JSON v1
+
+A plan response is wrapped in the standard assistant query envelope:
+
+```json
+{
+  "responseType": 1,
+  "query": "<JSON-encoded plan>",
+  "header": [],
+  "data": []
+}
+```
+
+The `query` field is a JSON-encoded string. After decoding, the plan must conform to the following shape:
+
+```jsonc
+{
+  "mode": "plan",                     // discriminator; always "plan" in plan mode
+  "version": "v1",                    // schema version; follows SemVer
+  "operation": "get_metrics",         // entity-call method canonical name
+  "data_source": {
+    "data_set":    { "domain", "kind", "name" },
+    "storage":     { "domain", "type", "name", "config" },
+    "data_link":   { "domain", "name", "spec" },
+    "storage_link":{ "domain", "name", "spec" }
+  },
+  "params_echo": {                    // caller-supplied entity-call params
+    "metric": "request_count",        // empty strings and nil stripped
+    "step":   "30s",
+    "aggregate": false                // executors recover full call context here
+  },
+  "query": { /* method-specific storage query */ },
+  "time_range": {                     // present only when set on the request
+    "from": "...",
+    "to":   "..."
+  }
+}
+```
+
+### Top-level fields
+
+| Field         | Type   | Required | Notes                                              |
+|---------------|--------|----------|----------------------------------------------------|
+| `mode`        | string | yes      | Always `"plan"`. Mirrors request mode.             |
+| `version`     | string | yes      | `"v1"` for this spec. Bumps follow SemVer.         |
+| `operation`   | string | yes      | Canonical entity-call name (`get_metrics`, etc.).  |
+| `data_source` | object | yes      | Resolved DataSet, Storage, DataLink, StorageLink.  |
+| `params_echo` | object | yes      | Caller-supplied params, nil/empty stripped.        |
+| `query`       | object | yes      | Storage-specific executable query.                 |
+| `time_range`  | object | no       | Present when the request supplied a time range.    |
+
+### `data_source` substructure
+
+| Field                | Type    | Notes                                              |
+|----------------------|---------|----------------------------------------------------|
+| `data_set.domain`    | string  | Owning domain.                                     |
+| `data_set.kind`      | string  | `metric_set` / `log_set` / etc.                    |
+| `data_set.name`      | string  | DataSet name.                                      |
+| `storage.domain`     | string  | Storage element domain.                            |
+| `storage.type`       | string  | Storage kind (`prometheus`, `elasticsearch`, ...). |
+| `storage.name`       | string  | Storage element name.                              |
+| `storage.config`     | object  | Storage element spec, opaque to executor framework.|
+| `data_link.spec`     | object  | Full DataLink spec including `fields_mapping`.     |
+| `storage_link.spec`  | object  | Full StorageLink spec including `fields_mapping`.  |
+
+### `params_echo` semantics
+
+`params_echo` MUST contain every entity-call parameter the caller actually supplied, with values preserved at their native JSON type (boolean stays boolean, number stays number, string stays string). Empty strings and `null` values MUST be stripped so an executor cannot mistake an unset parameter for an explicit empty value. Defaults from the method signature are **not** echoed unless the caller actually set them.
+
+## 3. Method signature contract
+
+`get_metrics` and `get_logs` declare the union of all parameters either side may accept. The open-source planner ignores some of them; the PaaS executor consumes them all. Both sides surface the same set through `__list_method__`.
+
+### `get_metrics`
+
+| Key              | Type      | Required | OSS consumes | PaaS consumes | Default |
+|------------------|-----------|----------|--------------|---------------|---------|
+| `domain`         | varchar   | yes      | ✓            | ✓             |         |
+| `name`           | varchar   | yes      | ✓            | ✓             |         |
+| `metric`         | varchar   | no       | ✓            | ✓             |         |
+| `query`          | varchar   | no       | ✓            | ✓             |         |
+| `query_type`     | varchar   | no       | ✓            | ✓             |         |
+| `step`           | varchar   | no       | ✓            | ✓             |         |
+| `aggregate`      | boolean   | no       | echo only    | ✓             | `true`  |
+| `storage_domain` | varchar   | no       | echo only    | ✓             |         |
+| `storage_name`   | varchar   | no       | echo only    | ✓             |         |
+| `storage_kind`   | varchar   | no       | echo only    | ✓             |         |
+
+### `get_logs`
+
+| Key              | Type    | Required | OSS consumes | PaaS consumes |
+|------------------|---------|----------|--------------|---------------|
+| `domain`         | varchar | yes      | ✓            | ✓             |
+| `name`           | varchar | yes      | ✓            | ✓             |
+| `query`          | varchar | no       | ✓            | ✓             |
+| `storage_domain` | varchar | no       | echo only    | ✓             |
+| `storage_name`   | varchar | no       | echo only    | ✓             |
+| `storage_kind`   | varchar | no       | echo only    | ✓             |
+
+The open-source parser MUST accept every parameter in these tables. "Echo only" means the planner records the value in `params_echo` but does not use it to alter the plan content.
+
+### Aliases
+
+Both sides expose canonical and alias names. unified-model normalizes `get_log` → `get_logs` and `get_metric` → `get_metrics` at parse time. umodel-assistant uses the singular form as canonical and accepts the plural as an alias. Either spelling MUST round-trip through both sides without behavior change.
+
+## 4. Compatibility rules
+
+The contract follows SemVer:
+
+- **Minor bump within v1**: additive top-level fields, additive method parameters, broader value types. Existing consumers MUST keep working.
+- **Major bump (v2+)**: any breaking change — renamed/removed top-level fields, removed method parameters, altered field types, changed required/optional flags.
+
+Open-source unified-model MUST NOT introduce any method, parameter, or plan field that does not exist in umodel-assistant. PaaS is the source of truth; the open-source surface is a subset.
+
+Either side proposing a v2 MUST publish an RFC, ship a migration window, and update this spec in lockstep with the new release.
+
+## 5. Non-goals
+
+This spec deliberately does NOT specify:
+
+- The shape of `data`-mode responses on umodel-assistant (rows, labels, sample arrays). Those are PaaS-internal contracts; only the *transition* from plan to data is bound here.
+- Storage executor internals (how PromQL is dispatched, how Elasticsearch DSL is built). Plans contain enough metadata for executors to do their job; the *how* is implementation-defined.
+- Migration tooling that copies workspaces or entities from open source to PaaS. That is a separate effort tracked outside this spec.
+
+## 6. Enforcement
+
+Both projects MUST keep contract tests that:
+
+- Decode a plan emitted by unified-model and verify all required v1 fields are present.
+- Verify that the umodel-assistant plan parser accepts the unified-model plan output verbatim.
+- Verify that `__list_method__` on each side reports the parameters in §3.
+
+Any test failure in this set blocks merge on both repos.
+
+## See also
+
+- [Query Service Guide](../guides/query-service.md)
+- [GraphStore Providers](../graphstore-providers.md)
+- [Public Domain Models](../../../pkg/model/types.go)
+- [Stable Error Codes](../../../pkg/errors/errors.go)

--- a/docs/en/spec/plan-schema-v1.md
+++ b/docs/en/spec/plan-schema-v1.md
@@ -45,7 +45,15 @@ When both the body field and the query parameter are present, the body wins. Whe
 | `plan`  | Return a query plan; do not execute        | supported     | supported        |
 | `data`  | Execute the plan; return rows of data      | rejected      | supported        |
 
-unified-model rejects `mode=data` with HTTP 4xx and error code `NOT_IMPLEMENTED`. The error message must include a pointer to umodel-assistant so clients can migrate.
+unified-model rejects `mode=data` with HTTP 4xx and error code `NOT_IMPLEMENTED`. The error MUST also carry structured migration hints in `details` so an AI agent can act on the failure without parsing the message:
+
+| Key                   | Example                                                                  |
+|-----------------------|--------------------------------------------------------------------------|
+| `requested_mode`      | `"data"`                                                                 |
+| `supported_modes`     | `"plan"`                                                                 |
+| `migration_service`   | `"umodel-assistant"`                                                     |
+| `migration_action`    | `"switch_endpoint_to_umodel_assistant"`                                  |
+| `migration_docs_url`  | URL of this spec or the umodel-assistant migration guide                 |
 
 ### Capabilities discovery
 
@@ -82,6 +90,9 @@ The `query` field is a JSON-encoded string. After decoding, the plan must confor
   "mode": "plan",                     // discriminator; always "plan" in plan mode
   "version": "v1",                    // schema version; follows SemVer
   "operation": "get_metrics",         // entity-call method canonical name
+  "description": "Retrieve metric \"request_count\" from MetricSet devops/devops.metric.service with step 30s (storage: prometheus/devops.prometheus.core). Forward this plan to a UModel data executor (e.g. umodel-assistant) to fetch real time series.",
+  "next_action": "forward_to_executor", // recommended next step for an agent
+  "source_query": ".entity_set with(...) | entity-call get_metrics(...)", // echo of the original SPL
   "data_source": {
     "data_set":    { "domain", "kind", "name" },
     "storage":     { "domain", "type", "name", "config" },
@@ -103,15 +114,26 @@ The `query` field is a JSON-encoded string. After decoding, the plan must confor
 
 ### Top-level fields
 
-| Field         | Type   | Required | Notes                                              |
-|---------------|--------|----------|----------------------------------------------------|
-| `mode`        | string | yes      | Always `"plan"`. Mirrors request mode.             |
-| `version`     | string | yes      | `"v1"` for this spec. Bumps follow SemVer.         |
-| `operation`   | string | yes      | Canonical entity-call name (`get_metrics`, etc.).  |
-| `data_source` | object | yes      | Resolved DataSet, Storage, DataLink, StorageLink.  |
-| `params_echo` | object | yes      | Caller-supplied params, nil/empty stripped.        |
-| `query`       | object | yes      | Storage-specific executable query.                 |
-| `time_range`  | object | no       | Present when the request supplied a time range.    |
+| Field          | Type   | Required | Notes                                              |
+|----------------|--------|----------|----------------------------------------------------|
+| `mode`         | string | yes      | Always `"plan"`. Mirrors request mode.             |
+| `version`      | string | yes      | `"v1"` for this spec. Bumps follow SemVer.         |
+| `operation`    | string | yes      | Canonical entity-call name (`get_metrics`, etc.).  |
+| `description`  | string | yes      | One-line human-readable summary of the plan.       |
+| `next_action`  | string | yes      | Recommended next step. Currently `"forward_to_executor"`. |
+| `source_query` | string | yes      | Echo of the original SPL the caller submitted.     |
+| `data_source`  | object | yes      | Resolved DataSet, Storage, DataLink, StorageLink.  |
+| `params_echo`  | object | yes      | Caller-supplied params, nil/empty stripped.        |
+| `query`        | object | yes      | Storage-specific executable query.                 |
+| `time_range`   | object | no       | Present when the request supplied a time range.    |
+
+### Agent-facing fields
+
+`description`, `next_action`, and `source_query` exist so an AI agent can act on a plan without parsing the inner storage query or re-deriving the user's intent:
+
+- **`description`** — one-line summary the agent can relay back to the user. Includes the metric/log set, filter clause (in `[...]`), and storage info.
+- **`next_action`** — discriminator the agent uses to decide what to do next. `"forward_to_executor"` means: do not try to execute the storage query yourself; hand the plan off to a UModel data executor (e.g. umodel-assistant). Future values may include `"render_to_user"` or `"prompt_for_consent"`.
+- **`source_query`** — the original SPL the caller submitted. Useful in multi-agent pipelines where the agent receiving the plan did not originate the query.
 
 ### `data_source` substructure
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -56,6 +56,12 @@ English: [UModel Documentation](../en/README.md)
 - [公共领域模型](../../pkg/model/types.go)
 - [稳定错误码](../../pkg/errors/errors.go)
 
+## 规范
+
+跨实现的契约文档，同时约束 `unified-model`（开源）与 `umodel-assistant`（商业版）。任一方破坏视为 P0 回归。
+
+- [Plan Schema v1](spec/plan-schema-v1.md) - mode 协议、plan JSON 信封以及 `get_metrics` / `get_logs` 的对齐方法签名。
+
 ## 生成的 Schema 文档
 
 - [中文 Schema HTML](../html_cn/index.html)

--- a/docs/zh/spec/plan-schema-v1.md
+++ b/docs/zh/spec/plan-schema-v1.md
@@ -1,0 +1,204 @@
+# Plan Schema v1
+
+English: [Plan Schema v1](../../en/spec/plan-schema-v1.md)
+
+> 规范状态：**v1**，强制约束。
+> 范围：unified-model（开源）与 umodel-assistant（商业版）。
+> Owner：UModel maintainers。Breaking change 必须升至新的 major 版本。
+
+本文档定义 `unified-model` 返回的 **plan** 模式与 `umodel-assistant` 支持的 **plan / data** 模式之间的共享契约。两端必须同时遵守；任一方破坏该契约都视为 P0 回归。
+
+## 为什么需要这份规范
+
+UModel 由两个协同的服务面组成：
+
+- **unified-model**（开源）是 *plan provider*。接收一条 SPL 查询，解析涉及到的 EntitySet、DataLink、Storage、StorageLink，返回一个 **查询计划** —— 描述下游 executor 需要执行什么的序列化结构。
+- **umodel-assistant**（商业 PaaS）是 *plan executor*。它在 plan 之上能进一步针对真实存储（SLS、Prometheus、Elasticsearch 等）执行查询，返回时序数据、日志行等具体数据。
+
+要让用户从开源迁移到 PaaS 时不改 SPL、不改客户端代码，两端必须共享：
+
+1. 相同的方法签名（parser 接受的参数集合）。
+2. 相同的 plan JSON 形态（executor 消费的契约）。
+3. 相同的 mode 协议（客户端如何区分要 plan 还是 data）。
+
+Plan Schema v1 固定这个契约。
+
+## 1. Mode 协议
+
+### 请求
+
+客户端通过 HTTP `?mode=` query 参数或请求 body 指定期望的模式：
+
+```http
+POST /api/v1/query/{workspace}/execute?mode=plan
+Content-Type: application/json
+
+{ "query": ".entity_set with(...) | entity-call get_metrics(...)", "mode": "plan" }
+```
+
+当 body 字段与 query 参数同时存在时，**body 优先**。两者都缺省时，服务端按自己的 `default_mode` 兜底。
+
+### 支持值
+
+| Mode    | 含义                              | unified-model | umodel-assistant |
+|---------|-----------------------------------|---------------|------------------|
+| `plan`  | 返回查询计划，不执行              | 支持          | 支持             |
+| `data`  | 执行计划，返回真实数据            | 拒绝          | 支持             |
+
+unified-model 收到 `mode=data` 时返回 HTTP 4xx + 错误码 `NOT_IMPLEMENTED`。错误消息必须指向 umodel-assistant，便于客户端迁移。
+
+### 能力发现
+
+服务端在 `GET /api/v1/capabilities` 暴露能力：
+
+```json
+{
+  "service": "unified-model",
+  "version": "<服务版本>",
+  "modes_supported": ["plan"],
+  "default_mode": "plan"
+}
+```
+
+SDK / CLI 启动时应当调用一次 `/api/v1/capabilities` 并据此调整默认行为。硬编码 mode 假设视为不合规。
+
+## 2. Plan JSON v1
+
+Plan 响应被包装在标准的 assistant query 信封里：
+
+```json
+{
+  "responseType": 1,
+  "query": "<JSON 编码后的 plan>",
+  "header": [],
+  "data": []
+}
+```
+
+`query` 字段是一个 JSON 编码字符串。反序列化后必须符合以下结构：
+
+```jsonc
+{
+  "mode": "plan",                     // 模式判别字段；plan 模式下永远是 "plan"
+  "version": "v1",                    // schema 版本，遵循 SemVer
+  "operation": "get_metrics",         // entity-call 方法的规范名
+  "data_source": {
+    "data_set":    { "domain", "kind", "name" },
+    "storage":     { "domain", "type", "name", "config" },
+    "data_link":   { "domain", "name", "spec" },
+    "storage_link":{ "domain", "name", "spec" }
+  },
+  "params_echo": {                    // 调用方实际传入的 entity-call 参数
+    "metric": "request_count",        // nil 与空字符串被剔除
+    "step":   "30s",
+    "aggregate": false                // executor 在这里恢复完整调用上下文
+  },
+  "query": { /* 与方法相关的存储侧查询 */ },
+  "time_range": {                     // 仅当请求设置了时间范围时出现
+    "from": "...",
+    "to":   "..."
+  }
+}
+```
+
+### 顶层字段
+
+| 字段          | 类型   | 必填 | 备注                                            |
+|---------------|--------|------|-------------------------------------------------|
+| `mode`        | string | 是   | 永远 `"plan"`，镜像请求 mode。                  |
+| `version`     | string | 是   | 当前规范为 `"v1"`，遵循 SemVer。                |
+| `operation`   | string | 是   | entity-call 规范名（`get_metrics` 等）。        |
+| `data_source` | object | 是   | 解析后的 DataSet / Storage / DataLink / StorageLink。 |
+| `params_echo` | object | 是   | 调用方实际传入的参数，剔除 nil 与空字符串。     |
+| `query`       | object | 是   | 存储侧可执行的具体查询。                        |
+| `time_range`  | object | 否   | 请求带时间范围时出现。                          |
+
+### `data_source` 子结构
+
+| 字段                 | 类型    | 备注                                              |
+|----------------------|---------|---------------------------------------------------|
+| `data_set.domain`    | string  | 所属 domain。                                     |
+| `data_set.kind`      | string  | `metric_set` / `log_set` 等。                     |
+| `data_set.name`      | string  | DataSet 名称。                                    |
+| `storage.domain`     | string  | Storage 元素 domain。                             |
+| `storage.type`       | string  | Storage 种类（`prometheus` / `elasticsearch` 等）。|
+| `storage.name`       | string  | Storage 元素名称。                                |
+| `storage.config`     | object  | Storage 元素 spec，对 executor 框架不透明。       |
+| `data_link.spec`     | object  | 完整 DataLink spec，含 `fields_mapping`。         |
+| `storage_link.spec`  | object  | 完整 StorageLink spec，含 `fields_mapping`。      |
+
+### `params_echo` 语义
+
+`params_echo` 必须包含调用方实际传入的每个 entity-call 参数，原生 JSON 类型保留（boolean 保留 boolean、number 保留 number、string 保留 string）。空字符串与 `null` 值必须剔除，避免 executor 把"未设置"误当作"显式空值"。方法签名里的默认值不会被回显，除非调用方真的传了。
+
+## 3. 方法签名契约
+
+`get_metrics` 与 `get_logs` 声明两端任意一方都可能接受的全部参数。开源 planner 只消费其中一部分；PaaS executor 全部消费。两端必须通过 `__list_method__` 暴露同一组参数。
+
+### `get_metrics`
+
+| Key              | 类型      | 必填 | OSS 消费 | PaaS 消费 | 默认值   |
+|------------------|-----------|------|----------|-----------|----------|
+| `domain`         | varchar   | 是   | ✓        | ✓         |          |
+| `name`           | varchar   | 是   | ✓        | ✓         |          |
+| `metric`         | varchar   | 否   | ✓        | ✓         |          |
+| `query`          | varchar   | 否   | ✓        | ✓         |          |
+| `query_type`     | varchar   | 否   | ✓        | ✓         |          |
+| `step`           | varchar   | 否   | ✓        | ✓         |          |
+| `aggregate`      | boolean   | 否   | 仅回显   | ✓         | `true`   |
+| `storage_domain` | varchar   | 否   | 仅回显   | ✓         |          |
+| `storage_name`   | varchar   | 否   | 仅回显   | ✓         |          |
+| `storage_kind`   | varchar   | 否   | 仅回显   | ✓         |          |
+
+### `get_logs`
+
+| Key              | 类型    | 必填 | OSS 消费 | PaaS 消费 |
+|------------------|---------|------|----------|-----------|
+| `domain`         | varchar | 是   | ✓        | ✓         |
+| `name`           | varchar | 是   | ✓        | ✓         |
+| `query`          | varchar | 否   | ✓        | ✓         |
+| `storage_domain` | varchar | 否   | 仅回显   | ✓         |
+| `storage_name`   | varchar | 否   | 仅回显   | ✓         |
+| `storage_kind`   | varchar | 否   | 仅回显   | ✓         |
+
+开源 parser 必须接受这两张表里列出的全部参数。"仅回显"指 planner 把值记录到 `params_echo`，但不影响 plan 内容生成。
+
+### 别名
+
+两端都同时支持规范名与别名。unified-model 在 parse 阶段把 `get_log` 归一化为 `get_logs`、`get_metric` 归一化为 `get_metrics`。umodel-assistant 以单数为规范名，复数作为别名。无论写哪种拼法，行为必须一致。
+
+## 4. 兼容性规则
+
+契约遵循 SemVer：
+
+- **v1 内的 minor bump**：可加顶层字段、可加方法参数、可拓宽取值类型。现有 consumer 必须仍然可用。
+- **major bump（v2+）**：任何破坏性变更——重命名/删除顶层字段、删除方法参数、改字段类型、改必填/选填标记。
+
+unified-model（开源）不得引入 umodel-assistant 没有的方法、参数或 plan 字段。PaaS 是 source of truth，开源面是其子集。
+
+任一方提议升级到 v2 必须先发 RFC、提供迁移窗口，并在新版本发布的同时更新本文档。
+
+## 5. 非目标
+
+本规范**不**约定：
+
+- umodel-assistant 在 `data` 模式下返回的具体行结构（rows、labels、采样数组）。那些是 PaaS 内部契约；此处只约束 plan→data 的转换边界。
+- 存储 executor 的实现细节（PromQL 如何派发、ES DSL 如何拼装）。Plan 已含足够元数据，"怎么执行"由实现自定。
+- 把 workspace / 实体从开源拷贝到 PaaS 的迁移工具，由本规范以外的工作跟进。
+
+## 6. 强制约束
+
+两端必须维护契约测试：
+
+- 解码 unified-model 输出的 plan，校验所有 v1 必填字段齐全。
+- 校验 umodel-assistant 的 plan parser 能原样接受 unified-model 的 plan 输出。
+- 校验两端 `__list_method__` 报出的参数符合 §3。
+
+该测试集任意失败均阻断两边 repo 的 merge。
+
+## 相关文档
+
+- [Query Service Guide](../guides/query-service.md)
+- [GraphStore Providers](../graphstore-providers.md)
+- [公共 Go 模型](../../../pkg/model/types.go)
+- [稳定错误码](../../../pkg/errors/errors.go)

--- a/docs/zh/spec/plan-schema-v1.md
+++ b/docs/zh/spec/plan-schema-v1.md
@@ -45,7 +45,15 @@ Content-Type: application/json
 | `plan`  | 返回查询计划，不执行              | 支持          | 支持             |
 | `data`  | 执行计划，返回真实数据            | 拒绝          | 支持             |
 
-unified-model 收到 `mode=data` 时返回 HTTP 4xx + 错误码 `NOT_IMPLEMENTED`。错误消息必须指向 umodel-assistant，便于客户端迁移。
+unified-model 收到 `mode=data` 时返回 HTTP 4xx + 错误码 `NOT_IMPLEMENTED`。错误结构 `details` 里必须带结构化迁移信息，便于 AI agent 直接消费而非解析自然语言：
+
+| Key                   | 示例                                                                     |
+|-----------------------|--------------------------------------------------------------------------|
+| `requested_mode`      | `"data"`                                                                 |
+| `supported_modes`     | `"plan"`                                                                 |
+| `migration_service`   | `"umodel-assistant"`                                                     |
+| `migration_action`    | `"switch_endpoint_to_umodel_assistant"`                                  |
+| `migration_docs_url`  | 本规范或 umodel-assistant 迁移指南的 URL                                 |
 
 ### 能力发现
 
@@ -82,6 +90,9 @@ Plan 响应被包装在标准的 assistant query 信封里：
   "mode": "plan",                     // 模式判别字段；plan 模式下永远是 "plan"
   "version": "v1",                    // schema 版本，遵循 SemVer
   "operation": "get_metrics",         // entity-call 方法的规范名
+  "description": "Retrieve metric \"request_count\" from MetricSet devops/devops.metric.service with step 30s (storage: prometheus/devops.prometheus.core). Forward this plan to a UModel data executor (e.g. umodel-assistant) to fetch real time series.",
+  "next_action": "forward_to_executor", // 给 agent 的下一步建议
+  "source_query": ".entity_set with(...) | entity-call get_metrics(...)", // 原始 SPL 回显
   "data_source": {
     "data_set":    { "domain", "kind", "name" },
     "storage":     { "domain", "type", "name", "config" },
@@ -103,15 +114,26 @@ Plan 响应被包装在标准的 assistant query 信封里：
 
 ### 顶层字段
 
-| 字段          | 类型   | 必填 | 备注                                            |
-|---------------|--------|------|-------------------------------------------------|
-| `mode`        | string | 是   | 永远 `"plan"`，镜像请求 mode。                  |
+| 字段           | 类型   | 必填 | 备注                                            |
+|----------------|--------|------|-------------------------------------------------|
+| `mode`         | string | 是   | 永远 `"plan"`，镜像请求 mode。                  |
 | `version`     | string | 是   | 当前规范为 `"v1"`，遵循 SemVer。                |
-| `operation`   | string | 是   | entity-call 规范名（`get_metrics` 等）。        |
-| `data_source` | object | 是   | 解析后的 DataSet / Storage / DataLink / StorageLink。 |
-| `params_echo` | object | 是   | 调用方实际传入的参数，剔除 nil 与空字符串。     |
-| `query`       | object | 是   | 存储侧可执行的具体查询。                        |
-| `time_range`  | object | 否   | 请求带时间范围时出现。                          |
+| `operation`    | string | 是   | entity-call 规范名（`get_metrics` 等）。        |
+| `description`  | string | 是   | 一句话描述 plan 做什么，便于 agent 复述。       |
+| `next_action`  | string | 是   | 给 agent 的下一步建议。当前固定 `"forward_to_executor"`。|
+| `source_query` | string | 是   | 调用方提交的原始 SPL 回显。                     |
+| `data_source`  | object | 是   | 解析后的 DataSet / Storage / DataLink / StorageLink。 |
+| `params_echo`  | object | 是   | 调用方实际传入的参数，剔除 nil 与空字符串。     |
+| `query`        | object | 是   | 存储侧可执行的具体查询。                        |
+| `time_range`   | object | 否   | 请求带时间范围时出现。                          |
+
+### Agent 友好字段
+
+`description` / `next_action` / `source_query` 这三个字段是给 AI Agent 准备的，避免 agent 自己反向解析存储侧 query 或者推断用户意图：
+
+- **`description`** —— 一句话总结，agent 可以直接复述给用户。包含 metric / log set、过滤条件（用 `[...]` 包裹）以及存储信息。
+- **`next_action`** —— agent 用来判别下一步动作的字段。`"forward_to_executor"` 表示：不要自己执行存储侧 query，把 plan 转发给 UModel data executor（如 umodel-assistant）。后续可能加入 `"render_to_user"`、`"prompt_for_consent"` 等。
+- **`source_query`** —— 调用方提交的原始 SPL。多 agent 协作场景里，下游 agent 没有用户输入的上下文时靠这个字段恢复。
 
 ### `data_source` 子结构
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -130,6 +130,7 @@ func (a *App) apiMux(includeRoot bool) *http.ServeMux {
 		mux.HandleFunc("/", a.handleRoot)
 	}
 	mux.HandleFunc("/healthz", a.handleHealth)
+	mux.HandleFunc("/api/v1/capabilities", a.handleCapabilities)
 	mux.HandleFunc("/api/v1/workspaces", a.handleWorkspaces)
 	mux.HandleFunc("/api/v1/workspaces/", a.handleWorkspace)
 	mux.HandleFunc("/api/v1/umodel/", a.handleUModel)
@@ -257,6 +258,27 @@ func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "graphstore": health})
 }
 
+// serviceVersion is the unified-model service version reported via
+// /api/v1/capabilities. Build tooling can override at link time via
+// -ldflags "-X github.com/alibaba/UnifiedModel/internal/bootstrap.serviceVersion=<v>".
+var serviceVersion = "dev"
+
+// handleCapabilities reports what query modes this server supports.
+// unified-model is plan-only by design; umodel-assistant supports plan and data.
+// See docs/en/spec/plan-schema-v1.md for the shared mode protocol.
+func (a *App) handleCapabilities(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, apperrors.New(apperrors.CodeInvalidArgument, "method not allowed"))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"service":         "unified-model",
+		"version":         serviceVersion,
+		"modes_supported": []string{"plan"},
+		"default_mode":    "plan",
+	})
+}
+
 func (a *App) handleWorkspaces(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
@@ -341,6 +363,11 @@ func (a *App) handleQuery(w http.ResponseWriter, r *http.Request) {
 	var req model.QueryRequest
 	if !decodeJSON(w, r, &req) {
 		return
+	}
+	if req.Mode == "" {
+		if mode := r.URL.Query().Get("mode"); mode != "" {
+			req.Mode = mode
+		}
 	}
 	switch action {
 	case "execute":

--- a/internal/bootstrap/capabilities_test.go
+++ b/internal/bootstrap/capabilities_test.go
@@ -1,0 +1,97 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+func TestCapabilitiesReportsPlanOnly(t *testing.T) {
+	handler := NewMemoryApp(t.TempDir()).Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/capabilities", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var payload struct {
+		Service        string   `json:"service"`
+		Version        string   `json:"version"`
+		ModesSupported []string `json:"modes_supported"`
+		DefaultMode    string   `json:"default_mode"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if payload.Service != "unified-model" {
+		t.Fatalf("service = %q, want %q", payload.Service, "unified-model")
+	}
+	if payload.DefaultMode != "plan" {
+		t.Fatalf("default_mode = %q, want %q", payload.DefaultMode, "plan")
+	}
+	if len(payload.ModesSupported) != 1 || payload.ModesSupported[0] != "plan" {
+		t.Fatalf("modes_supported = %+v, want [plan]", payload.ModesSupported)
+	}
+	if payload.Version == "" {
+		t.Fatalf("version should not be empty")
+	}
+}
+
+func TestCapabilitiesRejectsNonGET(t *testing.T) {
+	handler := NewMemoryApp(t.TempDir()).Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/capabilities", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code < 400 {
+		t.Fatalf("expected 4xx for POST, got %d", rr.Code)
+	}
+}
+
+func TestQueryEndpointRejectsModeDataInQueryParam(t *testing.T) {
+	app := NewMemoryApp(t.TempDir())
+	if _, err := app.Workspace.CreateWorkspace(context.Background(), model.CreateWorkspaceRequest{ID: "demo", Name: "Demo"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	handler := app.Handler()
+
+	body := `{"query":".umodel | limit 1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/query/demo/execute?mode=data", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code < 400 {
+		t.Fatalf("expected 4xx for mode=data, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestQueryEndpointAcceptsModePlanInQueryParam(t *testing.T) {
+	app := NewMemoryApp(t.TempDir())
+	if _, err := app.Workspace.CreateWorkspace(context.Background(), model.CreateWorkspaceRequest{ID: "demo", Name: "Demo"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	handler := app.Handler()
+
+	body := `{"query":".umodel | limit 1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/query/demo/execute?mode=plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -517,9 +517,12 @@ func logQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, logSet mod
 	methodQuery := stringFilter(plan.EntityCall.Parameters["query"])
 
 	queryPlan := map[string]any{
-		"mode":      "plan",
-		"version":   "v1",
-		"operation": "get_logs",
+		"mode":         "plan",
+		"version":      "v1",
+		"operation":    "get_logs",
+		"description":  describeLogPlan(logSet, binding.Storage, methodQuery),
+		"next_action":  nextActionForwardToExecutor,
+		"source_query": plan.Query,
 		"data_source": map[string]any{
 			"data_set": map[string]any{
 				"domain": logSet.Domain,
@@ -562,10 +565,14 @@ func metricQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, metricS
 	queryType := stringFilter(plan.EntityCall.Parameters["query_type"])
 	step := stringFilter(plan.EntityCall.Parameters["step"])
 
+	metricName := stringFilter(plan.EntityCall.Parameters["metric"])
 	queryPlan := map[string]any{
-		"mode":      "plan",
-		"version":   "v1",
-		"operation": "get_metrics",
+		"mode":         "plan",
+		"version":      "v1",
+		"operation":    "get_metrics",
+		"description":  describeMetricPlan(metricSet, binding.Storage, metricName, methodQuery, queryType, step),
+		"next_action":  nextActionForwardToExecutor,
+		"source_query": plan.Query,
 		"data_source": map[string]any{
 			"data_set": map[string]any{
 				"domain": metricSet.Domain,
@@ -596,6 +603,50 @@ func metricQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, metricS
 		queryPlan["time_range"] = plan.TimeRange
 	}
 	return queryPlan
+}
+
+// nextActionForwardToExecutor is the canonical "next_action" hint embedded in
+// every plan-mode response. An AI agent that receives this plan should not
+// try to execute the inner storage query itself; the canonical path is to
+// forward the plan to a UModel data executor (e.g. umodel-assistant) that
+// turns it into rows.
+const nextActionForwardToExecutor = "forward_to_executor"
+
+// describeMetricPlan returns a one-line human-readable summary of what the
+// metric plan does, so an AI agent can render or relay it to a user without
+// having to reverse-engineer the inner storage query.
+func describeMetricPlan(metricSet, storage model.UModelElement, metricName, filter, queryType, step string) string {
+	metricLabel := metricName
+	if metricLabel == "" {
+		metricLabel = "all metrics"
+	} else {
+		metricLabel = fmt.Sprintf("metric %q", metricName)
+	}
+	parts := []string{fmt.Sprintf("Retrieve %s from MetricSet %s/%s", metricLabel, metricSet.Domain, metricSet.Name)}
+	if filter != "" {
+		parts = append(parts, fmt.Sprintf("filtered by [%s]", filter))
+	}
+	if queryType != "" {
+		parts = append(parts, fmt.Sprintf("as %s query", queryType))
+	}
+	if step != "" {
+		parts = append(parts, fmt.Sprintf("with step %s", step))
+	}
+	parts = append(parts, fmt.Sprintf("(storage: %s/%s).", storage.Kind, storage.Name))
+	parts = append(parts, "Forward this plan to a UModel data executor (e.g. umodel-assistant) to fetch real time series.")
+	return strings.Join(parts, " ")
+}
+
+// describeLogPlan returns a one-line human-readable summary of what the log
+// plan does, parallel to describeMetricPlan.
+func describeLogPlan(logSet, storage model.UModelElement, filter string) string {
+	parts := []string{fmt.Sprintf("Retrieve logs from LogSet %s/%s", logSet.Domain, logSet.Name)}
+	if filter != "" {
+		parts = append(parts, fmt.Sprintf("filtered by [%s]", filter))
+	}
+	parts = append(parts, fmt.Sprintf("(storage: %s/%s).", storage.Kind, storage.Name))
+	parts = append(parts, "Forward this plan to a UModel data executor (e.g. umodel-assistant) to fetch real log rows.")
+	return strings.Join(parts, " ")
 }
 
 // echoParams returns the entity-call parameters that the caller actually

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -281,6 +281,9 @@ func methodInfoGetLogs() entityCallMethodInfo {
 				DisplayName: "Query expression for the log set",
 				Description: "Basic SPL where syntax, for example service_id = 'service_a' and level in ['ERROR', 'WARN'].",
 			},
+			{Key: "storage_domain", Type: "varchar", DisplayName: "Storage Domain", Description: "Optional storage domain used to select a specific StorageLink target."},
+			{Key: "storage_name", Type: "varchar", DisplayName: "Storage Name", Description: "Optional storage name used to select a specific StorageLink target."},
+			{Key: "storage_kind", Type: "varchar", DisplayName: "Storage Kind", Description: "Optional storage kind used to select a specific StorageLink target."},
 		},
 		Returns: []assistantReturnInfo{
 			{Key: "query", Type: "varchar", DisplayName: "Log query plan"},
@@ -310,6 +313,10 @@ func methodInfoGetMetrics() entityCallMethodInfo {
 			},
 			{Key: "query_type", Type: "varchar", DisplayName: "Prometheus query type", Description: "range or instant. Defaults to the MetricSet/storage preference."},
 			{Key: "step", Type: "varchar", DisplayName: "Range query step", Description: "Range query step, for example 1m."},
+			{Key: "aggregate", Type: "boolean", DisplayName: "Aggregate time series", Description: "Whether to aggregate the time series.", Default: true},
+			{Key: "storage_domain", Type: "varchar", DisplayName: "Storage Domain", Description: "Optional storage domain used to select a specific StorageLink target."},
+			{Key: "storage_name", Type: "varchar", DisplayName: "Storage Name", Description: "Optional storage name used to select a specific StorageLink target."},
+			{Key: "storage_kind", Type: "varchar", DisplayName: "Storage Kind", Description: "Optional storage kind used to select a specific StorageLink target."},
 		},
 		Returns: []assistantReturnInfo{
 			{Key: "query", Type: "varchar", DisplayName: "Metric query plan"},

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -510,6 +510,8 @@ func logQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, logSet mod
 	methodQuery := stringFilter(plan.EntityCall.Parameters["query"])
 
 	queryPlan := map[string]any{
+		"mode":      "plan",
+		"version":   "v1",
 		"operation": "get_logs",
 		"data_source": map[string]any{
 			"data_set": map[string]any{
@@ -534,7 +536,11 @@ func logQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, logSet mod
 				"spec":   binding.Link.Spec,
 			},
 		},
-		"query": buildLogStorageQuery(logSet, binding.Storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, plan.Limit),
+		"params_echo": echoParams(plan.EntityCall.Parameters),
+		"query":       buildLogStorageQuery(logSet, binding.Storage, dataLinkMapping, storageLinkMapping, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, plan.Limit),
+	}
+	if plan.TimeRange.From != nil || plan.TimeRange.To != nil {
+		queryPlan["time_range"] = plan.TimeRange
 	}
 	return queryPlan
 }
@@ -550,6 +556,8 @@ func metricQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, metricS
 	step := stringFilter(plan.EntityCall.Parameters["step"])
 
 	queryPlan := map[string]any{
+		"mode":      "plan",
+		"version":   "v1",
 		"operation": "get_metrics",
 		"data_source": map[string]any{
 			"data_set": map[string]any{
@@ -574,12 +582,39 @@ func metricQueryPlan(plan model.QueryPlan, dataLink model.UModelElement, metricS
 				"spec":   binding.Link.Spec,
 			},
 		},
-		"query": buildMetricStorageQuery(metricSet, binding.Storage, dataLinkMapping, storageLinkMapping, metrics, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, queryType, step, plan.Limit),
+		"params_echo": echoParams(plan.EntityCall.Parameters),
+		"query":       buildMetricStorageQuery(metricSet, binding.Storage, dataLinkMapping, storageLinkMapping, metrics, entityIDs, entityQuery, dataFilter, methodQuery, plan.EntityData, queryType, step, plan.Limit),
 	}
 	if plan.TimeRange.From != nil || plan.TimeRange.To != nil {
 		queryPlan["time_range"] = plan.TimeRange
 	}
 	return queryPlan
+}
+
+// echoParams returns the entity-call parameters that the caller actually
+// supplied, with nil and empty-string values stripped. Plan v1 includes this
+// echo so an executor (e.g. umodel-assistant) can recover the full call
+// context — including parameters declared in the method signature but not
+// consumed by the open-source planner (aggregate, storage_*).
+func echoParams(params map[string]any) map[string]any {
+	if len(params) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(params))
+	for k, v := range params {
+		switch val := v.(type) {
+		case nil:
+			continue
+		case string:
+			if val == "" {
+				continue
+			}
+			out[k] = val
+		default:
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func selectedMetricSpecs(metricSet model.UModelElement, metricName string) ([]map[string]any, error) {

--- a/internal/query/mode_test.go
+++ b/internal/query/mode_test.go
@@ -63,3 +63,26 @@ func TestExplainAlsoValidatesMode(t *testing.T) {
 		t.Fatalf("Explain should reject mode=data symmetrically, got: %v", err)
 	}
 }
+
+// TestModeRejectionCarriesMigrationDetails verifies that the mode=data error
+// includes structured migration_* keys an AI agent can act on without having
+// to parse the error message.
+func TestModeRejectionCarriesMigrationDetails(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "data",
+	})
+	target, ok := apperrors.As(err)
+	if !ok {
+		t.Fatalf("expected *apperrors.Error, got: %v", err)
+	}
+	for _, key := range []string{"requested_mode", "supported_modes", "migration_service", "migration_action", "migration_docs_url"} {
+		if _, ok := target.Details[key]; !ok {
+			t.Fatalf("error details missing %q: %+v", key, target.Details)
+		}
+	}
+	if target.Details["migration_service"] != "umodel-assistant" {
+		t.Fatalf("migration_service = %q, want umodel-assistant", target.Details["migration_service"])
+	}
+}

--- a/internal/query/mode_test.go
+++ b/internal/query/mode_test.go
@@ -1,0 +1,65 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+func TestExecuteAcceptsEmptyModeAsPlan(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "",
+	})
+	if err != nil {
+		t.Fatalf("empty mode should default to plan, got error: %v", err)
+	}
+}
+
+func TestExecuteAcceptsExplicitPlanMode(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "plan",
+	})
+	if err != nil {
+		t.Fatalf("mode=plan should be accepted, got error: %v", err)
+	}
+}
+
+func TestExecuteRejectsDataMode(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "data",
+	})
+	if !apperrors.IsCode(err, apperrors.CodeNotImplemented) {
+		t.Fatalf("mode=data should return CodeNotImplemented, got: %v", err)
+	}
+}
+
+func TestExecuteRejectsUnknownMode(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Execute(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "bogus",
+	})
+	if !apperrors.IsCode(err, apperrors.CodeNotImplemented) {
+		t.Fatalf("unknown mode should return CodeNotImplemented, got: %v", err)
+	}
+}
+
+func TestExplainAlsoValidatesMode(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	_, err := svc.Explain(context.Background(), "demo", model.QueryRequest{
+		Query: ".umodel | limit 1",
+		Mode:  "data",
+	})
+	if !apperrors.IsCode(err, apperrors.CodeNotImplemented) {
+		t.Fatalf("Explain should reject mode=data symmetrically, got: %v", err)
+	}
+}

--- a/internal/query/plan_v1_test.go
+++ b/internal/query/plan_v1_test.go
@@ -1,0 +1,136 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+// TestPlanV1EnvelopeForGetMetrics verifies that the get_metrics plan carries
+// the v1 envelope fields (mode, version, params_echo) — these are the
+// additive fields the shared plan ↔ data contract relies on. See
+// docs/en/spec/plan-schema-v1.md.
+func TestPlanV1EnvelopeForGetMetrics(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service', ids=['svc-1']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_metrics: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	if plan["mode"] != "plan" {
+		t.Fatalf(`plan["mode"] = %#v, want "plan"`, plan["mode"])
+	}
+	if plan["version"] != "v1" {
+		t.Fatalf(`plan["version"] = %#v, want "v1"`, plan["version"])
+	}
+	echo, ok := plan["params_echo"].(map[string]any)
+	if !ok {
+		t.Fatalf("plan[params_echo] is not a map: %#v", plan["params_echo"])
+	}
+	// Caller-supplied params (metric, step) survive echo so an executor can
+	// recover the full call context. The full param set including
+	// aggregate/storage_* is exercised end-to-end in commit 3 once the parse
+	// spec accepts those keys.
+	if echo["metric"] != "request_count" {
+		t.Fatalf("params_echo[metric] = %#v, want request_count", echo["metric"])
+	}
+	if echo["step"] != "30s" {
+		t.Fatalf("params_echo[step] = %#v, want 30s", echo["step"])
+	}
+	// The OSS planner ignores aggregate/storage_*, but the inner query object
+	// must still be present. Asserting only its presence keeps this test
+	// focused on the v1 envelope.
+	if _, ok := plan["query"]; !ok {
+		t.Fatalf("plan missing query field: %+v", plan)
+	}
+}
+
+// TestPlanV1EnvelopeForGetLogs verifies the same envelope for get_logs.
+func TestPlanV1EnvelopeForGetLogs(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  logQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_logs: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	if plan["mode"] != "plan" {
+		t.Fatalf(`plan["mode"] = %#v, want "plan"`, plan["mode"])
+	}
+	if plan["version"] != "v1" {
+		t.Fatalf(`plan["version"] = %#v, want "v1"`, plan["version"])
+	}
+	echo, ok := plan["params_echo"].(map[string]any)
+	if !ok {
+		t.Fatalf("plan[params_echo] is not a map: %#v", plan["params_echo"])
+	}
+	if echo["query"] != `level = "ERROR"` {
+		t.Fatalf("params_echo[query] = %#v", echo["query"])
+	}
+}
+
+// TestEchoParamsStripsEmptyAndNil verifies that the params_echo helper drops
+// nil and empty-string values so executors don't accidentally re-introduce
+// a parameter the caller never set.
+func TestEchoParamsStripsEmptyAndNil(t *testing.T) {
+	in := map[string]any{
+		"keep_string":  "yes",
+		"keep_bool":    true,
+		"keep_number":  int64(7),
+		"drop_empty":   "",
+		"drop_nil":     nil,
+		"keep_zero":    0,
+		"keep_false":   false,
+	}
+	out := echoParams(in)
+
+	for _, k := range []string{"keep_string", "keep_bool", "keep_number", "keep_zero", "keep_false"} {
+		if _, ok := out[k]; !ok {
+			t.Fatalf("expected %q to survive echo, got %+v", k, out)
+		}
+	}
+	for _, k := range []string{"drop_empty", "drop_nil"} {
+		if _, ok := out[k]; ok {
+			t.Fatalf("expected %q to be stripped, got %+v", k, out)
+		}
+	}
+}
+
+func unmarshalPlan(t *testing.T, raw any) map[string]any {
+	t.Helper()
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		t.Fatalf("expected JSON-stringified plan, got %#v", raw)
+	}
+	var plan map[string]any
+	if err := json.Unmarshal([]byte(s), &plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	return plan
+}

--- a/internal/query/plan_v1_test.go
+++ b/internal/query/plan_v1_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/UnifiedModel/internal/graphstore"
@@ -119,6 +120,80 @@ func TestEchoParamsStripsEmptyAndNil(t *testing.T) {
 		if _, ok := out[k]; ok {
 			t.Fatalf("expected %q to be stripped, got %+v", k, out)
 		}
+	}
+}
+
+// TestPlanV1AgentFriendlyFieldsForGetMetrics verifies that the agent-friendly
+// additions land in the metric plan: a human-readable description, a
+// next_action hint, and an echo of the original SPL source query.
+func TestPlanV1AgentFriendlyFieldsForGetMetrics(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	const spl = `.entity_set with(domain='devops', name='devops.service', ids=['svc-1']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')`
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: spl})
+	if err != nil {
+		t.Fatalf("execute get_metrics: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	desc, _ := plan["description"].(string)
+	if desc == "" {
+		t.Fatalf("plan[description] missing or empty: %#v", plan["description"])
+	}
+	for _, want := range []string{"request_count", "devops.metric.service", "umodel-assistant"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description should mention %q, got %q", want, desc)
+		}
+	}
+	if plan["next_action"] != "forward_to_executor" {
+		t.Fatalf("plan[next_action] = %#v, want forward_to_executor", plan["next_action"])
+	}
+	if plan["source_query"] != spl {
+		t.Fatalf("plan[source_query] = %#v, want %q", plan["source_query"], spl)
+	}
+}
+
+// TestPlanV1AgentFriendlyFieldsForGetLogs verifies the same for logs.
+func TestPlanV1AgentFriendlyFieldsForGetLogs(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  logQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	const spl = `.entity_set with(domain='devops', name='devops.service') | entity-call get_logs('devops', 'devops.log.service', query='level = "ERROR"')`
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: spl})
+	if err != nil {
+		t.Fatalf("execute get_logs: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	desc, _ := plan["description"].(string)
+	if desc == "" {
+		t.Fatalf("plan[description] missing or empty: %#v", plan["description"])
+	}
+	for _, want := range []string{"devops.log.service", `level = "ERROR"`, "umodel-assistant"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description should mention %q, got %q", want, desc)
+		}
+	}
+	if plan["next_action"] != "forward_to_executor" {
+		t.Fatalf("plan[next_action] = %#v, want forward_to_executor", plan["next_action"])
+	}
+	if plan["source_query"] != spl {
+		t.Fatalf("plan[source_query] = %#v, want %q", plan["source_query"], spl)
 	}
 }
 

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -194,6 +194,9 @@ func entityCallMethodSpecFor(name string) (entityCallMethodSpec, bool) {
 					DisplayName: "Query expression for the log set",
 					Description: "Basic SPL where syntax, for example service_id = 'service_a' and level in ['ERROR', 'WARN'].",
 				},
+				{Key: "storage_domain", Type: "varchar", DisplayName: "Storage Domain", Description: "Optional storage domain used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
+				{Key: "storage_name", Type: "varchar", DisplayName: "Storage Name", Description: "Optional storage name used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
+				{Key: "storage_kind", Type: "varchar", DisplayName: "Storage Kind", Description: "Optional storage kind used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
 			},
 		}, true
 	case "get_metric", "get_metrics":
@@ -216,6 +219,10 @@ func entityCallMethodSpecFor(name string) (entityCallMethodSpec, bool) {
 				},
 				{Key: "query_type", Type: "varchar", DisplayName: "Prometheus query type", Description: "range or instant. Defaults to the MetricSet/storage preference."},
 				{Key: "step", Type: "varchar", DisplayName: "Range query step", Description: "Range query step, for example 1m."},
+				{Key: "aggregate", Type: "boolean", DisplayName: "Aggregate time series", Description: "Whether to aggregate the time series. Echoed into the plan; not consumed by the open-source planner.", Default: true},
+				{Key: "storage_domain", Type: "varchar", DisplayName: "Storage Domain", Description: "Optional storage domain used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
+				{Key: "storage_name", Type: "varchar", DisplayName: "Storage Name", Description: "Optional storage name used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
+				{Key: "storage_kind", Type: "varchar", DisplayName: "Storage Kind", Description: "Optional storage kind used to select a specific StorageLink target. Echoed into the plan; not consumed by the open-source planner."},
 			},
 		}, true
 	default:

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -3,8 +3,30 @@ package query
 import (
 	"context"
 
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
 )
+
+// ModePlan is the only query mode supported by unified-model. umodel-assistant
+// additionally supports "data". See docs/en/spec/plan-schema-v1.md for the
+// shared mode protocol.
+const ModePlan = "plan"
+
+// normalizeMode applies the unified-model mode policy: empty becomes "plan",
+// "plan" passes through, anything else is rejected. unified-model never
+// executes plans against real storage.
+func normalizeMode(mode string) (string, error) {
+	switch mode {
+	case "", ModePlan:
+		return ModePlan, nil
+	default:
+		return "", apperrors.WithDetails(
+			apperrors.CodeNotImplemented,
+			"unified-model only supports mode=plan. To execute queries against real storage, use umodel-assistant.",
+			map[string]string{"requested_mode": mode, "supported_modes": ModePlan},
+		)
+	}
+}
 
 type graphStore interface {
 	GetUModelSnapshot(ctx context.Context, req model.UModelSnapshotRequest) (model.UModelSnapshot, error)
@@ -38,6 +60,11 @@ func NewServiceWithSearch(graph graphStore, search searchService) *Service {
 }
 
 func (s *Service) Execute(ctx context.Context, workspace string, req model.QueryRequest) (model.QueryResult, error) {
+	mode, err := normalizeMode(req.Mode)
+	if err != nil {
+		return model.QueryResult{}, err
+	}
+	req.Mode = mode
 	plan, caps, health, err := s.plan(ctx, workspace, req)
 	if err != nil {
 		return model.QueryResult{}, err
@@ -65,6 +92,11 @@ func (s *Service) Execute(ctx context.Context, workspace string, req model.Query
 }
 
 func (s *Service) Explain(ctx context.Context, workspace string, req model.QueryRequest) (model.QueryExplain, error) {
+	mode, err := normalizeMode(req.Mode)
+	if err != nil {
+		return model.QueryExplain{}, err
+	}
+	req.Mode = mode
 	plan, caps, health, err := s.plan(ctx, workspace, req)
 	if err != nil {
 		return model.QueryExplain{}, err

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -15,6 +15,10 @@ const ModePlan = "plan"
 // normalizeMode applies the unified-model mode policy: empty becomes "plan",
 // "plan" passes through, anything else is rejected. unified-model never
 // executes plans against real storage.
+//
+// On rejection the error carries migration_* keys in Details so an AI agent
+// (or any structured client) can act on the failure programmatically rather
+// than parsing the message.
 func normalizeMode(mode string) (string, error) {
 	switch mode {
 	case "", ModePlan:
@@ -23,7 +27,13 @@ func normalizeMode(mode string) (string, error) {
 		return "", apperrors.WithDetails(
 			apperrors.CodeNotImplemented,
 			"unified-model only supports mode=plan. To execute queries against real storage, use umodel-assistant.",
-			map[string]string{"requested_mode": mode, "supported_modes": ModePlan},
+			map[string]string{
+				"requested_mode":     mode,
+				"supported_modes":    ModePlan,
+				"migration_service":  "umodel-assistant",
+				"migration_action":   "switch_endpoint_to_umodel_assistant",
+				"migration_docs_url": "https://github.com/alibaba/UnifiedModel/blob/main/docs/en/spec/plan-schema-v1.md",
+			},
 		)
 	}
 }

--- a/internal/query/signature_alignment_test.go
+++ b/internal/query/signature_alignment_test.go
@@ -1,0 +1,159 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+// TestGetMetricsAcceptsAggregateAndStorageParams verifies that the parser
+// accepts the aggregate / storage_domain / storage_name / storage_kind named
+// arguments aligned with umodel-assistant's get_metric handler. The
+// open-source planner does not consume them, but they round-trip through
+// params_echo so a downstream executor can act on them.
+func TestGetMetricsAcceptsAggregateAndStorageParams(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  metricQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service', ids=['svc-1']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s', aggregate=false, storage_domain='alt', storage_name='primary', storage_kind='prometheus')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_metrics: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	echo, ok := plan["params_echo"].(map[string]any)
+	if !ok {
+		t.Fatalf("params_echo missing: %+v", plan)
+	}
+	if echo["aggregate"] != false {
+		t.Fatalf("params_echo[aggregate] = %#v, want false", echo["aggregate"])
+	}
+	if echo["storage_domain"] != "alt" {
+		t.Fatalf("params_echo[storage_domain] = %#v, want alt", echo["storage_domain"])
+	}
+	if echo["storage_name"] != "primary" {
+		t.Fatalf("params_echo[storage_name] = %#v, want primary", echo["storage_name"])
+	}
+	if echo["storage_kind"] != "prometheus" {
+		t.Fatalf("params_echo[storage_kind] = %#v, want prometheus", echo["storage_kind"])
+	}
+}
+
+// TestGetLogsAcceptsStorageParams verifies the same alignment for get_logs.
+func TestGetLogsAcceptsStorageParams(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements:  logQueryPlanElements(),
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"', storage_domain='alt', storage_name='primary', storage_kind='elasticsearch')",
+	})
+	if err != nil {
+		t.Fatalf("execute get_logs: %v", err)
+	}
+
+	plan := unmarshalPlan(t, result.Rows[0]["query"])
+	echo, ok := plan["params_echo"].(map[string]any)
+	if !ok {
+		t.Fatalf("params_echo missing: %+v", plan)
+	}
+	if echo["storage_domain"] != "alt" {
+		t.Fatalf("params_echo[storage_domain] = %#v, want alt", echo["storage_domain"])
+	}
+	if echo["storage_name"] != "primary" {
+		t.Fatalf("params_echo[storage_name] = %#v, want primary", echo["storage_name"])
+	}
+	if echo["storage_kind"] != "elasticsearch" {
+		t.Fatalf("params_echo[storage_kind] = %#v, want elasticsearch", echo["storage_kind"])
+	}
+}
+
+// TestListMethodReportsAlignedSignatures verifies that __list_method__ surfaces
+// the same params the parser accepts, so external clients (PaaS executor,
+// MCP, SDK) discover them through the canonical metadata path.
+func TestListMethodReportsAlignedSignatures(t *testing.T) {
+	ctx := context.Background()
+	store := graphstore.NewMemoryStore()
+	if _, err := store.PutUModelElements(ctx, model.UModelElementBatch{
+		Workspace: "demo",
+		Elements: []model.UModelElement{
+			{Kind: "entity_set", Domain: "devops", Name: "devops.service"},
+		},
+	}); err != nil {
+		t.Fatalf("put umodel: %v", err)
+	}
+
+	svc := NewService(store)
+	result, err := svc.Execute(ctx, "demo", model.QueryRequest{
+		Query: ".entity_set with(domain='devops', name='devops.service') | entity-call __list_method__()",
+	})
+	if err != nil {
+		t.Fatalf("execute __list_method__: %v", err)
+	}
+
+	if len(result.Rows) == 0 {
+		t.Fatalf("expected __list_method__ to return a row")
+	}
+	envelope := result.Rows[0]
+	data, ok := envelope["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected envelope.data to be []map[string]any, got %T", envelope["data"])
+	}
+
+	signatures := map[string][]string{} // method name -> param keys
+	for _, entry := range data {
+		values, ok := entry["values"].([]string)
+		if !ok || len(values) < 4 {
+			continue
+		}
+		name := values[0]
+		paramsJSON := values[3]
+		var params []map[string]any
+		if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+			t.Fatalf("decode params for %q: %v", name, err)
+		}
+		keys := make([]string, 0, len(params))
+		for _, p := range params {
+			if k, ok := p["key"].(string); ok {
+				keys = append(keys, k)
+			}
+		}
+		signatures[name] = keys
+	}
+
+	mustContain := func(method string, wanted []string) {
+		t.Helper()
+		got, ok := signatures[method]
+		if !ok {
+			t.Fatalf("method %q missing from __list_method__: %+v", method, signatures)
+		}
+		joined := strings.Join(got, ",")
+		for _, w := range wanted {
+			if !strings.Contains(joined, w) {
+				t.Fatalf("method %q params missing %q (got %s)", method, w, joined)
+			}
+		}
+	}
+
+	mustContain("get_metrics", []string{"domain", "name", "metric", "query", "query_type", "step", "aggregate", "storage_domain", "storage_name", "storage_kind"})
+	mustContain("get_logs", []string{"domain", "name", "query", "storage_domain", "storage_name", "storage_kind"})
+}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -273,6 +273,10 @@ type QueryRequest struct {
 	EntityData       *EntityData    `json:"entity_data,omitempty"`
 	EntityDataCamel  *EntityData    `json:"entityData,omitempty"`
 	FilterByEntities *EntityData    `json:"filterByEntities,omitempty"`
+	// Mode selects between returning a query plan and executing the plan against
+	// real storage. unified-model only supports "plan"; umodel-assistant supports
+	// "plan" and "data". Empty defaults to the server's default_mode (plan for OSS).
+	Mode string `json:"mode,omitempty"`
 }
 
 func (r QueryRequest) EntityFilterData() *EntityData {


### PR DESCRIPTION
## Summary

This PR formalizes the query plan as a **versioned, extensible contract**. Query Service can now return either a **plan** (a structured description of what to execute) or, in future implementations, **data** (the actual rows). This open-source surface stays plan-only — it does not execute plans against real storage — but the protocol leaves a clean extension point for any downstream executor to consume the same plan and produce data.

Three things are introduced together:

- A **`mode` protocol** on `QueryRequest` (`plan` / `data`) plus a new `GET /api/v1/capabilities` endpoint so clients can discover what a server supports.
- **Plan JSON v1**, a stable envelope around the existing `data_source` / `query` fields, with discoverable metadata: `mode`, `version`, `operation`, `description`, `next_action`, `source_query`, `params_echo`.
- **Method-signature alignment**: `get_metrics` and `get_logs` accept the full union of parameters a downstream executor might need (`aggregate`, `storage_domain`, `storage_name`, `storage_kind`), so the same SPL round-trips cleanly across implementations.

## Why

Today `get_metrics` and `get_logs` return a query plan whose shape evolves implicitly with the code. As more clients (Web UI, MCP, SDKs, agents) and more downstream executors consume that plan, an undocumented shape becomes a permanent liability — every consumer ends up reverse-engineering the JSON.

This PR turns the plan into a documented v1 contract that can evolve under SemVer:

- **Minor versions** add fields (the AI-agent-friendly `description` / `next_action` / `source_query` introduced in this PR are themselves an example).
- **Major versions** are reserved for breaking changes, gated by an RFC.

It also draws an explicit boundary: this project only emits plans; executing them against real storage is left to plan executors built on top. A `?mode=data` request is rejected with `NOT_IMPLEMENTED` plus structured `migration_*` details so clients can program against the failure rather than parsing prose.

## Changes

5 commits, each self-contained, all `make ci` green locally:

1. **`bc36812` feat(query): add mode protocol and capabilities endpoint**
   - `QueryRequest.Mode` (`plan` / `data`); `?mode=` query param accepted; body wins on conflict
   - `Service.Execute` / `Explain` validate via `normalizeMode`; empty → `plan`; anything else → `NOT_IMPLEMENTED`
   - New `GET /api/v1/capabilities` reports `{service, version, modes_supported, default_mode}`

2. **`cdf12e3` feat(query): upgrade plan JSON to v1 (mode/version/params_echo)**
   - Add `mode`, `version`, `params_echo` to both `logQueryPlan` and `metricQueryPlan`
   - `echoParams` strips nil / empty-string entries so executors can recover the full call context — including parameters declared in the method signature but ignored by the planner
   - `time_range` now also present on log plans (was metric-only)

3. **`854bb27` feat(query): broaden get_metrics/get_logs parameter union**
   - `get_metrics` accepts `aggregate`, `storage_domain`, `storage_name`, `storage_kind`
   - `get_logs` accepts `storage_domain`, `storage_name`, `storage_kind`
   - Both the parser whitelist (`entityCallMethodSpecFor`) and `__list_method__` metadata (`methodInfoGetMetrics` / `methodInfoGetLogs`) are updated together
   - The planner does not consume the new params — they ride along in `params_echo` for downstream executors

4. **`47b82fb` docs(spec): add plan schema v1 specification**
   - New `docs/{en,zh}/spec/plan-schema-v1.md`: mode protocol, plan JSON v1 envelope, parameter contract, SemVer compatibility rules
   - Linked from `docs/{en,zh}/README.md` under a new "Specifications" section
   - Spec mandates contract tests; breaking the contract is treated as a release-blocking regression

5. **`e78ea93` feat(query): make plan JSON v1 AI-agent friendly (additive)**
   - Add `description` (one-line summary), `next_action` (currently `forward_to_executor`), `source_query` (echo of the original SPL) to every plan
   - `mode=data` rejection error gains `migration_service` / `migration_action` / `migration_docs_url` in `details` so agents can act on the failure structurally
   - Purely additive within v1; existing consumers unaffected

## Test plan

- [x] `make build`
- [x] `make test-service` — all green
- [x] `make guard` — architecture guard passed
- [x] `make ci` — full local gate passed
- [x] End-to-end probe against `make quickstart`:
  - [x] `GET /api/v1/capabilities` returns `{service: unified-model, modes_supported: [plan], default_mode: plan}`
  - [x] `get_metrics(..., aggregate=false, storage_kind='prometheus')` plan contains `mode=plan`, `version=v1`, `description`, `next_action`, `source_query`, full `params_echo`
  - [x] `POST /api/v1/query/{ws}/execute?mode=data` returns `NOT_IMPLEMENTED` with `migration_*` details
  - [x] `__list_method__` reports `get_metrics` with 10 params and `get_logs` with 6 params

## Not in scope (explicit)

- Real data execution — this project stays plan-only; executors are a separate concern
- Response envelope restructure (de-stringify, fold noisy `data_source.storage.config` / `data_link.spec` / `storage_link.spec`) — separate PR
- Migration tooling for porting workspaces between implementations — separate effort