### PR TITLE
docs(skills): per-platform skill install for Qoder and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Loadable skills let a skill-aware agent drive UModel directly — read entities,
 /plugin install umodel@unifiedmodel
 ```
 
-Cursor, Qoder, Codex, and other agents load the same `SKILL.md` files directly. See [Agent Skills](skills/README.md) for the catalog and [the skills quickstart](skills/QUICKSTART.md) for an end-to-end walkthrough.
+Qoder, Codex, Cursor, and other agents load the same two `SKILL.md` files — copy them into the agent's skills directory (`.qoder/skills/` for Qoder, `.agents/skills/` for Codex, `.claude/skills/` for Claude Code). See [Agent Skills](skills/README.md) for the catalog and [the skills quickstart](skills/QUICKSTART.md) for per-agent install.
 
 ## Architecture
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,7 +82,7 @@ make stop-all
 /plugin install umodel@unifiedmodel
 ```
 
-Cursor、Qoder、Codex 等 Agent 可直接加载同样的 `SKILL.md` 文件。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，端到端走查见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
+Qoder、Codex、Cursor 等 Agent 加载同样的两个 `SKILL.md` 文件——把它们拷进对应 Agent 的技能目录（Qoder 用 `.qoder/skills/`，Codex 用 `.agents/skills/`，Claude Code 用 `.claude/skills/`）。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，分平台安装见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
 
 ## 架构
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -82,7 +82,7 @@ make stop-all
 /plugin install umodel@unifiedmodel
 ```
 
-Cursor、Qoder、Codex 等 Agent 可直接加载同样的 `SKILL.md` 文件。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，端到端走查见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
+Qoder、Codex、Cursor 等 Agent 加载同样的两个 `SKILL.md` 文件——把它们拷进对应 Agent 的技能目录（Qoder 用 `.qoder/skills/`，Codex 用 `.agents/skills/`，Claude Code 用 `.claude/skills/`）。技能目录见 [UModel Agent 技能](skills/README.zh-CN.md)，分平台安装见 [技能快速上手](skills/QUICKSTART.zh-CN.md)。
 
 ## 架构
 

--- a/skills/QUICKSTART.md
+++ b/skills/QUICKSTART.md
@@ -17,8 +17,8 @@ locally, in memory, with **no API key and no network**.
 
 ## 1. Install the skills
 
-The skills are plain `SKILL.md` files under [`skills/`](README.md). How you install
-depends on your agent:
+The skills are plain `SKILL.md` folders under [`skills/`](README.md). All three
+agents load them natively — pick your client:
 
 - **Claude Code** — install both skills as a plugin in one command:
   ```
