### PR TITLE
docs: make incident-investigation demo discoverable; fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Start with the bilingual documentation index: [docs/README.md](docs/README.md).
 | Guides | [Model Authoring](docs/en/guides/model-authoring.md), [Entity And Relation Writes](docs/en/guides/entity-relation-writes.md), [Query Service](docs/en/guides/query-service.md), [Web UI](docs/en/guides/web-ui.md), [SDK And Client Guide](docs/en/guides/sdk-clients.md) |
 | Architecture | [Architecture Overview](docs/en/architecture/overview.md), [Runtime Flow](docs/en/architecture/runtime-flow.md), [Query And Agent Architecture](docs/en/architecture/query-and-agent.md) |
 | Reference | [CLI](docs/en/reference/cli.md), [MCP](docs/en/reference/mcp.md), [REST OpenAPI](api/openapi/openapi.yaml), [MCP Tool And Resource Schema](api/mcp/tools.schema.json) |
-| Examples | [Multi-Domain Quickstart Example Pack](examples/quickstart-multidomain/README.md) |
+| Examples | [Multi-Domain Quickstart Example Pack](examples/quickstart-multidomain/README.md), [Incident Investigation Demo (AI agent)](examples/incident-investigation/README.md) |
 | Deployment | [Docker And Compose](deployments/README.md) |
 
 Chinese documentation: [docs/zh/README.md](docs/zh/README.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@ UModel 围绕 workspace-scoped object graph 运行本地服务：
 | 指南 | [模型编写](docs/zh/guides/model-authoring.md)、[实体与关系写入](docs/zh/guides/entity-relation-writes.md)、[Query Service](docs/zh/guides/query-service.md)、[Web UI](docs/zh/guides/web-ui.md)、[SDK 与客户端](docs/zh/guides/sdk-clients.md) |
 | 架构 | [架构总览](docs/zh/architecture/overview.md)、[运行时流程](docs/zh/architecture/runtime-flow.md)、[Query 与 Agent 架构](docs/zh/architecture/query-and-agent.md) |
 | 参考 | [CLI](docs/zh/reference/cli.md)、[MCP](docs/zh/reference/mcp.md)、[REST OpenAPI](api/openapi/openapi.yaml)、[MCP Tool 和 Resource Schema](api/mcp/tools.schema.json) |
-| 示例 | [多域 Quickstart 示例包](examples/quickstart-multidomain/README.zh-CN.md) |
+| 示例 | [多域 Quickstart 示例包](examples/quickstart-multidomain/README.zh-CN.md)、[故障排查 Demo（AI Agent）](examples/incident-investigation/README.zh-CN.md) |
 | 部署 | [Docker 与 Compose](deployments/README.zh-CN.md) |
 
 英文文档：[docs/en/README.md](docs/en/README.md)。

--- a/README_CN.md
+++ b/README_CN.md
@@ -102,7 +102,7 @@ UModel 围绕 workspace-scoped object graph 运行本地服务：
 | 指南 | [模型编写](docs/zh/guides/model-authoring.md)、[实体与关系写入](docs/zh/guides/entity-relation-writes.md)、[Query Service](docs/zh/guides/query-service.md)、[Web UI](docs/zh/guides/web-ui.md)、[SDK 与客户端](docs/zh/guides/sdk-clients.md) |
 | 架构 | [架构总览](docs/zh/architecture/overview.md)、[运行时流程](docs/zh/architecture/runtime-flow.md)、[Query 与 Agent 架构](docs/zh/architecture/query-and-agent.md) |
 | 参考 | [CLI](docs/zh/reference/cli.md)、[MCP](docs/zh/reference/mcp.md)、[REST OpenAPI](api/openapi/openapi.yaml)、[MCP Tool 和 Resource Schema](api/mcp/tools.schema.json) |
-| 示例 | [多域 Quickstart 示例包](examples/quickstart-multidomain/README.zh-CN.md) |
+| 示例 | [多域 Quickstart 示例包](examples/quickstart-multidomain/README.zh-CN.md)、[故障排查 Demo（AI Agent）](examples/incident-investigation/README.zh-CN.md) |
 | 部署 | [Docker 与 Compose](deployments/README.zh-CN.md) |
 
 英文文档：[docs/en/README.md](docs/en/README.md)。

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -36,6 +36,11 @@ Documentation root: [docs/README.md](../README.md)
 - [SDK And Client Guide](guides/sdk-clients.md) - REST, CLI, MCP, generated model SDKs, and integration examples.
 - [MCP Examples](../../examples/mcp/README.md) - stdio, Streamable HTTP, HTTP+SSE, and TOON payload examples.
 
+## Examples
+
+- [Multi-Domain Quickstart Example Pack](../../examples/quickstart-multidomain/README.md) - five domains connected in one workspace; the default `make quickstart` sample.
+- [Incident Investigation Demo](../../examples/incident-investigation/README.md) - scenario-driven, AI-agent-assisted root-cause analysis of a payment-gateway SLO breach across business, platform, and runtime domains, with a runbook-guided diagnosis path.
+
 ## Architecture
 
 - [Architecture Overview](architecture/overview.md) - system view, layers, public contracts, and guardrails.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -36,6 +36,11 @@ English: [UModel Documentation](../en/README.md)
 - [SDK 与客户端指南](guides/sdk-clients.md) - REST、CLI、MCP、生成模型 SDK 和集成示例。
 - [MCP 示例](../../examples/mcp/README.zh-CN.md) - stdio、Streamable HTTP、HTTP+SSE 和 TOON payload 示例。
 
+## 示例
+
+- [多域 Quickstart 示例包](../../examples/quickstart-multidomain/README.zh-CN.md) - 一个 workspace 里连接五个 domain；`make quickstart` 默认样例。
+- [故障排查 Demo](../../examples/incident-investigation/README.zh-CN.md) - 场景驱动、AI Agent 辅助的根因分析：跨业务、平台、运行时三个 domain 排查支付网关 SLO 违约，演示 runbook 引导的诊断路径。
+
 ## 架构
 
 - [架构总览](architecture/overview.md) - 系统视图、分层、公共契约和 guardrails。

--- a/examples/incident-investigation/README.md
+++ b/examples/incident-investigation/README.md
@@ -252,7 +252,7 @@ Connect from `.mcp.json`:
 }
 ```
 
-See [Remote MCP Connection Guide](../../docs/en/guides/remote-mcp.md) for SSH tunnels, Nginx proxy, Docker, and troubleshooting.
+See the [MCP Reference](../../docs/en/reference/mcp.md) for transports (stdio, Streamable HTTP, HTTP+SSE), tools, resources, and a local smoke test.
 
 ## Contents
 

--- a/examples/incident-investigation/README.zh-CN.md
+++ b/examples/incident-investigation/README.zh-CN.md
@@ -252,7 +252,7 @@ go run ./cmd/umodel-mcp --quickstart \
 }
 ```
 
