### PR TITLE
feat(skills): umodel-query reads metrics/logs via plan→execute + progressive-disclosure references

### DIFF
--- a/skills/QUICKSTART.md
+++ b/skills/QUICKSTART.md
@@ -130,6 +130,7 @@ With the data loaded and the agent connected, just ask in natural language.
 - "List the services in this workspace and their status."
 - "What does payment-gateway depend on? Show me the topology."
 - "Which metric and log sets are attached to payment-gateway?"
+- "Read payment-gateway's p99 latency over the last hour." (fetches the plan, runs it against your Prometheus)
 
 **Root-cause analysis — activates `umodel-rca`:**
 
@@ -140,6 +141,12 @@ metrics/logs → traverse to the upstream caller → find the retry config chang
 rule out the red-herring deployment → find the promotion traffic → conclude the
 root cause (retry ×2.5 × promotion ×3.5 = **8.75×** overload) and recommend a
 rollback.
+
+> **Metrics & logs need a backend.** `.entity` / `.topo` / `.umodel` reads work out
+> of the box; for metric/log **values**, `get_metrics` / `get_logs` return an
+> executable plan (PromQL / Elasticsearch DSL) that the agent runs against **your
+> Prometheus / Elasticsearch** — point it at where you loaded the data. See
+> *Read metrics & logs* in [umodel-query](umodel-query/SKILL.md).
 
 ## Troubleshooting
 

