### PR TITLE
feat(skills): one-command install via Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,43 @@
+{
+  "name": "unifiedmodel",
+  "owner": {
+    "name": "UnifiedModel (UModel) maintainers"
+  },
+  "metadata": {
+    "description": "Agent skills for UModel — the open-source object-graph semantic layer for observability and AI agents.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "umodel",
+      "displayName": "UModel",
+      "description": "Use UModel from your agent: read entities, relationships, topology, and the model itself through the umctl CLI, and run model-guided autonomous root-cause analysis over the object graph. Bundles the umodel-query and umodel-rca skills.",
+      "source": "./",
+      "strict": false,
+      "version": "0.1.0",
+      "author": {
+        "name": "UnifiedModel (UModel) maintainers"
+      },
+      "homepage": "https://github.com/alibaba/UnifiedModel",
+      "repository": "https://github.com/alibaba/UnifiedModel",
+      "license": "Apache-2.0",
+      "keywords": [
+        "observability",
+        "semantic-layer",
+        "object-graph",
+        "topology",
+        "root-cause-analysis",
+        "rca",
+        "aiops",
+        "agent",
+        "mcp",
+        "umctl"
+      ],
+      "category": "observability",
+      "skills": [
+        "./skills/umodel-query",
+        "./skills/umodel-rca"
+      ]
+    }
+  ]
+}

--- a/skills/QUICKSTART.md
+++ b/skills/QUICKSTART.md
@@ -20,12 +20,14 @@ locally, in memory, with **no API key and no network**.
 The skills are plain `SKILL.md` files under [`skills/`](README.md). How you install
 depends on your agent:
 
-- **Claude Code** (native skills) — copy into a skills directory it scans:
-  ```bash
-  mkdir -p .claude/skills
-  cp -R skills/umodel-query skills/umodel-rca .claude/skills/
+- **Claude Code** — install both skills as a plugin in one command:
   ```
-  (or your user-level `~/.claude/skills/`).
+  /plugin marketplace add alibaba/UnifiedModel
+  /plugin install umodel@unifiedmodel
+  ```
+  The `umodel` plugin bundles both skills; they auto-activate by prompt. (Or copy
+  them into a scanned directory: `mkdir -p .claude/skills && cp -R
+  skills/umodel-query skills/umodel-rca .claude/skills/`.)
 - **Qoder / Codex / agents without a `SKILL.md` loader** — the skills are just
   instructions, so include their content as agent context: reference or paste
   [`skills/umodel-query/SKILL.md`](umodel-query/SKILL.md) and

--- a/skills/QUICKSTART.zh-CN.md
+++ b/skills/QUICKSTART.zh-CN.md
@@ -17,12 +17,13 @@ runtime）、约 65 个实体、约 83 条关系、1 个 Runbook，以及指标/
 
 技能就是 [`skills/`](README.zh-CN.md) 下的 `SKILL.md` 文件。安装方式取决于你的 Agent：
 
-- **Claude Code**（原生技能）—— 拷贝到它扫描的技能目录：
-  ```bash
-  mkdir -p .claude/skills
-  cp -R skills/umodel-query skills/umodel-rca .claude/skills/
+- **Claude Code** —— 一条命令把两个技能作为插件装上：
   ```
-  （或用户级 `~/.claude/skills/`）。
+  /plugin marketplace add alibaba/UnifiedModel
+  /plugin install umodel@unifiedmodel
+  ```
+  `umodel` 插件含两个技能，按提问自动激活。（或拷贝到扫描目录：`mkdir -p
+  .claude/skills && cp -R skills/umodel-query skills/umodel-rca .claude/skills/`。）
 - **Qoder / Codex / 没有 `SKILL.md` 加载器的 Agent** —— 技能就是一段指令，把内容作为
   Agent 上下文带上即可：把 [`skills/umodel-query/SKILL.md`](umodel-query/SKILL.md)
   和 [`skills/umodel-rca/SKILL.md`](umodel-rca/SKILL.md) 引用或粘贴进项目指令

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,6 +37,21 @@ No API key or network is required for the demo.
 
 ## Using a skill
 
+### Option A — Claude Code plugin marketplace (one command)
+
+In Claude Code, install both skills as a plugin straight from this repo:
+
+```
+/plugin marketplace add alibaba/UnifiedModel
+/plugin install umodel@unifiedmodel
+```
+
+This installs the `umodel` plugin — both `umodel-query` and `umodel-rca` — which
+then activate automatically based on your prompt. Update later with
+`/plugin marketplace update unifiedmodel`.
+
+### Option B — copy into a skills directory (any agent)
+
 Most skill-aware agents discover skills from a directory. Point your agent at a
 skill here, or copy it into the location your agent scans, for example:
 

--- a/skills/README.zh-CN.md
+++ b/skills/README.zh-CN.md
@@ -33,6 +33,20 @@ demo 无需任何密钥或网络。
 
 ## 使用技能
 
+### 方式 A —— Claude Code 插件市场（一条命令）
+
+在 Claude Code 里，直接从本仓库把两个技能作为插件装上：
+
+```
+/plugin marketplace add alibaba/UnifiedModel
+/plugin install umodel@unifiedmodel
+```
+
+这会装上 `umodel` 插件——含 `umodel-query` 与 `umodel-rca`——随后按你的提问自动激活。
+之后用 `/plugin marketplace update unifiedmodel` 更新。
+
+### 方式 B —— 拷贝到技能目录（任意 Agent）
+
 多数支持技能的 Agent 从一个目录发现技能。把这里的技能指给你的 Agent，或拷贝到
 Agent 扫描的位置，例如：
 


### PR DESCRIPTION
## What

Packages the two agent skills (`umodel-query`, `umodel-rca`) as an installable **Claude Code plugin**, so users add both in one command instead of copying directories:

```
/plugin marketplace add alibaba/UnifiedModel
/plugin install umodel@unifiedmodel
```

Both skills then activate automatically based on the user's prompt.

## Changes

- **`.claude-plugin/marketplace.json`** — a `unifiedmodel` marketplace with a single `umodel` plugin that bundles both skills (`strict: false`, `source: "./"`, skills listed explicitly, `Apache-2.0`, `observability` category). Mirrors the `anthropics/skills` layout.
- **`skills/README.md` + `skills/QUICKSTART.md`** (and `.zh-CN`) — lead the Claude Code install with the one-command marketplace flow; keep `cp -R` as the any-agent fallback.

## Scope / boundary

The MCP server is **not** bundled in the plugin this round. It needs a Go toolchain and a running backend, which would make a skills install brittle and drag a runtime dependency into what should be a markdown-only install. Cross-tool MCP distribution is tracked separately — publishing `umodel-mcp` to the **MCP Registry** once it has a public install artifact (Docker image / release binary).

## Verification

- `claude plugin validate .` → ✔ passed.
- `claude plugin marketplace add <local>` → registered cleanly; source resolves.

## Notes

- **Stacked on #37** (the skills live there). Base retargets to `main` once #37 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)