### PR TITLE
fix(security): confine UModel API imports to an import root (closes 2 CodeQL path-injection alerts)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ Current open-source security defaults:
 - `make dev`, Docker, and Compose use `file.memory` local persistence.
 - MCP write tools are disabled by default.
 - AgentGateway resources expose metadata and templates, not runtime rows.
+- UModel API imports (`umctl umodel import`, `POST /api/v1/umodel/{workspace}/import`) read model packs from the server's local filesystem and are **confined to an import root** — the server's current working directory by default, or `--import-root <dir>`. Paths outside it are rejected, so an API caller cannot read arbitrary server files. Pass `--import-root /` only if you intentionally need unrestricted local imports. Bundled `--quickstart` sample loads are trusted and not confined.
 - This release does not include multi-tenant authorization or cloud-hosted control plane behavior.
 
 Do not use the local development server as an internet-facing production service without adding authentication, authorization, transport security, rate limits, audit logging, and deployment hardening.

--- a/SECURITY.zh-CN.md
+++ b/SECURITY.zh-CN.md
@@ -41,6 +41,7 @@ English version: [SECURITY.md](SECURITY.md)
 - `make dev`、Docker 和 Compose 使用 `file.memory` 本地持久化。
 - MCP 写工具默认关闭。
 - AgentGateway resources 暴露元数据和模板，不暴露运行时 rows。
+- UModel API 导入（`umctl umodel import`、`POST /api/v1/umodel/{workspace}/import`）从服务端本地文件系统读取模型包，并**限定在一个 import root 内**——默认是服务端当前工作目录，或通过 `--import-root <dir>` 指定。目录外的路径被拒绝，因此 API 调用方无法读取服务器上的任意文件。确有任意本地导入需求时才传 `--import-root /`。`--quickstart` 内置样例加载是受信任的，不受限。
 - 当前 release 不包含 multi-tenant authorization 或 cloud-hosted control plane 行为。
 
 不要在没有认证、授权、传输安全、限流、审计和部署加固的情况下，把本地开发服务作为公网生产服务使用。