--- a/skills/QUICKSTART.zh-CN.md
+++ b/skills/QUICKSTART.zh-CN.md
@@ -120,6 +120,7 @@ args = ["run", "./cmd/umodel-mcp", "--quickstart",
 - "列一下这个 workspace 里的服务和它们的状态。"
 - "payment-gateway 依赖了什么？把拓扑给我看看。"
 - "payment-gateway 挂了哪些指标集和日志集？"
+- "读一下 payment-gateway 最近一小时的 p99 延迟。"（取回 plan，在你的 Prometheus 上执行）
 
 **根因分析 —— 激活 `umodel-rca`：**
 
@@ -128,6 +129,11 @@ args = ["run", "./cmd/umodel-mcp", "--quickstart",
 Agent 随后自主工作：定位 degraded 服务 → 拉它的指标/日志 → 顺拓扑找到上游调用方 →
 发现重试配置变更 → 排除红鲱鱼部署 → 找到促销流量 → 得出根因（重试 ×2.5 × 促销 ×3.5
 = **8.75×** 过载）并建议回滚。
+
+> **指标/日志需要后端。** `.entity` / `.topo` / `.umodel` 读取开箱即用；要拿指标/日志
+> 的**数值**，`get_metrics` / `get_logs` 返回一段可执行 **plan**（PromQL / Elasticsearch
+> DSL），由 Agent 在**你的 Prometheus / Elasticsearch** 上执行——把它指向你灌数据的后端。
+> 详见 [umodel-query](umodel-query/SKILL.md) 的 *Read metrics & logs*。
 
 ## 排错
 

--- a/skills/umodel-query/SKILL.md
+++ b/skills/umodel-query/SKILL.md
@@ -1,120 +1,92 @@
 ---
 name: umodel-query
 description: >-
-  Read data and model from a UModel object-graph semantic layer, primarily
-  through the `umctl` CLI (MCP alternative noted). Reads (1) entity and
-  relationship/topology data and (2) the UModel model itself — entity sets,
-  datasets, links, runbooks. Entity/relation/model reads return real rows in
-  open source; against a PaaS-backed endpoint the same calls return the PaaS
-  API's data. Use when asked to query or read UModel entities, relations,
-  topology, or model metadata; look up services / dependencies; or list what
-  objects and datasets exist. For root-cause analysis built on these reads,
-  see the `umodel-rca` skill. Triggers: UModel, object graph, .entity / .topo /
-  .umodel, query entities, read topology, list services / dependencies /
-  datasets, 实体查询, 关系/拓扑查询, 读模型, 查服务依赖.
+  Read from a UModel object-graph semantic layer with the `umctl` CLI (MCP
+  alternative noted). Three kinds of read: (1) entities & relationships / topology
+  (`.entity`, `.topo`) and (2) the model itself (`.umodel`, and `.entity_set`
+  methods) return real rows; (3) metrics & logs (`get_metrics` / `get_logs`)
+  return an executable *plan* — PromQL / Elasticsearch DSL with the entity id
+  pre-substituted — that you run against the backend. Against a PaaS endpoint the
+  same calls return data rows instead of a plan. Use to query or read UModel
+  entities, relations, topology, or model metadata; to read a service's metrics or
+  logs; to look up services and dependencies; or to discover what objects,
+  datasets, and methods exist. For root-cause analysis on top of these reads, see
+  the `umodel-rca` skill. Triggers: UModel, object graph, .entity / .topo /
+  .umodel / .entity_set, query entities, read topology, read metrics / logs,
+  get_metrics / get_logs, list services / dependencies / datasets, 实体查询,
+  关系/拓扑查询, 读模型, 读指标, 读日志, 查指标, 查日志, 查服务依赖.
 ---
 
-# UModel Query — read entities, relationships, and the model
+# UModel Query — read entities, relationships, the model, and telemetry
 
 UModel is an **object-graph semantic layer**: enterprise objects (services, Pods,
 deployments, config changes, promotions, …), their typed relationships (`calls`,
-`runs-on`, `affects`, `triggers`, `impacts`, …), and the datasets (metrics, logs)
-that hang off them — all queryable through one SPL surface.
+`depends_on`, `affects`, …), and the datasets (metrics, logs) hanging off them — all read
+through one SPL surface via the `umctl` CLI (MCP alternative at the bottom).
 
-This skill teaches you (an agent) to **read** it. Prefer the `umctl` CLI; an MCP
-alternative is at the end. *(For model-guided root-cause analysis on top of these
-reads, load the `umodel-rca` skill.)*
+This file is the **overview + setup**. Each query surface has a focused guide under
+[`references/`](references/) — **read the one your task needs** (don't load them all).
 
 ## Setup (CLI-first)
 
-Point `umctl` at a running UModel server (open source, or a PaaS-backed
-endpoint). For the bundled demo:
+**1. Ensure `umctl` is on PATH** — UModel's read CLI:
 
 ```bash
-make quickstart QUICKSTART_SAMPLE=examples/incident-investigation   # serves http://localhost:8080
+command -v umctl || go install github.com/alibaba/UnifiedModel/cmd/umctl@latest   # needs Go 1.22+
 ```
 
-Every read is one command — **always pass `-o json`** for machine-readable rows:
+No Go toolchain? Download a prebuilt `umctl` from the repo's Releases, or build from a clone
+(`make build-cli` → `./bin/umctl`). Verify with `umctl version`.
+
+**2. Point `umctl` at your UModel server** — set the address explicitly (flag, env, or a
+saved profile):
 
 ```bash
-umctl query run <workspace> "<SPL>" -o json     # execute
-umctl query explain <workspace> "<SPL>"          # see the plan/providers without running
-umctl --addr http://<host>:8080 query run …       # target a specific server (e.g. a PaaS endpoint)
+umctl --addr http://<host>:8080 query run <workspace> "<SPL>" -o json   # per call
+export UMCTL_ADDR=http://<host>:8080                                    # or for the session
+umctl configure                                                         # or save a profile
 ```
 
-**Response shape** (parse this): rows live in `data.data` (a matrix), column names
-in `data.header`.
-
-```jsonc
-{ "code": "200", "success": true,
-  "data": {
-    "header": ["display_name", "status", "owner", "sla_tier"],
-    "data":   [ ["payment-gateway", "degraded", "payments-backend", "platinum"] ]
-  } }
-```
-
-So `columns = data.header`, `rows = data.data`. Zip them to read records.
-
-## Read entity & relationship data
-
-Real rows directly (from EntityStore / GraphStore), in open source and against a
-PaaS endpoint alike. *(Against a PaaS-backed `--addr`, the same commands return
-the PaaS API's data response — same SPL, same shape.)*
-
-### Entities — `.entity`
+**3. Pick the workspace** — every read takes a workspace name. List what the server has and
+use the one your data lives in (the bundled demo is `demo`):
 
 ```bash
-umctl query run demo ".entity with(domain='platform', name='platform.service', query='degraded') | project display_name, status, owner, sla_tier" -o json
-# → ["payment-gateway","degraded","payments-backend","platinum"]
+umctl workspace list -o json
 ```
 
-- `query='…'` is full-text over all entity fields. Add `mode='vector'` or
-  `mode='hyper'` for semantic / hybrid search, `topk=N` to bound matches.
-- `with(ids=['<entity_id>'])` fetches specific entities by id.
-- Pipe `| project a,b,c`, `| where …`, `| sort …`, `| limit N`.
+> No server yet? The bundled demo serves one with sample data on `:8080`:
+> `make quickstart QUICKSTART_SAMPLE=examples/incident-investigation` (needs a repo clone + Go).
 
-### Relationships & topology — `.topo`
+**Always pass `-o json`.** Plain reads put column names in `data.header` and rows in
+`data.data` (a matrix) — zip them to read records. (Entity-call results wrap differently; see
+the entity-set guide.)
 
-```bash
-# neighbors along a relationship (raise the hop count for multi-hop)
-umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"platform@platform.service\" {__entity_id__:'63718b78868895d2590551b27ec6f51c'})]) | with(__relation_type__='calls')" -o json
+## Query surfaces — open the reference you need
 
-# direct relations of a node; or full Cypher
-umctl query run demo ".topo | graph-call getDirectRelations([(:\"platform@platform.service\" {__entity_id__:'…'})])" -o json
-umctl query run demo ".topo | graph-call cypher(\`MATCH (s)-[r]->(d) RETURN properties(s), type(r), properties(d) LIMIT 20\`)" -o json
-```
+| Your goal | SPL surface | Guide |
+|---|---|---|
+| Read objects (services, deployments, config changes…) by type / search / id | `.entity` | [references/entity.md](references/entity.md) |
+| Traverse relationships, dependencies, topology | `.topo` | [references/topology.md](references/topology.md) |
+| List what object types / datasets / links / runbooks exist | `.umodel` | [references/model.md](references/model.md) |
+| Call an EntitySet's methods (discover via `__list_method__`, list datasets) | `.entity_set \| entity-call` | [references/entity-set.md](references/entity-set.md) |
+| Read a service's **metrics / logs** (fetch a plan, then run it) | `get_metrics` / `get_logs` | [references/metrics-logs.md](references/metrics-logs.md) |
 
-Each relation row carries the source ref, relation type, destination ref, and edge
-properties. **Topology rows reference entities by ID** — resolve display names with
-a follow-up `.entity … with(ids=[…])` when you need them.
+**How they relate:** `.umodel` defines the **types**. The `domain` + `name` you pass
+everywhere names one of those definitions — for `.entity` / `.entity_set` it's an
+**EntitySet** (`.umodel with(kind='entity_set')`); for `get_metrics` / `get_logs` it's a
+**MetricSet** / **LogSet**. `.entity` reads the runtime **instances** of an EntitySet;
+`.entity_set` calls **methods** on the EntitySet itself; the same `domain`/`name` join them.
 
-## Read the UModel model — `.umodel`
+Typical flow: `.umodel` to learn the types → `.entity` to find an object and grab its
+`__entity_id__` → `.topo` / `.entity_set` / telemetry build on that id.
 
-The model is the **map**: what object types, datasets, links, and runbooks exist,
-and how they connect. Read it before assuming structure.
+## Notes
 
-```bash
-# what object types / datasets / runbooks exist
-umctl query run demo ".umodel with(kind='entity_set') | project domain, name" -o json
-umctl query run demo ".umodel with(kind='runbook_set', name='platform.service.ops')" -o json
-
-# what can a given EntitySet do, and what telemetry hangs off it
-umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['…']) | entity-call __list_method__()" -o json
-umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['…']) | entity-call list_data_set(['metric_set','log_set'], true)" -o json
-```
-
-Kinds you can list: `entity_set`, `metric_set`, `log_set`, `event_set`,
-`entity_set_link`, `data_link`, `storage_link`, `runbook_set`. Use `.umodel` +
-`__list_method__` + `list_data_set` to discover capabilities instead of guessing.
-
-## Notes & gotchas
-
-- **Always `-o json`**; parse `rows = data.data`, `columns = data.header`.
-- `.entity` / `.topo` / `.umodel` reads return **real rows** in open source.
-  (Telemetry reads — `get_metrics` / `get_logs` — return a *plan* in open source
-  and *data* via a PaaS endpoint; those belong to the `umodel-rca` skill.)
-- Topology rows carry entity **IDs**, not names — resolve with `.entity with(ids=[…])`.
 - Stay **read-only**.
+- `.entity` / `.topo` / `.umodel` reads return **real rows** in open source. `get_metrics` /
+  `get_logs` return an executable *plan* you run against Prometheus / Elasticsearch (or, against
+  a PaaS endpoint with `mode='data'`, rows directly) — see
+  [references/metrics-logs.md](references/metrics-logs.md).
 - **MCP alternative** (instead of the CLI): connect `umodel-mcp` and call the
-  `query_spl_execute` tool with `{ "workspace": "demo", "query": "<the same SPL>" }`
-  (arg key is `query`, not `spl`). Same SPL either way.
+  `query_spl_execute` tool with `{ "workspace": "demo", "query": "<the same SPL>" }` (arg key
+  is `query`, not `spl`). Same SPL, same results.

--- a/skills/umodel-query/references/entity-set.md
+++ b/skills/umodel-query/references/entity-set.md
@@ -1,0 +1,50 @@
+# `.entity_set | entity-call` — call methods on an EntitySet
+
+`.entity_set with(domain=…, name=…, ids=[…])` selects an EntitySet (optionally bound to
+specific entities by their `__entity_id__`); `| entity-call <method>(…)` runs one of its
+methods.
+
+## Discover methods first — `__list_method__()`
+
+Don't guess signatures — list the methods and their exact params/returns:
+
+```bash
+umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['63718b78868895d2590551b27ec6f51c']) | entity-call __list_method__()" -o json
+```
+
+The demo EntitySet exposes four:
+
+- `__list_method__()` — this method list.
+- `list_data_set(types?, detail?)` — datasets on the entity; `types` e.g.
+  `['metric_set','log_set']`, `detail=true` adds `fields_mapping`, `fields`, `storage_info`.
+- `get_metrics(domain, name, metric?, query?, query_type?, step?)` — a metric query **plan**.
+- `get_logs(domain, name, query?)` — a log query **plan**.
+
+For `get_metrics` / `get_logs` (fetch the plan, then run it), see [metrics-logs.md](metrics-logs.md).
+
+## Returned format — entity-call result shape
+
+Every entity-call returns **one wrapped row** whose outer columns are
+`["responseType","query","header","data"]` (so `data.data[0]` is `[responseType, query,
+innerHeader, innerData]`):
+
+- **Table methods** (`__list_method__`, `list_data_set`) → `responseType = 2`: the real table
+  is the inner header at `data.data[0][2]` and inner rows at `data.data[0][3]` (each
+  `{"values":[…]}`).
+- **Plan methods** (`get_metrics`, `get_logs`) → `responseType = 1`: the **plan is the JSON
+  string at `data.data[0][1]`** (the `query` column); inner header/data are empty.
+
+## Worked example — `__list_method__()`
+
+The call above returns `responseType = 2`; the inner header (`data.data[0][2]`) is
+`["name","display_name","description","params","returns"]`, and each inner row
+(`data.data[0][3]`) is a method, e.g. (trimmed):
+
+```jsonc
+{"values": ["get_metrics", "Get Metrics", "Get metric query plan from a MetricSet",
+  "[{\"key\":\"domain\",\"type\":\"varchar\",\"required\":true},{\"key\":\"metric\",\"type\":\"varchar\",\"required\":false},{\"key\":\"step\",\"type\":\"varchar\",\"required\":false}]",
+  "[{\"key\":\"query\",\"type\":\"varchar\",\"display_name\":\"Metric query plan\"}]"]}
+```
+
+So `params` and `returns` are **JSON strings** — parse them to get each method's signature
+(`{key, type, required, default}`) before you call it.

--- a/skills/umodel-query/references/entity.md
+++ b/skills/umodel-query/references/entity.md
@@ -1,0 +1,50 @@
+# `.entity` — read entities (objects)
+
+Reads runtime objects (services, deployments, config changes, promotions, pods, …) from
+EntityStore / GraphStore. A bare read returns **all fields** of the matching objects — no
+pipe required:
+
+```bash
+umctl query run demo ".entity with(domain='platform', name='platform.service', query='degraded')" -o json
+```
+
+## Parameters — `with(...)`
+
+- `domain=` + `name=` — **required**: the EntitySet (object type), e.g. domain `platform`,
+  name `platform.service`. Discover the available ones with `.umodel with(kind='entity_set')`
+  (see [model.md](model.md)).
+- `query='…'` — full-text over all fields; add `mode='vector'` or `mode='hyper'` for
+  semantic / hybrid search, `topk=N` to cap matches. Omit `query` to read every object.
+- `ids=['<entity_id>', …]` — fetch specific objects by their `__entity_id__`.
+
+Pipes are **optional** — add them only to shape the output: `| project a,b,c` (narrow
+columns), `| where field='x'`, `| sort field`, `| limit N`.
+
+## Returned format
+
+Plain rows: column names in `data.header`, rows in `data.data` (a matrix) — zip them. Each row
+is **system fields** (`__*__`) + the object's **own fields**. For `platform.service` the real
+columns are:
+
+```jsonc
+"header": ["__domain__","__entity_type__","__entity_id__","__last_observed_time__","__deleted__",
+           "display_name","status","owner","sla_tier","environment","id", "..."]
+```
+
+`__entity_id__` is the stable handle you reuse in `.topo` (see [topology.md](topology.md)) and
+in `.entity_set … ids=[…]` (see [entity-set.md](entity-set.md)).
+
+## Worked example
+
+```bash
+umctl query run demo ".entity with(domain='platform', name='platform.service', query='degraded') | project __entity_id__, display_name, status, owner, sla_tier" -o json
+```
+
+→ one row (zip with the projected header `__entity_id__, display_name, status, owner, sla_tier`):
+
+```jsonc
+"data": [["63718b78868895d2590551b27ec6f51c","payment-gateway","degraded","payments-backend","platinum"]]
+```
+
+So `payment-gateway` (`63718b78…`) is **degraded**, owned by `payments-backend`, a `platinum`
+SLO service. Reuse that `__entity_id__` for topology and telemetry.

--- a/skills/umodel-query/references/metrics-logs.md
+++ b/skills/umodel-query/references/metrics-logs.md
@@ -1,0 +1,126 @@
+# `get_metrics` / `get_logs` — read the plan, then run it
+
+`get_metrics` / `get_logs` return an executable **plan**, not values (open source = plan
+provider). Read the plan, then run its query against the backend with whatever tooling you
+have. These are `.entity_set` entity-call methods — see [entity-set.md](entity-set.md) for the
+call mechanics and the wrapped result shape.
+
+## 1. Fetch the plan
+
+Resolve the entity id first (`.entity … query='payment-gateway' | project __entity_id__`, see
+[entity.md](entity.md)), then call the method:
+
+```bash
+umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['63718b78868895d2590551b27ec6f51c']) | entity-call get_metrics('platform','platform.service.metrics','latency_p99_ms', step='30s')" -o json
+umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['63718b78868895d2590551b27ec6f51c']) | entity-call get_logs('platform','platform.service.logs', query='level = \"ERROR\"')" -o json
+```
+
+## 2. The returned plan — format
+
+The call returns a wrapped row; the plan is the JSON string at `data.data[0][1]` (see
+[entity-set.md](entity-set.md)). Parsed, it is a `v1` envelope — the same shape for both
+operations, with an operation-specific `query` block:
+
+```jsonc
+{
+  "mode": "plan", "version": "v1", "operation": "get_metrics",
+  "description": "<human summary>",
+  "params_echo": { "domain": "...", "name": "...", "metric": "...", "step": "30s" },
+  "source_query": "<the SPL you ran>",
+  "data_source": {                 // model provenance + where the data lives
+    "data_set": { "kind": "metric_set", "name": "platform.service.metrics", ... },
+    "data_link": { ... }, "storage_link": { ... },
+    "storage": {
+      "type": "prometheus",        // or "elasticsearch"
+      "config": { "endpoint": "http://prometheus.platform.example:9090",
+                  "api_prefix": "/api/v1", "tenant_header": "X-Scope-OrgID", ... }
+    }
+  },
+  "query": { "dialect": "...", ... } // ← the executable query; dispatch on dialect
+}
+```
+
+Dispatch on **`query.dialect`**:
+
+### `prometheus_promql` (real `query` block, trimmed)
+
+```jsonc
+"query": {
+  "dialect": "prometheus_promql",
+  "endpoint": "http://prometheus.platform.example:9090",
+  "api_prefix": "/api/v1",
+  "query_type": "range",            // or "instant"
+  "step": "30s",
+  "queries": [
+    { "name": "latency_p99_ms", "unit": "ms",
+      "promql": "histogram_quantile(0.99, sum(rate(platform_service_request_duration_seconds_bucket{service_id=\"63718b78868895d2590551b27ec6f51c\"}[1m])) by (le)) * 1000" }
+  ],
+  "label_matchers": [ { "label": "service_id", "operator": "=", "value": "63718b78868895d2590551b27ec6f51c" } ],
+  "tenant": "incident-investigation", "tenant_header": "X-Scope-OrgID", "limit": 100
+}
+```
+
+Run each `queries[].promql` against `endpoint` + `api_prefix`; send the header
+`<tenant_header>: <tenant>` if present.
+
+### `elasticsearch_dsl` (real `query` block, trimmed)
+
+```jsonc
+"query": {
+  "dialect": "elasticsearch_dsl",
+  "index": "platform-service-logs-*",
+  "body": {
+    "size": 100,
+    "query": { "bool": { "filter": [
+      { "term": { "svc_id": "63718b78868895d2590551b27ec6f51c" } },
+      { "term": { "severity": "ERROR" } }
+    ] } },
+    "sort": [ { "timestamp": { "order": "desc" } } ],
+    "_source": [ "timestamp", "svc_id", "env", "severity", "log_message", "trace_id" ]
+  }
+}
+```
+
+The ES `query` block has **no `endpoint`** — take it from
+`data_source.storage.config.endpoint` (here `https://elasticsearch.platform.example:9200`).
+POST `body` to `<endpoint>/<index>/_search`.
+
+## 3. Execute it with what you have
+
+The query is ready to run — you decide how: if a Prometheus / Elasticsearch CLI is available
+in your environment, call it; otherwise hit the HTTP API directly, or use any client you have.
+The backend's own response format is what you parse next: Prometheus →
+`.data.result[]` (each `{metric, value:[ts,"v"]}` for instant, or `values:[[ts,"v"],…]` for
+range); Elasticsearch → `.hits.hits[]._source` (one object per log line).
+
+## 4. Adapt the parameters
+
+- **Endpoint:** the plan's `endpoint` / `index` come from the model's storage config and may
+  be placeholders (e.g. `prometheus.platform.example:9090`) — point at your real backend.
+- **Time window:** the plan carries `step` but **no range** — an instant query uses "now"; a
+  range query needs a start/end you choose. Tune `size` for logs.
+- **Auth:** pass credentials (or the `tenant_header`) via env — never hardcode or echo them.
+- **Read-only:** run only the plan's query; don't invent mutating calls.
+- **Field/label names:** the matcher value is the entity's mapped id (the demo maps it to a
+  hash, `service_id="63718b78…"`), and log rows return **mapped** names (`svc_id`, `severity`,
+  …) — your backend's labels/fields must match, or adjust them.
+
+## Worked example — payment-gateway P99 latency
+
+1. **Fetch:** `… | entity-call get_metrics('platform','platform.service.metrics','latency_p99_ms', step='30s')` → the `prometheus_promql` plan above.
+2. **Read:** `query.queries[0].promql` (ready PromQL), `query.endpoint` (placeholder), `query.tenant`/`tenant_header`.
+3. **Override the endpoint and run** (here via the HTTP API + jq; a Prometheus CLI works too):
+
+   ```bash
+   PROMQL='histogram_quantile(0.99, sum(rate(platform_service_request_duration_seconds_bucket{service_id="63718b78868895d2590551b27ec6f51c"}[1m])) by (le)) * 1000'
+   curl -sG http://YOUR-PROMETHEUS:9090/api/v1/query \
+     --data-urlencode "query=$PROMQL" \
+     -H "X-Scope-OrgID: incident-investigation" | jq '.data.result'
+   ```
+4. **Parse:** `.data.result[].value[1]` is the P99 value (e.g. a `~2150` ms spike on your data).
+
+Logs are analogous: take `query.body` + `query.index` + the storage `endpoint`, then
+`curl -s https://YOUR-ES:9200/platform-service-logs-*/_search -H 'Content-Type: application/json' -d '<body>' | jq '.hits.hits[]._source'`.
+
+> **PaaS shortcut:** against a PaaS endpoint with `mode='data'`, `get_metrics` / `get_logs`
+> return the **rows directly** — no execution step. Same SPL.

--- a/skills/umodel-query/references/metrics-logs.md
+++ b/skills/umodel-query/references/metrics-logs.md
@@ -7,8 +7,19 @@ call mechanics and the wrapped result shape.
 
 ## 1. Fetch the plan
 
-Resolve the entity id first (`.entity … query='payment-gateway' | project __entity_id__`, see
-[entity.md](entity.md)), then call the method:
+Two lookups give you the call arguments — **get both from the entity, not from a global model
+scan**:
+
+- **Entity id** — `.entity … query='payment-gateway' | project __entity_id__` (see
+  [entity.md](entity.md)).
+- **Dataset name** (the metric_set / log_set this entity exposes) — call
+  `entity-call list_data_set(['metric_set'])` (or `['log_set']`) on the entity-set (see
+  [entity-set.md](entity-set.md)); the returned row gives the `domain`+`name` to pass below. Do
+  **not** reach for `.umodel with(kind='metric_set')` — that lists every dataset in the
+  workspace, unscoped to your entity, so it can't tell you which one applies (and `| project
+  name` on `.umodel` comes back null).
+
+Then call the method:
 
 ```bash
 umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['63718b78868895d2590551b27ec6f51c']) | entity-call get_metrics('platform','platform.service.metrics','latency_p99_ms', step='30s')" -o json
@@ -86,6 +97,10 @@ The ES `query` block has **no `endpoint`** — take it from
 POST `body` to `<endpoint>/<index>/_search`.
 
 ## 3. Execute it with what you have
+
+**You are the executor.** The plan describes the query and where it lives; running it is your
+job — don't stop at the plan. (If a plan's `description` or `next_action` suggests forwarding it
+to a separate data executor, that's the PaaS path; in this skill you execute it yourself.)
 
 The query is ready to run — you decide how: if a Prometheus / Elasticsearch CLI is available
 in your environment, call it; otherwise hit the HTTP API directly, or use any client you have.

--- a/skills/umodel-query/references/model.md
+++ b/skills/umodel-query/references/model.md
@@ -1,0 +1,54 @@
+# `.umodel` — the model catalog
+
+The model is the **map**: what object types, datasets, links, and runbooks exist. Read it
+before assuming structure.
+
+```bash
+umctl query run demo ".umodel with(kind='entity_set') | project domain, name" -o json
+umctl query run demo ".umodel with(kind='runbook_set', name='platform.service.ops')" -o json
+```
+
+`with(kind=…)` filters by element kind; add `name=…` to fetch one element in full. Kinds:
+`entity_set` (object types `.entity` reads), `metric_set` / `log_set` / `event_set` (datasets),
+`entity_set_link` / `data_link` / `storage_link` (how objects, datasets, and storage connect —
+incl. the `fields_mapping` that scopes telemetry), `runbook_set` (operational runbooks).
+
+## Returned format
+
+Rows describe model elements. A full read (`with(kind=…, name=…)`) returns the columns
+`["kind","domain","name","version","spec"]`, where **`spec`** is the element's full definition
+(JSON). With `| project domain, name` you get just those two columns.
+
+## Worked example
+
+List the object types in the workspace:
+
+```bash
+umctl query run demo ".umodel with(kind='entity_set') | project domain, name" -o json
+```
+
+→ (real)
+
+```jsonc
+"data": [["business","business.order_flow"],["business","business.promotion"],
+         ["platform","platform.config_change"],["platform","platform.deployment"],
+         ["platform","platform.incident"],["platform","platform.service"],
+         ["platform","platform.team"],["runtime","runtime.cluster"],
+         ["runtime","runtime.namespace"],["runtime","runtime.pod"],["runtime","runtime.workload"]]
+```
+
+Fetch one element in full to see its `spec` (here a runbook, whose `spec` holds
+failure-pattern `knowledge` and `automations`):
+
+```bash
+umctl query run demo ".umodel with(kind='runbook_set', name='platform.service.ops')" -o json
+# → ["runbook_set","platform","platform.service.ops","v1.0.0", { "knowledge":[…], "automations":[…] }]
+```
+
+The `domain` + `name` of each `entity_set` listed here are exactly what you pass to `.entity`
+(read its runtime instances, see [entity.md](entity.md)) and `.entity_set` (call its methods);
+likewise a `metric_set` / `log_set` `domain`+`name` is what `get_metrics` / `get_logs` take.
+`.umodel` defines the **types**; `.entity` returns their **instances**.
+
+To go from a model element to what you can *do* with it (its methods, its datasets), use
+`.entity_set | entity-call` — see [entity-set.md](entity-set.md).

--- a/skills/umodel-query/references/model.md
+++ b/skills/umodel-query/references/model.md
@@ -46,9 +46,13 @@ umctl query run demo ".umodel with(kind='runbook_set', name='platform.service.op
 ```
 
 The `domain` + `name` of each `entity_set` listed here are exactly what you pass to `.entity`
-(read its runtime instances, see [entity.md](entity.md)) and `.entity_set` (call its methods);
-likewise a `metric_set` / `log_set` `domain`+`name` is what `get_metrics` / `get_logs` take.
+(read its runtime instances, see [entity.md](entity.md)) and `.entity_set` (call its methods).
 `.umodel` defines the **types**; `.entity` returns their **instances**.
+
+`.umodel with(kind='metric_set')` browses the dataset **catalog** — every dataset in the
+workspace. To find which metric_set / log_set a **specific entity** exposes (the `domain`+`name`
+`get_metrics` / `get_logs` actually take), don't scan the catalog — ask the entity:
+`.entity_set … | entity-call list_data_set(['metric_set'])` (see [entity-set.md](entity-set.md)).
 
 To go from a model element to what you can *do* with it (its methods, its datasets), use
 `.entity_set | entity-call` — see [entity-set.md](entity-set.md).

--- a/skills/umodel-query/references/topology.md
+++ b/skills/umodel-query/references/topology.md
@@ -1,0 +1,58 @@
+# `.topo` — relationships & topology
+
+`graph-call` runs a graph method. The start node is `(:"<domain>@<entity_set>"
+{__entity_id__:'<id>'})`; `getNeighborNodes(scope, hops, [start])` takes a scope (`'full'`),
+a hop count (raise it for multi-hop), and the start node.
+
+```bash
+# all neighbors of a node
+umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"platform@platform.service\" {__entity_id__:'63718b78868895d2590551b27ec6f51c'})])" -o json
+
+# filter rows by relation type with a `where` pipe — use `where`, NOT `with(...)`, which
+# does NOT filter graph-call output:
+umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"platform@platform.service\" {__entity_id__:'63718b78868895d2590551b27ec6f51c'})]) | where __relation_type__ = 'calls'" -o json
+
+# direct relations of a node; or full (read-only) Cypher
+umctl query run demo ".topo | graph-call getDirectRelations([(:\"platform@platform.service\" {__entity_id__:'…'})])" -o json
+umctl query run demo ".topo | graph-call cypher(\`MATCH (s)-[r]->(d) RETURN properties(s), type(r), properties(d) LIMIT 20\`)" -o json
+```
+
+## Returned format
+
+Each row is an **edge**. The real columns are:
+
+```jsonc
+"header": ["src","relation","dest","__relation_type__","__src_entity_id__","__dest_entity_id__",
+           "__src_domain__","__dest_domain__","__src_entity_type__","__dest_entity_type__", "display_name"]
+```
+
+Read it as `__src_entity_id__` →(`__relation_type__`)→ `__dest_entity_id__`, plus a
+human `display_name`. `getNeighborNodes` returns edges in **both directions**, so use src/dest
+to separate **upstream from downstream**:
+
+- who *calls* / *depends on* this node → rows where `__dest_entity_id__` is your node;
+- what it calls / depends on → rows where `__src_entity_id__` is your node.
+
+Demo relation types: `calls`, `depends_on`, `affects`, `targets`, `impacts`, `runs_as`,
+`owns`. Rows reference entities by **ID** — resolve display names with `.entity … with(ids=[…])`
+(see [entity.md](entity.md)).
+
+## Worked example
+
+Find who *calls* payment-gateway (`63718b78…`) — filter to `calls`, then read direction:
+
+```bash
+umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"platform@platform.service\" {__entity_id__:'63718b78868895d2590551b27ec6f51c'})]) | where __relation_type__ = 'calls'" -o json
+```
+
+→ 3 `calls` edges (`__src_entity_id__` → `__dest_entity_id__`, `display_name`):
+
+```
+149632df… → 63718b78…   Checkout service calls payment gateway — critical payment path
+f25ae292… → 63718b78…   Order service confirms payment via payment gateway
+63718b78… → 394ba4c2…   Payment gateway validates auth token via auth service
+```
+
+The first two have payment-gateway as `dest` → **upstream callers** (checkout, order). The
+third has it as `src` → auth is **downstream**. Resolve `149632df…` with `.entity … with(ids=['149632df…'])`
+→ `checkout-service`.

--- a/skills/umodel-rca/SKILL.md
+++ b/skills/umodel-rca/SKILL.md
@@ -24,28 +24,25 @@ inline below.
 
 ## Setup
 
-Same server and CLI as `umodel-query`. For the bundled demo:
-
-```bash
-make quickstart QUICKSTART_SAMPLE=examples/incident-investigation   # serves http://localhost:8080
-```
+Same server and CLI as `umodel-query` — ensure `umctl` is on PATH, pointed at your
+UModel server, and using the right workspace (`umctl workspace list`; the demo is
+`demo`). See that skill's **Setup** for details. The bundled demo serves sample data
+with `make quickstart QUICKSTART_SAMPLE=examples/incident-investigation`.
 
 ## Model-guided data fetch (autonomous retrieval)
 
-`get_metrics` / `get_logs` are driven by the object graph: the model knows which
-metric/log set hangs off an entity and the `fields_mapping`, so it **fills in
-`service_id` for you** — you never hand-write PromQL or guess an ID.
+To get evidence, call `get_metrics` / `get_logs` on the entity. The object graph
+auto-scopes the query — it fills in `service_id` from the `fields_mapping`, so you
+never hand-write PromQL or guess an ID:
 
 ```bash
 umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['63718b78868895d2590551b27ec6f51c']) | entity-call get_metrics('platform','platform.service.metrics','latency_p99_ms', step='30s')" -o json