@@ -26,14 +26,24 @@ depends on your agent:
   /plugin install umodel@unifiedmodel
   ```
   The `umodel` plugin bundles both skills; they auto-activate by prompt. (Or copy
-  them into a scanned directory: `mkdir -p .claude/skills && cp -R
-  skills/umodel-query skills/umodel-rca .claude/skills/`.)
-- **Qoder / Codex / agents without a `SKILL.md` loader** — the skills are just
-  instructions, so include their content as agent context: reference or paste
-  [`skills/umodel-query/SKILL.md`](umodel-query/SKILL.md) and
-  [`skills/umodel-rca/SKILL.md`](umodel-rca/SKILL.md) into your project
-  instructions (e.g. `AGENTS.md`) or attach them to the conversation.
+  them into `.claude/skills/`.)
+- **Qoder** — copy both skills into the workspace skills directory:
+  ```bash
+  mkdir -p .qoder/skills && cp -R skills/umodel-query skills/umodel-rca .qoder/skills/
+  ```
+  They auto-activate by prompt, or trigger one manually with `/umodel-query`.
+  (Qoder also has a Skills Marketplace and a built-in `create-skill` helper.)
+- **Codex** — copy both into the vendor-neutral `.agents/skills/` directory (use
+  `~/.agents/skills/` to make them user-global):
+  ```bash
+  mkdir -p .agents/skills && cp -R skills/umodel-query skills/umodel-rca .agents/skills/
+  ```
+  They auto-activate by description, or mention one with `$umodel-query` (type `$`,
+  or run `/skills`, to browse). Restart Codex if a new skill doesn't appear.
 
+> `.agents/skills/` is the cross-agent open-standard path — Qoder reads it too, so a
+> single copy there can serve both Qoder and Codex.
+>
 > A skill's `description` is what triggers activation in agents that support skills.
 
 ## 2. Initialize the demo data

--- a/skills/QUICKSTART.zh-CN.md
+++ b/skills/QUICKSTART.zh-CN.md
@@ -15,20 +15,29 @@ runtime）、约 65 个实体、约 83 条关系、1 个 Runbook，以及指标/
 
 ## 1. 安装技能
 
-技能就是 [`skills/`](README.zh-CN.md) 下的 `SKILL.md` 文件。安装方式取决于你的 Agent：
+技能就是 [`skills/`](README.zh-CN.md) 下的 `SKILL.md` 目录。三个 Agent 都原生加载，按你的客户端选：
 
 - **Claude Code** —— 一条命令把两个技能作为插件装上：
   ```
   /plugin marketplace add alibaba/UnifiedModel
   /plugin install umodel@unifiedmodel
   ```
-  `umodel` 插件含两个技能，按提问自动激活。（或拷贝到扫描目录：`mkdir -p
-  .claude/skills && cp -R skills/umodel-query skills/umodel-rca .claude/skills/`。）
-- **Qoder / Codex / 没有 `SKILL.md` 加载器的 Agent** —— 技能就是一段指令，把内容作为
-  Agent 上下文带上即可：把 [`skills/umodel-query/SKILL.md`](umodel-query/SKILL.md)
-  和 [`skills/umodel-rca/SKILL.md`](umodel-rca/SKILL.md) 引用或粘贴进项目指令
-  （如 `AGENTS.md`），或直接附到对话里。
+  `umodel` 插件含两个技能，按提问自动激活。（或拷贝到 `.claude/skills/`。）
+- **Qoder** —— 把两个技能拷进工作区 skills 目录：
+  ```bash
+  mkdir -p .qoder/skills && cp -R skills/umodel-query skills/umodel-rca .qoder/skills/
+  ```
+  按提问自动激活，或用 `/umodel-query` 手动触发。（Qoder 另有 Skills Marketplace
+  和内置 `create-skill` 助手。）
+- **Codex** —— 拷进中立的 `.agents/skills/` 目录（用 `~/.agents/skills/` 做用户级全局）：
+  ```bash
+  mkdir -p .agents/skills && cp -R skills/umodel-query skills/umodel-rca .agents/skills/
+  ```
+  按 description 自动激活，或用 `$umodel-query` 提及（打 `$`，或跑 `/skills`，浏览）。
+  新技能没出现就重启 Codex。
 
+> `.agents/skills/` 是跨 Agent 的开放标准路径——Qoder 也读它，放一份即可同时服务 Qoder 和 Codex。
+>
 > 技能的 `description` 决定支持技能的 Agent 何时激活它。
 
 ## 2. 初始化 demo 数据

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ over the `umctl` CLI or MCP.
 
 A *skill* here is a self-contained `SKILL.md` (YAML frontmatter `name` +
 `description`, then instructions) in the format consumed by skill-aware agent
-runtimes such as Claude Code, Cursor, and Qoder.
+runtimes such as Claude Code, Cursor, Qoder, and Codex.
 
 > **New here? Start with the [Quickstart](QUICKSTART.md)** — install the skills,
 > load a demo object graph (entities + relations), connect Claude Code / Qoder /
@@ -50,21 +50,30 @@ This installs the `umodel` plugin — both `umodel-query` and `umodel-rca` — w
 then activate automatically based on your prompt. Update later with
 `/plugin marketplace update unifiedmodel`.
 
-### Option B — copy into a skills directory (any agent)
+### Option B — copy into your agent's skills directory
 
-Most skill-aware agents discover skills from a directory. Point your agent at a
-skill here, or copy it into the location your agent scans, for example:
+Most skill-aware agents discover skills from a directory — drop both skill folders
+into the one your agent scans:
+
+| Agent | Skills directory |
+|---|---|
+| Claude Code | `.claude/skills/` |
+| Cursor | `.cursor/skills/` |
+| Qoder | `.qoder/skills/` |
+| Codex | `.agents/skills/` (or `~/.agents/skills/` for user-global) |
 
 ```bash
