### PR TITLE
docs(github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a defect in UModel — something that does not behave as documented.
+title: "[bug] <short description>"
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- One-sentence description of what's broken. -->
+
+## Reproduction
+
+Minimal steps that reproduce the issue:
+
+1. ...
+2. ...
+3. ...
+
+If the bug only shows up with specific data, paste a minimal UModel definition / SPL query / sample request below.
+
+```
+<minimal sample>
+```
+
+## Expected behavior
+
+<!-- What you expected to happen. Quote the doc page or spec section if relevant. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages, stack traces, or unexpected output. -->
+
+## Environment
+
+- UModel version / commit:           <!-- `umctl --version` or git SHA -->
+- GraphStore provider:               <!-- memory / file.memory / local.ladybug / other -->
+- OS / Go / Node version (if relevant):
+- Surface affected:                  <!-- REST / CLI / MCP / Web UI / SDK -->
+
+## Additional context
+
+<!-- Logs, screenshots, related issues, or anything else that helps narrow it down. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or general discussion
+    url: https://github.com/alibaba/UnifiedModel/discussions
+    about: Open-ended questions about UModel concepts, integration, or usage are best discussed in GitHub Discussions.
+  - name: Security report
+    url: https://github.com/alibaba/UnifiedModel/security/policy
+    about: Please report security vulnerabilities privately via the security policy, not through public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose new functionality, a new GraphStore provider, an SDK improvement, or any capability extension.
+title: "[feat] <short description>"
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What can you not do today with UModel? What forced you to file this issue? Concrete user scenarios beat abstract wishlists. -->
+
+## Proposed solution
+
+<!-- Sketch what the feature would look like. For new APIs, draft the method signature or SPL form. For new providers/integrations, name the contract surface you'd extend. -->
+
+## Why UModel, not external tooling
+
+<!-- UModel is a vendor-neutral semantic layer; we keep the open-source core focused and resist scope creep. Briefly explain why this belongs inside UModel rather than a downstream extension. -->
+
+## Alternatives considered
+
+<!-- Other approaches you weighed and why they're worse. -->
+
+## Additional context
+
+<!-- Links to related issues / RFCs / specs, prior-art from adjacent ecosystems (OpenTelemetry, Prometheus, K8s, CMDB), screenshots if UI-related. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,23 @@
+---
+name: Question
+about: Use this only if your question is rooted in a specific bug, doc gap, or contract ambiguity. For open-ended discussion ("how do I do X with UModel?"), please use GitHub Discussions instead.
+title: "[question] <short description>"
+labels: question
+assignees: ''
+---
+
+## What are you trying to do
+
+<!-- Concrete user scenario, not a general capability survey. -->
+
+## What did you check first
+
+<!-- Which docs / examples / issues did you look at and what was missing? This helps us patch the doc, not just answer privately. -->
+
+- [ ] Searched [open and closed issues](https://github.com/alibaba/UnifiedModel/issues?q=is%3Aissue)
+- [ ] Searched [Discussions](https://github.com/alibaba/UnifiedModel/discussions)
+- [ ] Read the [`docs/`](https://github.com/alibaba/UnifiedModel/blob/main/docs/README.md) section for this area
+
+## Your environment (only if it matters)
+
+<!-- Skip if irrelevant. Otherwise: UModel version, GraphStore provider, surface (REST / CLI / MCP / Web UI / SDK). -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for contributing to UModel! Before submitting, please make sure your PR:
+
+- Targets `main`.
+- Includes both English and Chinese docs when changing user-facing behavior (paired `docs/en/**` and `docs/zh/**` files).
+- Passes `make ci` locally.
+- Keeps the open-source surface focused — capabilities better implemented in downstream tooling do not belong here.
+
+Please fill in the sections below.
+-->
+
+## Summary
+
+<!-- One or two sentences. What does this PR change and why? -->
+
+## Motivation
+
+<!-- Link the issue / RFC / scenario this addresses. If it's a behavior change without a tracking issue, briefly explain what prompted it. -->
+
+## Changes
+
+<!-- Bulleted summary of the substantive edits. Group by area (query / graphstore / sdk / docs / sample data / web). -->
+
+-
+-
+-
+
+## Test plan
+
+- [ ] `make build`
+- [ ] `make test-service`
+- [ ] `make guard`
+- [ ] `make ci`
+- [ ] If user-facing: ran an end-to-end probe (describe briefly)
+
+## Compatibility
+
+<!-- Anything reviewers should know about backwards compatibility, public contracts (REST / SPL / MCP / SDK / plan schema), or migration. If this PR is purely additive within an existing spec, say so. -->
+
+## Out of scope
+
+<!-- Things this PR deliberately does NOT do, so reviewers don't ask. Optional but recommended for medium / large PRs. -->


### PR DESCRIPTION
## Summary

Add structured issue templates (bug / feature / question), an issue-template `config.yml` that routes open-ended questions to Discussions and security reports to the security policy, and a pull request template.

## Motivation

GitHub's community profile reports this repository at **62% health**, with `issue_template` and `pull_request_template` flagged as missing. The cost shows up daily: new issues land without reproduction steps, environment, or scope; new PRs land without a test plan or compatibility note. Triage time is higher than it should be, and external contributors don't know what we expect.

Most recent example: the question on Neo4j integration ([issue #20](https://github.com/alibaba/UnifiedModel/issues/20)) was opened as a regular issue when it should have been a Discussion. A template config routes that traffic to the right place.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes open-ended questions to Discussions, routes security reports to the security policy.
- `.github/ISSUE_TEMPLATE/bug_report.md` — reproduction, expected vs actual, environment block (provider, surface, versions).
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem first, then proposed solution, with an explicit "why UModel, not downstream tooling" prompt so scope discipline is visible from the very first issue.
- `.github/ISSUE_TEMPLATE/question.md` — scoped to questions rooted in a bug, doc gap, or contract ambiguity; nudges open-ended questions toward Discussions.
- `.github/pull_request_template.md` — summary, motivation, changes, test plan checklist, compatibility, out-of-scope.

Templates are intentionally short. Long templates get skipped; short templates with the right prompts get filled.

## Compatibility

No code or contract is affected. Existing open issues / PRs are unchanged. The templates apply only to newly opened ones.

## Out of scope

- Auto-labeling actions (e.g. action that applies `documentation` label to PRs that touch only `docs/**`). Worth doing later; not in this PR.
- A `CONTRIBUTING` rewrite. The existing CONTRIBUTING is fine; templates plug the most acute gap.
- Welcome bot for first-time contributors. Optional, can land separately.