-umctl query run demo ".entity_set with(domain='platform', name='platform.service', ids=['…']) | entity-call get_logs('platform','platform.service.logs', query='level = \"ERROR\"')" -o json
 ```
 
-> **Open source returns a query *plan*** (the rendered PromQL / ES query, with the
-> id substituted) — a downstream executor runs it. **Against a PaaS-backed
-> endpoint** (`umctl --addr <paas>` with `mode='data'`) the same call returns the
-> **actual rows** as the PaaS API response (`{__labels__, __ts__, __value__}` for
-> metrics). Either way, the object graph produced the exact, correctly-scoped query.
+These return an executable **plan**; run it against Prometheus / Elasticsearch to get the
+values — see *"Read metrics & logs — read the plan, then run it"* in the `umodel-query`
+skill for the plan's fields and how to execute. (A PaaS endpoint with `mode='data'`
+returns the rows directly.)
 
 ## The autonomous RCA loop
 
@@ -74,10 +71,12 @@ Run this loop; let evidence — not a fixed script — drive your next query.
 ## Runbook as scaffold
 
 If the entity links a `runbook_set` (read it with `.umodel with(kind='runbook_set',
-name='…')`), use its **observations** as a reasoning frame — each is a hypothesis +
-how to check it + a conclusion rule. Structure your reasoning with it; you may
-still form hypotheses it didn't list. Cite its `knowledge` (failure patterns) and
-`toolkits` (allowed remediation tools).
+name='…')`), use it as a reasoning frame. Its `spec.knowledge` holds documented
+**failure patterns** — in the demo, a *Retry Storm* pattern with the exact amplification
+formula `base_qps × promotion_multiplier × (new_retries / old_retries)`; `spec.automations`
+are the wired-up context-collection / remediation actions. Cite the matching knowledge
+entry as your mechanism (it's where the worked example's 8.75× comes from); you may still
+form hypotheses it didn't list.
 
 ## Output
 
