### PR TITLE
chore: fix LICENSE so Apache-2.0 is detected; add NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -184,16 +184,16 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2024 UModel Project
+   Copyright [yyyy] [name of copyright owner]
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+UModel
+Copyright 2024 The UModel Project Authors
+
+This product includes software developed at
+The UModel Project (https://github.com/alibaba/UnifiedModel).


### PR DESCRIPTION
## Summary

Restore the canonical Apache 2.0 LICENSE text so GitHub's Licensee scanner can detect the license, and move the actual copyright notice into a new `NOTICE` file per Apache 2.0 §4(d) convention.

## Motivation

Today `GET /repos/alibaba/UnifiedModel` reports `licenseInfo: NOASSERTION`. The repository sidebar therefore has no Apache-2.0 badge, and license-aware tools (OSSF Scorecard, dependency scanners, SBOM tooling) treat the project as having an unknown license. The README explicitly says Apache-2.0, so this is a detection issue, not a licensing change.

Root cause: the previous `LICENSE` file ended with an un-indented `Copyright 2024 UModel Project` block followed by a duplicated boilerplate paragraph. The canonical Apache 2.0 `LICENSE` keeps the APPENDIX example indented three spaces and uses the literal placeholders `[yyyy]` and `[name of copyright owner]`. Licensee fingerprints the file by hash; the deviation broke the match.

## Changes

- `LICENSE`: restored the canonical APPENDIX example block with the standard 3-space indentation and placeholder fields. The textual content matches upstream Apache 2.0.
- `NOTICE` (new): carries the project's actual copyright notice. NOTICE is the place to declare project copyright and attribution; LICENSE should remain canonical so it detects cleanly.

## Test plan

- [x] Compared the new `LICENSE` against the canonical [apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt) — APPENDIX block matches.
- [x] After merge, `GET /repos/alibaba/UnifiedModel` should report `licenseInfo.spdxId: "Apache-2.0"` and the sidebar should show the Apache-2.0 badge.

## Compatibility

The legal terms granted are unchanged — the file is the same Apache 2.0 license it was before, just in the canonical form that Licensee recognizes. No code or contract is affected.

## Out of scope

- Changing the license. This PR is detection-only.
- Per-file source headers. If we later want every `.go` file to carry the Apache header, that is a separate sweep.