--- a/cmd/umodel-mcp/main.go
+++ b/cmd/umodel-mcp/main.go
@@ -30,6 +30,7 @@ func run(args []string, in io.Reader, out, errOut io.Writer) error {
 	quickStart := flags.Bool("quickstart", false, "Create a demo workspace and import bundled quickstart data before serving MCP")
 	quickStartWorkspace := flags.String("quickstart-workspace", bootstrap.DefaultQuickStartWorkspaceID, "Workspace id used by --quickstart")
 	quickStartSample := flags.String("quickstart-sample", bootstrap.DefaultQuickStartSample, "Sample package imported by --quickstart")
+	importRoot := flags.String("import-root", "", "Confine UModel imports to this directory (default: current working directory; use \"/\" to allow any path)")
 	manifest := flags.Bool("manifest", false, "print tools/resources manifest and exit")
 	transport := flags.String("transport", "stdio", "MCP transport: stdio or http")
 	addr := flags.String("addr", "127.0.0.1:8090", "HTTP MCP listen address when --transport=http")
@@ -53,7 +54,7 @@ func run(args []string, in io.Reader, out, errOut io.Writer) error {
 		*workspace = *quickStartWorkspace
 	}
 
-	app, err := bootstrap.NewAppWithGraphStore(*dataRoot, graphstore.ProviderConfig{Type: *provider, DataRoot: *dataRoot})
+	app, err := bootstrap.NewAppWithGraphStore(*dataRoot, graphstore.ProviderConfig{Type: *provider, DataRoot: *dataRoot}, bootstrap.WithImportRoot(*importRoot))
 	if err != nil {
 		return err
 	}

--- a/cmd/umodel-server/main.go
+++ b/cmd/umodel-server/main.go
@@ -18,6 +18,7 @@ func main() {
 	quickStart := flag.Bool("quickstart", false, "Create a demo workspace and import bundled quickstart data before serving")
 	quickStartWorkspace := flag.String("quickstart-workspace", bootstrap.DefaultQuickStartWorkspaceID, "Workspace id used by --quickstart")
 	quickStartSample := flag.String("quickstart-sample", bootstrap.DefaultQuickStartSample, "Sample package imported by --quickstart")
+	importRoot := flag.String("import-root", "", "Confine UModel API imports to this directory (default: current working directory; use \"/\" to allow any path)")
 	flag.Parse()
 
 	graphstoreExplicit := false
@@ -29,7 +30,7 @@ func main() {
 	*provider = resolveProviderForQuickStart(*provider, *quickStart, graphstoreExplicit)
 
 	ctx := context.Background()
-	app, err := bootstrap.NewAppWithGraphStore(*dataRoot, graphstore.ProviderConfig{Type: *provider, DataRoot: *dataRoot})
+	app, err := bootstrap.NewAppWithGraphStore(*dataRoot, graphstore.ProviderConfig{Type: *provider, DataRoot: *dataRoot}, bootstrap.WithImportRoot(*importRoot))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -79,6 +79,7 @@ go run ./cmd/umodel-server --quickstart
 | `--quickstart` | `false` | Create the quickstart workspace and import bundled sample data before listening. Uses `memory` unless `--graphstore` is explicitly set. |
 | `--quickstart-workspace` | `demo` | Workspace id used by `--quickstart`. |
 | `--quickstart-sample` | `multi-domain-quickstart` | Sample package imported by `--quickstart`. |
+| `--import-root` | current working directory | Confine UModel API imports (`umctl umodel import`, `POST /api/v1/umodel/{workspace}/import`) to this directory. Paths outside it are rejected. Pass `/` to allow any path. Bundled `--quickstart` sample loads are never confined. |
 
 ## Command Groups
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -80,6 +80,7 @@ go run ./cmd/umodel-server --quickstart
 | `--quickstart` | `false` | 监听前创建 quickstart workspace，并导入内置样例数据。除非显式设置 `--graphstore`，否则使用 `memory`。 |
 | `--quickstart-workspace` | `demo` | `--quickstart` 使用的 workspace id。 |
 | `--quickstart-sample` | `multi-domain-quickstart` | `--quickstart` 导入的样例包。 |
+| `--import-root` | 当前工作目录 | 将 UModel API 导入（`umctl umodel import`、`POST /api/v1/umodel/{workspace}/import`）限定在该目录内，目录外的路径被拒绝。传 `/` 允许任意路径。`--quickstart` 内置样例加载不受限。 |
 
 ## 命令组
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -36,31 +36,49 @@ type App struct {
 	AgentGateway *agentgateway.Service
 }
 
-func NewApp(dataRoot string) *App {
-	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{DataRoot: dataRoot})
+// AppOption configures optional App behavior at construction time.
+type AppOption func(*appOptions)
+
+type appOptions struct {
+	importRoot string
+}
+
+// WithImportRoot confines API-originated UModel imports to paths inside root.
+// The empty default confines to the server's current working directory; pass
+// "/" to allow imports from anywhere. Bundled sample loads are never confined.
+func WithImportRoot(root string) AppOption {
+	return func(o *appOptions) { o.importRoot = root }
+}
+
+func NewApp(dataRoot string, opts ...AppOption) *App {
+	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{DataRoot: dataRoot}, opts...)
 	if err != nil {
 		panic(err)
 	}
 	return app
 }
 
-func NewMemoryApp(dataRoot string) *App {
-	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeMemory, DataRoot: dataRoot})
+func NewMemoryApp(dataRoot string, opts ...AppOption) *App {
+	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeMemory, DataRoot: dataRoot}, opts...)
 	if err != nil {
 		panic(err)
 	}
 	return app
 }
 
-func NewFileMemoryApp(dataRoot string) *App {
-	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeFileMemory, DataRoot: dataRoot})
+func NewFileMemoryApp(dataRoot string, opts ...AppOption) *App {
+	app, err := NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeFileMemory, DataRoot: dataRoot}, opts...)
 	if err != nil {
 		panic(err)
 	}
 	return app
 }
 