@@ -101,9 +100,9 @@ root cause **without** being told the steps:
   runbook `platform.service.ops` + datasets `platform.service.metrics`/`.logs`.
 - CHARACTERIZE: `get_metrics(… 'latency_p99_ms' …)` → P99 breaching;
   `get_logs(… level="ERROR")` → upstream-timeout signatures.
-- GATHER: `.topo getNeighborNodes … 'calls'` → upstream `checkout-service`
-  (`149632df…`); `.entity … platform.config_change query='checkout'` →
-  `cfg-checkout-retry`, `max_retries 2→5` 24h ago.
+- GATHER: `.topo getNeighborNodes … | where __relation_type__='calls'` → upstream
+  caller `checkout-service` (`149632df…`); `.entity … platform.config_change query='checkout'`
+  → `checkout-retry-policy-v2`: `max_retries 2→5`, `timeout 500→2000ms` (targets svc-checkout).
 - DISCRIMINATE: `.entity … platform.deployment query='payment'` → `payment-gw
   v3.2.1`, trivial logging change → **ruled out** (red herring).
 - CROSS-DOMAIN: `.entity … business.promotion query='active'` → `618 Flash Sale`,
@@ -115,7 +114,8 @@ root cause **without** being told the steps:
 
 - Reuse the `umodel-query` reads for everything except telemetry fetch; this skill
   adds the fetch + the reasoning loop.
