### PR TITLE
docs(changelog): mark 0.1.0 released, prep 0.2.0 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,34 @@ The project follows a simple changelog structure until stable releases are publi
 - `Removed` for removed behavior.
 - `Security` for vulnerability fixes.
 
-## 0.1.0 - Unreleased
+## 0.2.0 - Unreleased
+
+### Added
+
+- **Plan/data mode protocol on Query Service** (#25). New `mode` request field and `?mode=` query parameter let clients ask for a query plan or a data execution. This open-source surface stays plan-only and rejects `mode=data` with a structured `NOT_IMPLEMENTED` error that carries `migration_*` details so agents can act on the failure without parsing prose. New `GET /api/v1/capabilities` endpoint advertises supported modes and formats.
+- **Plan JSON v1 contract** (#25). Top-level envelope with `mode`, `version`, `operation`, `description`, `next_action`, `source_query`, `data_source`, `params_echo`, `query`, and `time_range`. Documented in `docs/{en,zh}/spec/plan-schema-v1.md` and treated as a release-blocking contract.
+- **Plan schema v1.1 agent-friendly envelope** (#26). New `?format=agent` returns the plan as a top-level JSON object (no assistant envelope, no string-encoded plan), with `data_source.*` fields folded to compact `{ref, kind}` references for compact agent context. `?include=spec` re-expands `storage.config`, `data_link.spec`, and `storage_link.spec` for debugging and diagnostic agents.
+- **`get_metrics` / `get_logs` plan emission with entity filters** (#18, #23). Both methods produce a structured query plan, render the downstream PromQL / Elasticsearch DSL, and translate entity ID and label filters into the storage-side query.
+- **`get_metrics` / `get_logs` parameter alignment** (#25). Parser now accepts `aggregate` (metrics) and `storage_domain` / `storage_name` / `storage_kind` (both). The open-source planner echoes them in `params_echo` for downstream executors.
+- **EntitySet dataset discovery** (#17). New `list_data_set` entity-call lists the related `metric_set` / `log_set` / `trace_set` / `event_set`, with optional detail expansion.
+- **Multi-domain quickstart sample pack expanded.** New devops domain entries — `log_set` / `metric_set` / `event_set`, the corresponding storage and links, sample data, and tests.
+- **Web UI improvements.** Workspace routing with UModel URLs (#15), Query Page example picker and result-table polish (#21), full internationalization across Explorer / Entity-Topo / Query components, Monaco editor preload, API Debugger panel, Imports feature, Settings refresh.
+
+### Changed
+
+- `docs/{en,zh}/README.md` documentation index gained a new **Specifications** section, pointing at `plan-schema-v1.md`.
+- `params_echo` in plan output strips nil and empty-string entries; default values from the method signature are not echoed unless the caller actually set them.
+
+### Fixed
+
+- Local Ladybug provider could lose workspace metadata across service restarts (#22). Recovery now reads metadata back from the data root.
+- Dependabot alerts on Vite resolved (#16).
+
+### Security
+
+- Reaffirmed: MCP write tools remain disabled by default. Security reporting policy unchanged.
+
+## 0.1.0 - 2026-05-28
 
 ### Added
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -13,7 +13,34 @@ English version: [CHANGELOG.md](CHANGELOG.md)
 - `Removed`：已移除的行为。
 - `Security`：安全修复。
 
-## 0.1.0 - Unreleased
+## 0.2.0 - Unreleased
+
+### Added
+
+- **Query Service 引入 plan/data 模式协议**（#25）。新增 `mode` 请求字段和 `?mode=` query 参数，让客户端在"返回查询计划"和"执行返回数据"之间选择。开源面定位为 plan provider，`mode=data` 返回结构化的 `NOT_IMPLEMENTED` 错误，错误体里带 `migration_*` 信息便于 agent 直接消费而非解析自然语言。新增 `GET /api/v1/capabilities` 端点声明支持的 modes 与 formats。
+- **Plan JSON v1 契约**（#25）。顶层 envelope 含 `mode`、`version`、`operation`、`description`、`next_action`、`source_query`、`data_source`、`params_echo`、`query`、`time_range`。规范文档落地为 `docs/{en,zh}/spec/plan-schema-v1.md`,作为发布阻断级契约。
+- **Plan schema v1.1 agent 友好 envelope**(#26)。新增 `?format=agent` 让 plan 对象直接作为 HTTP body 返回（不再走 assistant envelope 与字符串编码），`data_source.*` 字段折叠成紧凑的 `{ref, kind}` 引用，agent 上下文窗口消耗显著降低。`?include=spec` 还原 `storage.config`、`data_link.spec`、`storage_link.spec`，便于调试与诊断 agent。
+- **`get_metrics` / `get_logs` 查询计划与实体过滤**（#18、#23）。两个方法都生成结构化 query plan，渲染 PromQL / Elasticsearch DSL，并把 entity ID 与 label 过滤翻译进存储侧查询。
+- **`get_metrics` / `get_logs` 方法签名对齐**（#25）。parser 接受新的可选参数：`aggregate`（metrics）以及 `storage_domain` / `storage_name` / `storage_kind`（两者都加）。开源 planner 通过 `params_echo` 回显，供下游 executor 消费。
+- **EntitySet 数据集发现**（#17）。新增 `list_data_set` entity-call，列出相关的 `metric_set` / `log_set` / `trace_set` / `event_set`，可按需展开详情。
+- **多 domain quickstart 样例包扩展**。新增 devops 域的 `log_set` / `metric_set` / `event_set`，配套 storage、links、样例数据与测试。
+- **Web UI 改进**。基于 UModel URL 的 workspace 路由（#15）、查询页 example picker 与结果表优化（#21）、Explorer / Entity-Topo / Query 全面国际化、Monaco 编辑器预加载、API Debugger 面板、Imports 功能、Settings 优化。
+
+### Changed
+
+- `docs/{en,zh}/README.md` 文档入口新增 **Specifications** 段落，指向 `plan-schema-v1.md`。
+- Plan 输出的 `params_echo` 剔除 nil 与空字符串；方法签名的默认值不会被回显，除非调用方真的传了。
+
+### Fixed
+
+- 本地 Ladybug provider 在服务重启后可能丢失 workspace 元数据(#22),恢复路径现在从 data root 读取。
+- Vite 相关的 Dependabot 提醒解决（#16）。
+
+### Security
+
+- 重申：MCP 写工具默认关闭。安全报告策略不变。
+
+## 0.1.0 - 2026-05-28
 
 ### Added
 


### PR DESCRIPTION
## Summary

Two updates to both English and Chinese changelogs:

1. Stamp **0.1.0** with its actual release date (`2026-05-28`, matching the v0.1.0 tag). The previous `Unreleased` marker was inaccurate.
2. Prep the **0.2.0** section with the work that landed on `main` since v0.1.0.

## Motivation

We have not cut a release since `v0.1.0` (2026-05-28), but main has moved meaningfully since then — most notably the plan/data mode contract (#25), the agent-friendly v1.1 envelope (#26), and the get_metrics / get_logs plan emission work (#18, #23). The changelog should reflect that, and we should be in a position to tag v0.2.0 without a last-minute scramble.

This PR just preps the entries; the actual tag and GitHub release come in a follow-up step.

## Changes

`CHANGELOG.md` and `CHANGELOG.zh-CN.md` updated in lockstep:

- 0.2.0 — Unreleased section added with **Added** / **Changed** / **Fixed** / **Security** entries covering only what is already on main.
- 0.1.0 — Unreleased → `0.1.0 - 2026-05-28`.

Entry highlights for 0.2.0:

- Plan/data mode protocol and `/api/v1/capabilities` endpoint (#25)
- Plan JSON v1 contract documented in `docs/{en,zh}/spec/plan-schema-v1.md` (#25)
- Plan schema v1.1 agent-friendly response envelope, `?format=agent` and `?include=spec` (#26)
- `get_metrics` / `get_logs` plan emission with entity filters (#18, #23)
- `get_metrics` / `get_logs` parameter alignment — `aggregate`, `storage_*` echo (#25)
- `list_data_set` entity-call for dataset discovery (#17)
- Multi-domain quickstart sample pack expanded
- Web UI improvements (#15, #21, i18n, Monaco preload, API Debugger, Imports, Settings)
- Ladybug metadata recovery fix (#22), Vite Dependabot alerts resolved (#16)

## Compatibility

Documentation-only change. No code or contract affected.

## Out of scope

- Cutting the v0.2.0 git tag and GitHub release. Will be done in a follow-up once these prep PRs land.
- Listing entries from in-flight PRs (license detection / issue templates). If they merge before tag time, a small follow-up commit covers them.