### PR TITLE
docs(changelog): stamp 0.2.0 release date (2026-06-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The project follows a simple changelog structure until stable releases are publi
 - `Removed` for removed behavior.
 - `Security` for vulnerability fixes.
 
-## 0.2.0 - Unreleased
+## 0.2.0 - 2026-06-10
 
 ### Added
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -13,7 +13,7 @@ English version: [CHANGELOG.md](CHANGELOG.md)
 - `Removed`：已移除的行为。
 - `Security`：安全修复。
 
-## 0.2.0 - Unreleased
+## 0.2.0 - 2026-06-10
 
 ### Added
 


### PR DESCRIPTION
Final step before cutting the **v0.2.0** tag. The CHANGELOG already lists the entries that landed since v0.1.0 (#29); this PR just changes the section header from `0.2.0 - Unreleased` to `0.2.0 - 2026-06-10` so the tagged commit reflects ground truth.

After this lands, the v0.2.0 tag + GitHub release will be created against the resulting main commit.