-# Claude Code / Cursor / Qoder (Claude-Code-compatible skill loaders)
-mkdir -p .claude/skills
-cp -R skills/umodel-query skills/umodel-rca .claude/skills/
+# Qoder
+mkdir -p .qoder/skills  && cp -R skills/umodel-query skills/umodel-rca .qoder/skills/
+# Codex — the vendor-neutral .agents/skills/ is also read by Qoder
+mkdir -p .agents/skills && cp -R skills/umodel-query skills/umodel-rca .agents/skills/
 ```
 
 Then prompt the agent normally — e.g. *"query the degraded services in this
 workspace"* (activates `umodel-query`) or *"payment-gateway 的 SLO 告警了，帮我排查"*
 (activates `umodel-rca`). Each skill's `description` controls when the agent
-activates it.
+activates it; trigger one manually with `/umodel-query` (Claude Code / Qoder) or
+`$umodel-query` (Codex).
 
 ## How the skills relate
 

--- a/skills/README.zh-CN.md
+++ b/skills/README.zh-CN.md
@@ -4,7 +4,7 @@
 拉取遥测数据，并在对象图上做模型引导的根因分析——通过 `umctl` CLI 或 MCP。
 
 这里的*技能*是一个自包含的 `SKILL.md`（YAML frontmatter `name` + `description`，
-随后是指令），格式与 Claude Code、Cursor、Qoder 等支持技能的 Agent 运行时一致。
+随后是指令），格式与 Claude Code、Cursor、Qoder、Codex 等支持技能的 Agent 运行时一致。
 
 > **第一次用？从[快速上手](QUICKSTART.zh-CN.md)开始** —— 安装技能、载入一个 demo
 > 对象图（实体 + 关系）、接入 Claude Code / Qoder / Codex、然后提问。几分钟端到端跑通，无需密钥。
@@ -45,20 +45,28 @@ demo 无需任何密钥或网络。
 这会装上 `umodel` 插件——含 `umodel-query` 与 `umodel-rca`——随后按你的提问自动激活。
 之后用 `/plugin marketplace update unifiedmodel` 更新。
 
-### 方式 B —— 拷贝到技能目录（任意 Agent）
+### 方式 B —— 拷贝到 Agent 的技能目录
 
-多数支持技能的 Agent 从一个目录发现技能。把这里的技能指给你的 Agent，或拷贝到
-Agent 扫描的位置，例如：
+多数支持技能的 Agent 从一个目录发现技能——把两个技能目录拷进你的 Agent 扫描的位置：
+
+| Agent | 技能目录 |
+|---|---|
+| Claude Code | `.claude/skills/` |
+| Cursor | `.cursor/skills/` |
+| Qoder | `.qoder/skills/` |
+| Codex | `.agents/skills/`（或 `~/.agents/skills/` 做用户级全局） |
 
 ```bash
-# Claude Code / Cursor / Qoder（Claude-Code 兼容的技能加载器）
-mkdir -p .claude/skills
-cp -R skills/umodel-query skills/umodel-rca .claude/skills/
+# Qoder
+mkdir -p .qoder/skills  && cp -R skills/umodel-query skills/umodel-rca .qoder/skills/
+# Codex —— 中立的 .agents/skills/ Qoder 也读
+mkdir -p .agents/skills && cp -R skills/umodel-query skills/umodel-rca .agents/skills/
 ```
 
 然后正常提问——例如*"查一下这个 workspace 里 degraded 的服务"*（激活 `umodel-query`），
 或*"payment-gateway 的 SLO 告警了，帮我排查"*（激活 `umodel-rca`）。每个技能的
-`description` 决定 Agent 何时激活它。
+`description` 决定 Agent 何时激活它；手动触发用 `/umodel-query`（Claude Code / Qoder）
+或 `$umodel-query`（Codex）。
 
 ## 两个技能的关系
 


### PR DESCRIPTION
## What

The agent-skills install docs only had a real one-command path for **Claude Code**, and lumped **Qoder / Codex** under *"agents without a `SKILL.md` loader → paste the content into `AGENTS.md`"*. That was true when written, but both now load `SKILL.md` natively. This documents a first-class, per-platform install path for each and fixes a self-contradiction.

## Why

As of the Agent Skills open standard, Qoder and Codex each scan their own skills directory:

| Agent | Skills directory | Manual trigger |
|---|---|---|
| Claude Code | `/plugin install` (marketplace) or `.claude/skills/` | `/umodel-query` |
| Qoder | `.qoder/skills/` (also reads `.agents/skills/`) | `/umodel-query` |
| Codex | `.agents/skills/` (project) · `~/.agents/skills/` (user) | `$umodel-query` |

`.agents/skills/` is the vendor-neutral open-standard path — Qoder reads it too, so a single copy there serves both Qoder and Codex.

This also resolves a contradiction in our own docs: `README.md` called Qoder a "Claude-Code-compatible skill loader" while `QUICKSTART.md` listed it among agents "without a `SKILL.md` loader".

> One install still gets **both** skills on Claude Code — the `umodel` plugin in `marketplace.json` bundles `umodel-query` + `umodel-rca`. Unchanged.

## Changes

- `skills/QUICKSTART.md` §1 — per-platform install (Claude Code / Qoder / Codex)
- `skills/README.md` — "Option B" now a per-agent directory table; runtime list adds Codex; manual-trigger syntax noted
- `skills/QUICKSTART.zh-CN.md`, `skills/README.zh-CN.md` — mirrors

MCP-connection sections (QUICKSTART §3) were already per-platform and are untouched. Docs-only; no code changes.

## Sources

Codex path is from the official [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills) (`.agents/skills/`, not the third-party-blogged `.codex/skills/`); Qoder path corroborated by the Qoder Skills Marketplace and multi-IDE tooling.