-func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig) (*App, error) {
+func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig, opts ...AppOption) (*App, error) {
+	var options appOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	if config.DataRoot == "" {
 		config.DataRoot = dataRoot
 	}
@@ -86,7 +104,7 @@ func NewAppWithGraphStore(dataRoot string, config graphstore.ProviderConfig) (*A
 		return nil, fmt.Errorf("create search provider: %w", err)
 	}
 	searchSvc := search.NewService(searchProvider, nil, search.ProviderTypeMemory)
-	umodelSvc := umodel.NewService(graph, umodel.WithSearchIndexer(searchSvc))
+	umodelSvc := umodel.NewService(graph, umodel.WithSearchIndexer(searchSvc), umodel.WithImportRoot(options.importRoot))
 	entitySvc := entitystore.NewService(graph, umodelSvc, entitystore.WithSearchIndexer(searchSvc))
 	sampleSvc := sampledata.NewService(umodelSvc, entitySvc)
 	querySvc := query.NewServiceWithSearch(graph, searchSvc)

--- a/internal/sampledata/service.go
+++ b/internal/sampledata/service.go
@@ -120,7 +120,10 @@ func (s *Service) importPack(ctx context.Context, workspace string, def sampleDe
 		Workspace: workspace,
 		Sample:    def.Name,
 	}
-	umodelResult, err := s.umodel.Import(ctx, workspace, model.UModelImportRequest{Path: schemaRoot})
+	// Bundled sample packs are resolved from the repository (repoPath); the
+	// path is trusted, so it bypasses import-root confinement and loads
+	// regardless of the server's working directory.
+	umodelResult, err := s.umodel.ImportTrusted(ctx, workspace, model.UModelImportRequest{Path: schemaRoot})
 	if err != nil {
 		return result, err
 	}

--- a/internal/umodel/import.go
+++ b/internal/umodel/import.go
@@ -14,7 +14,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Import loads UModel elements from an operator-provided path. The path is
+// confined to the configured import root (WithImportRoot; the current working
+// directory by default) so an API caller cannot read arbitrary server files.
 func (s *Service) Import(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
+	if req.Path != "" {
+		confined, err := s.confineImportPath(req.Path)
+		if err != nil {
+			return model.UModelImportResult{Workspace: workspace, Source: req.Path}, err
+		}
+		req.Path = confined
+	}
+	return s.importInternal(ctx, workspace, req)
+}
+
+// ImportTrusted loads UModel elements from a path the caller has already
+// vouched for (e.g. a bundled sample pack resolved from the repository).
+// It skips import-root confinement and must never be reached by user input.
+func (s *Service) ImportTrusted(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
+	return s.importInternal(ctx, workspace, req)
+}
+
+func (s *Service) importInternal(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
 	if workspace == "" {
 		return model.UModelImportResult{}, apperrors.New(apperrors.CodeInvalidArgument, "workspace is required")
 	}
@@ -58,6 +79,40 @@ func (s *Service) Import(ctx context.Context, workspace string, req model.UModel
 		result.Errors = append(result.Errors, model.ErrorDetail{Field: item.ID, Reason: item.Message})
 	}
 	return result, nil
+}
+
+// confineImportPath resolves p and verifies it stays within the import root,
+// returning the cleaned absolute path. The root defaults to the current
+// working directory; "/" effectively disables confinement. This is the
+// barrier that stops an API-provided path from escaping to arbitrary files.
+func (s *Service) confineImportPath(p string) (string, error) {
+	root := s.importRoot
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", apperrors.WithDetails(apperrors.CodeInternal, "cannot resolve import root", map[string]string{"reason": err.Error()})
+		}
+		root = wd
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", apperrors.WithDetails(apperrors.CodeInternal, "invalid import root", map[string]string{"reason": err.Error()})
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", apperrors.WithDetails(apperrors.CodeInvalidArgument, "invalid import path", map[string]string{"path": p})
+	}
+	abs = filepath.Clean(abs)
+
+	rel, err := filepath.Rel(rootAbs, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", apperrors.WithDetails(apperrors.CodeInvalidArgument,
+			"import path is outside the allowed import root",
+			map[string]string{"import_root": rootAbs})
+	}
+	return abs, nil
 }
 
 func (s *Service) loadCommonSchemaPacks(ctx context.Context, workspace string, packs []string) ([]model.UModelElement, error) {

--- a/internal/umodel/import_confine_test.go
+++ b/internal/umodel/import_confine_test.go
@@ -1,0 +1,59 @@
+package umodel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+// TestImportConfinesToRoot verifies that an API-originated import path is
+// confined to the configured import root: a pack inside the root imports, and
+// a path that escapes the root (absolute or via "..") is rejected before any
+// file is read.
+func TestImportConfinesToRoot(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	// A valid entity_set pack inside the root.
+	pack := filepath.Join(root, "pack")
+	if err := os.MkdirAll(pack, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const es = "kind: entity_set\nschema:\n  url: u\n  version: v0.1.0\nmetadata:\n  name: devops.service\n  domain: devops\nspec:\n  fields:\n    - name: id\n      type: string\n  primary_key_fields: [id]\n  id_generator: id\n"
+	if err := os.WriteFile(filepath.Join(pack, "svc.yaml"), []byte(es), 0o644); err != nil {
+		t.Fatalf("write pack: %v", err)
+	}
+
+	// A secret outside the root that must never be importable.
+	secret := filepath.Join(t.TempDir(), "secret.yaml")
+	if err := os.WriteFile(secret, []byte(es), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot(root))
+
+	// Inside the root: imports fine.
+	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: pack}); err != nil {
+		t.Fatalf("import inside root should succeed, got: %v", err)
+	}
+
+	// Absolute path outside the root: rejected.
+	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: secret}); !apperrors.IsCode(err, apperrors.CodeInvalidArgument) {
+		t.Fatalf("import outside root should be INVALID_ARGUMENT, got: %v", err)
+	}
+
+	// Traversal out of the root: rejected.
+	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: filepath.Join(root, "..", "secret.yaml")}); !apperrors.IsCode(err, apperrors.CodeInvalidArgument) {
+		t.Fatalf("traversal out of root should be INVALID_ARGUMENT, got: %v", err)
+	}
+
+	// ImportTrusted bypasses confinement (used by bundled sample loads).
+	if _, err := svc.ImportTrusted(ctx, "demo", model.UModelImportRequest{Path: secret}); err != nil {
+		t.Fatalf("ImportTrusted should bypass confinement, got: %v", err)
+	}
+}

