### PR TITLE
docs(readme): surface one-command Agent Skills install on the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Stop local services:
 make stop-all
 ```
 
+## Agent Skills
+
+Loadable skills let a skill-aware agent drive UModel directly — read entities, relations, topology, and the model itself, then run model-guided root-cause analysis over the object graph. In Claude Code, install both skills in one command:
+
+```
+/plugin marketplace add alibaba/UnifiedModel
+/plugin install umodel@unifiedmodel
+```
+
+Cursor, Qoder, Codex, and other agents load the same `SKILL.md` files directly. See [Agent Skills](skills/README.md) for the catalog and [the skills quickstart](skills/QUICKSTART.md) for an end-to-end walkthrough.
+
 ## Architecture
 
 ![UModel architecture](images/architecture.png)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,6 +73,17 @@ make quickstart
 make stop-all
 ```
 
+## Agent 技能
+
+可加载的技能让支持技能的 Agent 直接驱动 UModel——读取实体、关系、拓扑和模型本身，并在对象图上做模型引导的根因分析。在 Claude Code 里，一条命令装上两个技能：
+
+```
+/plugin marketplace add alibaba/UnifiedModel
+/plugin install umodel@unifiedmodel
+```
+
+Cursor、Qoder、Codex 等 Agent 可直接加载同样的 `SKILL.md` 文件。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，端到端走查见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
+
 ## 架构
 
 ![UModel 架构](images/architecture.png)

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,6 +73,17 @@ make quickstart
 make stop-all
 ```
 
+## Agent 技能
+
+可加载的技能让支持技能的 Agent 直接驱动 UModel——读取实体、关系、拓扑和模型本身，并在对象图上做模型引导的根因分析。在 Claude Code 里，一条命令装上两个技能：
+
+```
+/plugin marketplace add alibaba/UnifiedModel
+/plugin install umodel@unifiedmodel
+```
+
+Cursor、Qoder、Codex 等 Agent 可直接加载同样的 `SKILL.md` 文件。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，端到端走查见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
+
 ## 架构
 
 ![UModel 架构](images/architecture.png)


### PR DESCRIPTION
## What

Adds a short **Agent Skills** section to the root READMEs (front page) so the new one-command install is discoverable at a glance, now that the `umodel` plugin is on `main`:

```
/plugin marketplace add alibaba/UnifiedModel
/plugin install umodel@unifiedmodel
```

The section also notes that Cursor / Qoder / Codex load the same `SKILL.md` files directly, and links to the skills catalog + quickstart.

## Changes

- `README.md` (en) — new `## Agent Skills` section after Quick Start.
- `README_CN.md` + `README.zh-CN.md` (zh) — same section; the two kept byte-identical.

Doc-only, +33 lines, no deletions. Agent integration is an in-scope README topic; kept concise per the README conciseness rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)