-- `get_metrics` / `get_logs`: *plan* in open source, *data* against a PaaS endpoint.
+- `get_metrics` / `get_logs`: *plan* in open source — execute it against Prometheus /
+  Elasticsearch to get evidence (see `umodel-query`); *data* directly via a PaaS endpoint.
 - Stay **read-only** — recommend remediation, do not execute it.
 - **MCP alternative**: call `query_spl_execute` with `{ "workspace", "query" }`
   instead of the CLI; same SPL.


### PR DESCRIPTION
## What

Makes **`umodel-query`** the complete data-retrieval skill across all read types and
restructures it for **progressive disclosure** (Agent Skills standard: a lean `SKILL.md` plus
`references/`).

Headline: `get_metrics` / `get_logs` return an executable **plan** (open source = plan
provider). The skill now teaches the agent to **read the plan and run it** against the backend
(Prometheus / Elasticsearch) with whatever tooling it has — completing entities → relations →
model → metrics/logs end to end. The LLM is the executor; **no engine code change**, endpoint-agnostic.

## Structure (progressive disclosure)

`skills/umodel-query/`
- `SKILL.md` — lean overview: setup (install `umctl`, point at the server, `umctl workspace list`),
  a surface→guide map, and how `.umodel` *types* relate to `.entity` / `.entity_set` via `domain`+`name`.