-详细的远程部署指南（SSH 隧道、Nginx 代理、Docker、故障排查）参见 [远程 MCP 连接操作手册](../../docs/zh/guides/remote-mcp.md)。
+传输方式（stdio、Streamable HTTP、HTTP+SSE）、tools、resources 以及本地冒烟测试参见 [MCP 参考](../../docs/zh/reference/mcp.md)。
 
 ## 目录结构
 


### PR DESCRIPTION
## Summary

Surface the existing `examples/incident-investigation/` demo from the README and docs index, and fix a broken link in the demo's own README.

## Motivation

The incident-investigation example is a complete, working AI-agent demo — a payment-gateway SLO breach diagnosed across business / platform / runtime domains, with a runbook-guided observation path, a deliberate red herring, `.mcp.json` configs for stdio and remote HTTP, and a passing MCP integration test. But it is effectively invisible:

- Not referenced from the root README (only the multi-domain quickstart is listed under Examples).
- Not present in the `docs/` index.
- Its own README links to `docs/en/guides/remote-mcp.md` (and the zh equivalent), which **does not exist** — a broken link.

A great demo nobody can find delivers no value. This PR fixes discoverability with no data or schema changes.

## Changes

- **Root README** (`README.md`, `README_CN.md`, `README.zh-CN.md`): add the demo to the Examples row beside the multi-domain quickstart. `README_CN.md` and `README.zh-CN.md` kept byte-identical per CLAUDE.md.
- **docs index** (`docs/en/README.md`, `docs/zh/README.md`): add an **Examples** section listing both the quickstart pack and the incident-investigation demo.
- **Demo README** (`examples/incident-investigation/README.md`, `README.zh-CN.md`): repoint the broken `remote-mcp.md` reference to `docs/{en,zh}/reference/mcp.md`, which already documents stdio / Streamable HTTP / HTTP+SSE transports and a local smoke test.

## Test plan

- [x] `README_CN.md` and `README.zh-CN.md` are identical (`diff` clean).
- [x] All link targets exist (`examples/incident-investigation/README*.md`, `docs/{en,zh}/reference/mcp.md`).
- [x] No remaining `remote-mcp` references anywhere under `examples/` or `docs/`.
- [x] `incident-investigation` is now referenced from all five entry docs.

## Out of scope

- Writing a full standalone `remote-mcp.md` guide (the demo's remote-HTTP config is self-contained; the MCP reference covers transports). Can land later if there's demand.
- Enhancing the demo with a telemetry layer (metric_set / log_set) so it exercises `get_metrics` / `get_logs` — that is the next PR in this series.