### PR TITLE
fix(security): harden path handling and bound query preallocation (8 CodeQL alerts)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ Current open-source security defaults:
 - `make dev`, Docker, and Compose use `file.memory` local persistence.
 - MCP write tools are disabled by default.
 - AgentGateway resources expose metadata and templates, not runtime rows.
+- The UModel import endpoint (`POST /api/v1/umodel/{workspace}/import`, `umctl umodel import`) reads model packs from operator-provided **server-local filesystem paths** by design, similar to `kubectl apply -f <path>`. It is an operator capability and must not be exposed to untrusted callers. Keep the import endpoint off any internet-facing surface, or front it with authentication/authorization.
 - This release does not include multi-tenant authorization or cloud-hosted control plane behavior.
 
 Do not use the local development server as an internet-facing production service without adding authentication, authorization, transport security, rate limits, audit logging, and deployment hardening.

--- a/SECURITY.zh-CN.md
+++ b/SECURITY.zh-CN.md
@@ -41,6 +41,7 @@ English version: [SECURITY.md](SECURITY.md)
 - `make dev`、Docker 和 Compose 使用 `file.memory` 本地持久化。
 - MCP 写工具默认关闭。
 - AgentGateway resources 暴露元数据和模板，不暴露运行时 rows。
+- UModel 导入端点（`POST /api/v1/umodel/{workspace}/import`、`umctl umodel import`）按设计从 operator 提供的**服务端本地文件路径**读取模型包，类似 `kubectl apply -f <path>`。这是 operator 能力，不得暴露给不受信任的调用方。请勿将导入端点放在公网可达的表面，或在其前面加认证/授权。
 - 当前 release 不包含 multi-tenant authorization 或 cloud-hosted control plane 行为。
 
 不要在没有认证、授权、传输安全、限流、审计和部署加固的情况下，把本地开发服务作为公网生产服务使用。

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -155,7 +155,14 @@ func spaFileHandler(uiDir string) http.HandlerFunc {
 		if cleanPath == "." || cleanPath == "" {
 			cleanPath = "index.html"
 		}
-		file := filepath.Join(uiDir, filepath.FromSlash(cleanPath))
+		rel := filepath.FromSlash(cleanPath)
+		// Confine the request to uiDir: reject anything that escapes it
+		// (absolute paths, "..", etc.) before it reaches the filesystem.
+		if !filepath.IsLocal(rel) {
+			http.NotFound(w, r)
+			return
+		}
+		file := filepath.Join(uiDir, rel)
 		if info, err := os.Stat(file); err == nil && !info.IsDir() {
 			http.ServeFile(w, r, file)
 			return

--- a/internal/bootstrap/spa_traversal_test.go
+++ b/internal/bootstrap/spa_traversal_test.go
@@ -1,0 +1,47 @@
+package bootstrap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSPAHandlerRejectsTraversal verifies the SPA static file handler confines
+// requests to uiDir and never serves a file outside it via path traversal.
+func TestSPAHandlerRejectsTraversal(t *testing.T) {
+	uiDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(uiDir, "index.html"), []byte("<html>app</html>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	// A secret sibling of uiDir that must never be reachable.
+	secret := filepath.Join(filepath.Dir(uiDir), "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP SECRET"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	handler := spaFileHandler(uiDir)
+
+	for _, target := range []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/%2e%2e/secret.txt",
+		"/assets/../../secret.txt",
+	} {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if got := rr.Body.String(); got == "TOP SECRET" {
+			t.Fatalf("traversal %q leaked the secret file", target)
+		}
+	}
+
+	// A normal request still serves index.html (SPA fallback intact).
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || rr.Body.String() != "<html>app</html>" {
+		t.Fatalf("expected index.html for '/', got code=%d body=%q", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/graphstore/file_memory.go
+++ b/internal/graphstore/file_memory.go
@@ -306,7 +306,22 @@ func (s *FileMemoryStore) workspaceNames() []string {
 }
 
 func (s *FileMemoryStore) workspaceDir(workspace string) string {
-	return filepath.Join(s.root, "workspaces", url.PathEscape(workspace))
+	return filepath.Join(s.root, "workspaces", safeWorkspaceSegment(workspace))
+}
+
+// safeWorkspaceSegment turns a workspace id into a single, contained path
+// segment. url.PathEscape neutralizes path separators but leaves "." and ".."
+// intact, which would still traverse out of the workspaces directory; the
+// IsLocal guard rejects those. Valid workspace ids
+// (^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]?$) are returned unchanged.
+func safeWorkspaceSegment(workspace string) string {
+	seg := url.PathEscape(workspace)
+	if seg == "" || !filepath.IsLocal(seg) {
+		// Pathological segment ("", ".", ".."): make it inert so it can only
+		// ever name a child of the workspaces directory.
+		return "_" + url.PathEscape(seg)
+	}
+	return seg
 }
 
 func (s *FileMemoryStore) ensureMapsLocked() {

--- a/internal/graphstore/memory.go
+++ b/internal/graphstore/memory.go
@@ -187,7 +187,7 @@ func (s *MemoryStore) QueryEntities(ctx context.Context, plan model.EntityQueryP
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rows := make([]map[string]any, 0, limit)
+	rows := make([]map[string]any, 0, allocHint(limit))
 	keys := make([]string, 0, len(s.entities[plan.Workspace]))
 	for key := range s.entities[plan.Workspace] {
 		keys = append(keys, key)
@@ -222,7 +222,7 @@ func (s *MemoryStore) QueryTopo(ctx context.Context, plan model.TopoQueryPlan) (
 		return s.queryCypherLocked(plan, limit)
 	}
 
-	rows := make([]map[string]any, 0, limit)
+	rows := make([]map[string]any, 0, allocHint(limit))
 	keys := make([]string, 0, len(s.relations[plan.Workspace]))
 	for key := range s.relations[plan.Workspace] {
 		keys = append(keys, key)
@@ -508,6 +508,23 @@ func methodOf(payload map[string]any) string {
 func normalizeLimit(limit, fallback int) int {
 	if limit <= 0 {
 		return fallback
+	}
+	return limit
+}
+
+// maxPreallocRows bounds the initial capacity we reserve for a result slice.
+// The slice still grows via append, so this never truncates results — it only
+// stops a caller-supplied limit from driving a huge up-front allocation
+// (defense in depth; the planner already caps limit against provider
+// capability before a request reaches the store).
+const maxPreallocRows = 1024
+
+func allocHint(limit int) int {
+	if limit < 0 {
+		return 0
+	}
+	if limit > maxPreallocRows {
+		return maxPreallocRows
 	}
 	return limit
 }

--- a/internal/graphstore/path_safety_test.go
+++ b/internal/graphstore/path_safety_test.go
@@ -1,0 +1,57 @@
+package graphstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSafeWorkspaceSegmentStaysContained verifies that no workspace id —
+// including traversal attempts — can produce a path that escapes the
+// workspaces directory.
+func TestSafeWorkspaceSegmentStaysContained(t *testing.T) {
+	root := filepath.Join("/srv", "data")
+	base := filepath.Join(root, "workspaces")
+
+	for _, ws := range []string{
+		"demo", "ws-1", "a_b",
+		"..", "../..", "../../etc/passwd", ".", "", "a/b", "..%2f..", "/etc/passwd",
+	} {
+		seg := safeWorkspaceSegment(ws)
+		if strings.ContainsAny(seg, "/\\") {
+			t.Fatalf("workspace %q produced a multi-segment path: %q", ws, seg)
+		}
+		full := filepath.Join(base, seg)
+		rel, err := filepath.Rel(base, full)
+		if err != nil {
+			t.Fatalf("workspace %q: rel error: %v", ws, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("workspace %q escaped the workspaces dir: full=%q rel=%q", ws, full, rel)
+		}
+	}
+}
+
+// TestSafeWorkspaceSegmentPreservesValidIDs verifies valid workspace ids are
+// passed through unchanged (so existing on-disk layouts are unaffected).
+func TestSafeWorkspaceSegmentPreservesValidIDs(t *testing.T) {
+	for _, ws := range []string{"demo", "incident", "service-localization", "ws_1", "a0"} {
+		if got := safeWorkspaceSegment(ws); got != ws {
+			t.Fatalf("valid workspace %q changed to %q", ws, got)
+		}
+	}
+}
+
+// TestAllocHintBounded verifies the prealloc hint is capped, so a huge
+// caller-supplied limit cannot drive a giant up-front allocation.
+func TestAllocHintBounded(t *testing.T) {
+	if got := allocHint(50); got != 50 {
+		t.Fatalf("allocHint(50) = %d, want 50", got)
+	}
+	if got := allocHint(-5); got != 0 {
+		t.Fatalf("allocHint(-5) = %d, want 0", got)
+	}
+	if got := allocHint(1 << 30); got != maxPreallocRows {
+		t.Fatalf("allocHint(2^30) = %d, want %d (capped)", got, maxPreallocRows)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **8 of the 10 open high-severity CodeQL alerts** — defense-in-depth hardening at the graphstore and static-file layers, which previously trusted their own inputs even though the upstream API validates workspace ids and the planner caps query limits.

| Rule | Location | Fix |
|---|---|---|
| `go/path-injection` | `internal/bootstrap/app.go` (SPA handler) | Reject any non-`filepath.IsLocal` request path before joining onto `uiDir` |
| `go/path-injection` | `internal/graphstore/file_memory.go` (`workspaceDir`) | New `safeWorkspaceSegment`: `url.PathEscape` neutralizes separators but leaves `.`/`..` intact → caught by an `IsLocal` guard |
| `go/uncontrolled-allocation-size` | `internal/graphstore/memory.go` (`QueryEntities`/`QueryTopo`) | Cap the `make([]…, 0, limit)` prealloc via `allocHint` (max 1024) |

All three are **behavior-preserving**:
- Valid workspace ids (`^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]?$`) pass through `safeWorkspaceSegment` unchanged, so on-disk layouts are unaffected.
- The query prealloc cap only bounds the *initial* slice capacity; the slice still grows via `append` and result truncation still uses the real `limit`, so query results are identical.
- The SPA handler still serves real assets and the `index.html` fallback; only traversal / absolute paths are rejected.

## Test plan

- [x] New `internal/graphstore/path_safety_test.go` — segment containment for `..`, `../../etc`, `.`, `a/b`, absolute; valid-id passthrough; `allocHint` cap.
- [x] New `internal/bootstrap/spa_traversal_test.go` — `/../secret.txt` and friends cannot leak a file outside `uiDir`; SPA fallback intact.
- [x] `make ci` green.

## Not in this PR — the 2 `import.go` alerts (deliberate)

`internal/umodel/import.go:77,140` (`go/path-injection`) flag `req.Path` from `POST /api/v1/umodel/{ws}/import` flowing into `os.Stat`/`os.ReadFile`. Unlike the above, **reading operator-provided local packs by absolute path is the intended feature**: the import tests import from `t.TempDir()` (absolute paths outside CWD), and the CLI documents `umctl umodel import demo <path>`. Confining it would break a documented capability, not fix a bug.

This is a **trust-model decision** to make separately:
- **(a)** accept by design and dismiss the two alerts with justification (import is an operator/admin local-filesystem capability on a local service, à la `kubectl apply -f <path>`); mitigate by deployment guidance (don't expose the import endpoint publicly) + a `SECURITY.md` note, **or**
- **(b)** add an opt-in `--import-root` flag that confines imports when set (default unrestricted, preserving current behavior).

Happy to do either as a follow-up once the direction is chosen.