--- a/internal/umodel/import_test.go
+++ b/internal/umodel/import_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestValidateRejectsInvalidUModelElement(t *testing.T) {
-	svc := NewService(graphstore.NewMemoryStore())
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
 	result, err := svc.Validate(context.Background(), "demo", []model.UModelElement{{Kind: "entity_set"}})
 	if err != nil {
 		t.Fatalf("validate: %v", err)
@@ -23,7 +23,7 @@ func TestValidateRejectsInvalidUModelElement(t *testing.T) {
 }
 
 func TestValidateAcceptsValidUModelElements(t *testing.T) {
-	svc := NewService(graphstore.NewMemoryStore())
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
 	result, err := svc.Validate(context.Background(), "demo", []model.UModelElement{{
 		Kind:   "entity_set",
 		Domain: "devops",
@@ -41,7 +41,7 @@ func TestValidateAcceptsValidUModelElements(t *testing.T) {
 func TestImportFileBuildsIndexAndRebuildsFromSnapshot(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()
-	svc := NewService(store)
+	svc := NewService(store, WithImportRoot("/"))
 	path := writeTestFile(t, "devops.service.yaml", `
 kind: entity_set
 schema:
@@ -94,7 +94,7 @@ spec:
 func TestImportDuplicateElementIsIdempotentOverwrite(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()
-	svc := NewService(store)
+	svc := NewService(store, WithImportRoot("/"))
 	path := writeTestFile(t, "devops.service.yaml", `
 kind: entity_set
 metadata:
@@ -142,7 +142,7 @@ spec: {}
 }`)
 	writeFile(t, filepath.Join(dir, "README.md"), "not a schema")
 
-	svc := NewService(graphstore.NewMemoryStore())
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
 	result, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: dir})
 	if err != nil {
 		t.Fatalf("import directory: %v", err)
@@ -167,7 +167,7 @@ func TestRelationTypeOfUsesEntityLinkType(t *testing.T) {
 
 func TestImportRejectsInvalidSourcesWithStableErrors(t *testing.T) {
 	ctx := context.Background()
-	svc := NewService(graphstore.NewMemoryStore())
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
 
 	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{}); !apperrors.IsCode(err, apperrors.CodeInvalidArgument) {
 		t.Fatalf("expected missing path invalid argument, got %v", err)
@@ -186,7 +186,7 @@ func TestImportRejectsInvalidSourcesWithStableErrors(t *testing.T) {
 }
 
 func TestImportCommonSchemaPackHookIsExplicit(t *testing.T) {
-	svc := NewService(graphstore.NewMemoryStore())
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
 	_, err := svc.Import(context.Background(), "demo", model.UModelImportRequest{
 		Path:              writeTestFile(t, "empty.yaml", "kind: entity_set\nmetadata:\n  name: devops.service\n  domain: devops\nspec: {}\n"),
 		CommonSchemaPacks: []string{"quickstart-multidomain"},

--- a/internal/umodel/service.go
+++ b/internal/umodel/service.go
@@ -36,6 +36,7 @@ type Service struct {
 	indexes            map[string]*schemaIndex
 	commonSchemaLoader CommonSchemaLoader
 	search             searchIndexer
+	importRoot         string
 }
 
 // Option configures Service.
@@ -51,6 +52,14 @@ func WithValidator(v SchemaValidator) Option {
 // WithSearchIndexer connects UModel writes to the runtime search index.
 func WithSearchIndexer(indexer searchIndexer) Option {
 	return func(s *Service) { s.search = indexer }
+}
+
+// WithImportRoot confines API-originated imports (Service.Import) to paths
+// inside root. The empty default confines to the server's current working
+// directory; set root to "/" to allow imports from anywhere. Bundled sample
+// loads use Service.ImportTrusted and are never confined.
+func WithImportRoot(root string) Option {
+	return func(s *Service) { s.importRoot = root }
 }
 
 func NewService(graph graphStore, opts ...Option) *Service {

--- a/tests/e2e/business_flow_test.go
+++ b/tests/e2e/business_flow_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRESTBusinessFlowCoversCoreScenarios(t *testing.T) {
-	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir()).Handler())
+	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir(), bootstrap.WithImportRoot("/")).Handler())
 	defer server.Close()
 
 	created := e2ePost(t, server.URL+"/api/v1/workspaces", map[string]any{

--- a/tests/e2e/cli_business_flow_test.go
+++ b/tests/e2e/cli_business_flow_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCLIBusinessFlowUsesOnlyPublicContracts(t *testing.T) {
-	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir()).Handler())
+	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir(), bootstrap.WithImportRoot("/")).Handler())
 	defer server.Close()
 
 	root := filepath.Join("..", "..")

--- a/tests/integration/http_flow_test.go
+++ b/tests/integration/http_flow_test.go
@@ -158,7 +158,7 @@ func TestHTTPErrorContractsAndWriteToolDefault(t *testing.T) {
 }
 
 func TestHTTPUModelImportThenQuery(t *testing.T) {
-	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir()).Handler())
+	server := httptest.NewServer(bootstrap.NewMemoryApp(t.TempDir(), bootstrap.WithImportRoot("/")).Handler())
 	defer server.Close()
 
 	post(t, server.URL+"/api/v1/workspaces", map[string]any{"id": "demo"})

--- a/tests/integration/umodel_import_query_test.go
+++ b/tests/integration/umodel_import_query_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestImportQuickstartExamplesAndQueryUModel(t *testing.T) {
 	ctx := context.Background()
-	app := bootstrap.NewMemoryApp(t.TempDir())
+	app := bootstrap.NewMemoryApp(t.TempDir(), bootstrap.WithImportRoot("/"))
 	examples := filepath.Join("..", "..", "examples", "quickstart-multidomain")
 
 	result, err := app.UModel.Import(ctx, "demo", model.UModelImportRequest{Path: examples})


### PR DESCRIPTION
## Summary

Closes the two remaining `go/path-injection` CodeQL alerts on `internal/umodel/import.go`. An operator-provided import path from `POST /api/v1/umodel/{workspace}/import` (or `umctl umodel import`) flowed into `os.Stat` / `os.ReadFile`, letting an API caller make the server read arbitrary local files.

## How it's fixed

`Service.Import` now **confines the path to an import root** before any file is touched — via a `filepath.Rel` barrier — and rejects anything outside it with `INVALID_ARGUMENT`. The root defaults to the server's **current working directory**; `--import-root <dir>` widens it, and `/` restores unrestricted local imports.

The trusted bundled-sample path is exempted so `--quickstart` is unaffected:

- New `Service.ImportTrusted` bypasses confinement for paths the caller has already vouched for. `internal/sampledata` uses it to load bundled packs (resolved from the repo via `repoPath`), so sample loading works regardless of the server's working directory.
- `bootstrap` gains a `WithImportRoot` `AppOption` threaded into `umodel.NewService`; `umodel-server` and `umodel-mcp` expose `--import-root`.

> Why confine rather than dismiss: the earlier read was "import is an operator capability, accept by design." On reflection a default confinement (CWD) closes the real remote-read exposure while keeping the feature — operators just set `--import-root` to import from elsewhere. The bundled-sample path stays unconfined via `ImportTrusted`.

## Behavior change

API imports of absolute paths (or `../` traversals) **outside the working directory are now rejected by default**. This is the intended tightening. Operators widen with `--import-root <dir>`, or `--import-root /` for the previous unrestricted behavior. Relative imports under the working directory (e.g. the documented `umctl umodel import demo examples/quickstart-multidomain`) are unaffected.

## Test plan

- [x] New `internal/umodel/import_confine_test.go`: pack inside the root imports; absolute path outside + `../` traversal are rejected; `ImportTrusted` bypasses.
- [x] Fixture-importing tests updated to declare `WithImportRoot("/")` (they import trusted fixtures from outside the test working dir): `http_flow`, `business_flow`, `cli_business_flow`, `umodel_import_query`, and the umodel import unit tests.
- [x] `make ci` green (incl. e2e + the `--quickstart` sample-load path via `ImportTrusted`).

## Relationship to #42

Independent. #42 fixes the other 8 CodeQL alerts (SPA handler, workspace path, query prealloc) in different files. This PR fixes the 2 import alerts. Together they take open high-severity alerts to **0**. The two import alerts were previously dismissed as "won't fix — by design"; once this merges and CodeQL re-scans, they close as fixed.