- `references/` — one focused guide per query surface, each documenting the **returned format + a
  worked example** with real demo values:
  - `entity.md` (`.entity`), `topology.md` (`.topo`), `model.md` (`.umodel`),
    `entity-set.md` (`.entity_set | entity-call`), `metrics-logs.md` (`get_metrics` / `get_logs`).

## Correctness (verified against the incident-investigation pack)

- topo relation filter is `| where __relation_type__='calls'` — `with(...)` does **not** filter graph-call output.
- `getNeighborNodes` returns edges in both directions; use `__src_entity_id__` / `__dest_entity_id__` to tell upstream from downstream.
- entity-call result shape: `responseType=1` → plan at `data.data[0][1]`; `=2` → table at `[2]`/`[3]`.
- Real plan fields and example values (PromQL, ES DSL, endpoints, mapped field names).

`umodel-rca` points at umodel-query's execute section and aligns its runbook / worked example to
the real pack. `skills/QUICKSTART.md` (+ `.zh-CN`): metric/log values run against your own
Prometheus / Elasticsearch.

## Verification

- `claude plugin validate` passes; SKILL↔references and inter-reference links all resolve.
- Plan shapes, topo filtering, the entity-call result shape, and the worked-example values were
  captured live from `make quickstart QUICKSTART_SAMPLE=examples/incident-investigation`.

Skill-only; no engine code change.