### PR TITLE
docs(examples): rebuild quickstart-multidomain README as a smart data-retrieval walkthrough

### DIFF
--- a/examples/quickstart-multidomain/README.md
+++ b/examples/quickstart-multidomain/README.md
@@ -1,10 +1,125 @@
-# Multi-Domain Quickstart Example Pack
+# Multi-Domain Quickstart — the smart data-retrieval demo
 
-`examples/quickstart-multidomain` is the default `make quickstart` sample. It shows how one workspace can connect DevOps ownership, coarse Kubernetes runtime topology, and enterprise scenario domains from `Demo/umodel-demo-2/umodel`.
+中文版本：[多域 Quickstart 示例包](README.zh-CN.md)
 
-The Kubernetes domain is intentionally coarse-grained: it models the runtime objects that help explain service topology, not a full Kubernetes object model.
+`examples/quickstart-multidomain` is the default `make quickstart` sample and the **smart
+data-retrieval (智能读数) showcase**: one workspace, **5 domains, 35 object types**, read
+end-to-end through a single SPL surface — discover the model, read objects and topology across
+domains, search semantically, and turn telemetry into executable query plans. It pairs with the
+[`umodel-query`](../../skills/umodel-query) skill, which lets an agent do this walkthrough
+autonomously.
 
-This pack includes entity topology plus a minimal DevOps observability chain. `devops.service` is linked to one `metric_set`, one `log_set`, and one `event_set`; each dataset is linked to a storage definition so EntitySet dataset discovery can be tested against real UModel data.
+The domains: **devops** (services, deployments, pipelines, SLOs, incidents…), **k8s** (coarse
+clusters / namespaces / workloads / pods), and three enterprise scenarios — **automaker**,
+**game**, **supplier**. `devops.service` carries a metric / log / event dataset, each linked to
+its storage (Prometheus / Elasticsearch / MySQL), so dataset discovery runs against real data.
+
+## Quick Start
+
+```bash
+make quickstart
+```
+
+API: `http://localhost:8080` | Web UI: `http://localhost:5173`. Loads 5 domains, 35 entity sets,
+93 entities, 125 relations into the `demo` workspace (in-memory, no API key).
+
+> API only (no Web UI):
+> `go run ./cmd/umodel-server --quickstart --quickstart-sample multi-domain-quickstart --graphstore memory`
+
+## Smart data-retrieval walkthrough
+
+Every read is one `umctl` command — always pass `-o json` (rows in `data.data`, columns in
+`data.header`). The same SPL works over MCP via the `query_spl_execute` tool. The
+[`umodel-query`](../../skills/umodel-query) skill performs these autonomously; here they are by hand.
+
+### 1. Discover the model
+
+```bash
+umctl query run demo ".umodel with(kind='entity_set') | project domain, name" -o json
+```
+
+→ 35 object types across `devops`, `k8s`, `automaker`, `game`, `supplier`. `.umodel` is the map;
+the `domain` + `name` you see here are what every other read takes.
+
+### 2. Read objects
+
+```bash
+umctl query run demo ".entity with(domain='devops', name='devops.service')" -o json   # all fields
+umctl query run demo ".entity with(domain='devops', name='devops.service') | project __entity_id__, display_name, status, owner" -o json
+```
+
+→ `checkout-service` (degraded), `catalog-api` (active), `delivery-service` (warning),
+`telemetry-collector` (active). `__entity_id__` (checkout-service = `10000000000000000000000000000101`)
+is the handle you reuse below. Pipes like `| project` are optional — a bare read returns all fields.
+
+### 3. Search
+
+Plain full-text — include any text and it matches across all fields:
+
+```bash
+umctl query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__, display_name, status" -o json
+# → checkout-service | degraded
+```
+
+For meaning-based ranking add `mode='vector'` (or `mode='hyper'` for hybrid) with `topk=N` — the
+top hit for `query='payment checkout'` is `checkout-service` ("Converts carts into paid orders").
+Semantic results come back as **full rows** ranked by similarity (the `| project` shortcut
+applies to plain reads).
+
+### 4. Traverse topology (including cross-domain)
+
+```bash
+umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"devops@devops.service\" {__entity_id__:'10000000000000000000000000000101'})]) | where __relation_type__ = 'runs'" -o json
+```
+
+→ `checkout-service --runs--> ` a **k8s** workload: a cross-domain edge (devops → k8s). Other
+relations on this node include `deploys`, `measured_by`, `runs_in`, `impacts`, `contains`. Filter
+rows with `where __relation_type__='…'` (a `with(...)` clause does **not** filter graph-call
+output). Rows carry entity **IDs** — resolve display names with `.entity … with(ids=[…])`.
+
+### 5. Discover an object's methods & datasets
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()" -o json
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call list_data_set(['metric_set','log_set','event_set'], true)" -o json
+```
+
+→ methods: `__list_method__`, `list_data_set`, `get_metrics`, `get_logs`. Datasets on the
+service: `devops.metric.service` (**Prometheus**), `devops.log.service` (**Elasticsearch**),
+`devops.event.deployment` (**MySQL**, table `deployment_events`). One object, three storage
+backends — all behind one model.
+
+### 6. Read metrics → plan → run
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops','devops.metric.service','request_count', step='30s')" -o json
+```
+
+→ a `prometheus_promql` plan carrying
+`sum(rate(devops_service_request_total{service_id="10000000000000000000000000000101"}[1m]))`
+against `http://prometheus.devops.example:9090` — the service id already substituted, no
+hand-written PromQL. Point the endpoint at your Prometheus and run it (see the skill's
+[metrics-logs guide](../../skills/umodel-query/references/metrics-logs.md)).
+
+### 7. Read logs → plan → run
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops','devops.log.service', query='level = \"ERROR\"')" -o json
+```
+
+→ an `elasticsearch_dsl` plan: a bool/filter query on index `devops-service-logs-*` against
+`https://elasticsearch.devops.example:9200`. Run it against your Elasticsearch the same way.
+
+> The `devops.event.deployment` event_set is modeled on **MySQL** (discoverable in Step 5 and via
+> `.umodel`), showing one model over three backends. The executable plan methods today are
+> `get_metrics` (Prometheus) and `get_logs` (Elasticsearch).
+
+## For an agent
+
+The [`umodel-query`](../../skills/umodel-query) skill teaches an agent to do all of the above —
+discover the model, read across domains, search, and turn `get_metrics` / `get_logs` plans into
+real values — on its own. Load it (and [`umodel-rca`](../../skills/umodel-rca) for root-cause
+analysis on top), connect over MCP or CLI, and ask in natural language.
 
 ## Contents
 
@@ -12,7 +127,7 @@ This pack includes entity topology plus a minimal DevOps observability chain. `d
 |---|---|---:|---|
 | DevOps entity sets | `devops/entity_set/` | 10 | Teams, services, repositories, pipelines, environments, deployments, releases, changes, incidents, and SLOs. |
 | Kubernetes entity sets | `k8s/entity_set/` | 7 | Coarse clusters, namespaces, workloads, pods, nodes, services, and ingresses. |
-| Enterprise demo entity sets | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | Entity topology reused from `Demo/umodel-demo-2/umodel`. |
+| Enterprise demo entity sets | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | Reused enterprise entity topology. |
 | Entity links | `*/link/entity_set_link/`, `cross-domain/link/entity_set_link/` | 42 | In-domain and cross-domain topology semantics. |
 | DevOps data sets | `devops/metric_set/`, `devops/log_set/`, `devops/event_set/` | 3 | Minimal service metrics, logs, and deployment events for EntitySet dataset discovery. |
 | Data and storage links | `devops/link/data_link/`, `devops/link/storage_link/` | 6 | Connect `devops.service` to datasets and datasets to storage. |
@@ -20,15 +135,9 @@ This pack includes entity topology plus a minimal DevOps observability chain. `d
 | Runtime entities | `sample-data/entities.json` | 93 | CMS 2.0 compatible entity payloads. |
 | Runtime relations | `sample-data/relations.json` | 125 | CMS 2.0 compatible topology payloads. |
 
-## Import
+## Manual import
 
-Start the quickstart server:
-
-```bash
-make quickstart
-```
-
-Manual import into another workspace:
+Into another workspace (the quickstart server imports automatically):
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/samples/demo/multi-domain-quickstart:import \
@@ -36,26 +145,11 @@ curl -X POST http://localhost:8080/api/v1/samples/demo/multi-domain-quickstart:i
   -d '{}'
 ```
 
-## Query Examples
-
-```bash
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__,display_name,status,owner | limit 10"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
-```
-
 ## Maintenance Rules
 
 - Keep model YAML, entity payloads, relation payloads, and docs aligned.
-- Keep the DevOps observability chain small: one service `metric_set`, one service `log_set`, one service `event_set`, and their `data_link` / `storage_link` definitions.
+- Keep the DevOps observability chain small: one service `metric_set`, one service `log_set`, one
+  service `event_set`, and their `data_link` / `storage_link` definitions.
 - Keep k8s coarse for quickstart readability.
-- Reuse only `entity_set` and `entity_set_link` from `Demo/umodel-demo-2/umodel`; keep dataset/storage definitions purpose-built for quickstart discovery.
+- Keep dataset/storage definitions purpose-built for quickstart discovery.
 - Run `make example-validate` and `go test ./internal/sampledata ./internal/bootstrap ./internal/query` after changing this pack.

--- a/examples/quickstart-multidomain/README.zh-CN.md
+++ b/examples/quickstart-multidomain/README.zh-CN.md
@@ -1,12 +1,94 @@
-# 多域 Quickstart 示例包
+# 多域 Quickstart — 智能读数 demo
 
 English: [Multi-Domain Quickstart Example Pack](README.md)
 
-`examples/quickstart-multidomain` 是 `make quickstart` 默认导入的样例。它展示一个 workspace 如何把 DevOps 归属、粗粒度 Kubernetes 运行拓扑，以及 `Demo/umodel-demo-2/umodel` 中的企业场景域连接起来。
+`examples/quickstart-multidomain` 是 `make quickstart` 默认导入的样例，也是**智能读数**的展示场景：一个 workspace、**5 个域、35 种对象类型**，通过同一套 SPL 入口端到端读取——发现模型、跨域读对象与拓扑、语义检索、把遥测变成可执行的查询 plan。它与 [`umodel-query`](../../skills/umodel-query) skill 配套，让 Agent 自主完成这套走查。
 
-Kubernetes 域刻意保持粗粒度：只建模能解释服务拓扑的运行时对象，不照搬完整 Kubernetes 对象模型。
+五个域：**devops**（服务、部署、流水线、SLO、故障…）、**k8s**（粗粒度集群/命名空间/工作负载/Pod），以及三个企业场景——**automaker**、**game**、**supplier**。`devops.service` 关联一个 metric / log / event 数据集，各自连到对应 Storage（Prometheus / Elasticsearch / MySQL），因此数据集发现是基于真实数据的。
 
-这个样例覆盖实体拓扑，并包含一条最小 DevOps 可观测链路。`devops.service` 关联一个 `metric_set`、一个 `log_set` 和一个 `event_set`，每个 DataSet 都关联到对应 Storage，用于基于真实 UModel 数据验证 EntitySet 的 DataSet 发现能力。
+## 快速开始
+
+```bash
+make quickstart
+```
+
+API：`http://localhost:8080` | Web UI：`http://localhost:5173`。把 5 个域、35 个 entity set、93 个实体、125 条关系载入 `demo` workspace（内存，无需密钥）。
+
+> 仅 API（不起 Web UI）：
+> `go run ./cmd/umodel-server --quickstart --quickstart-sample multi-domain-quickstart --graphstore memory`
+
+## 智能读数走查
+
+每次读取都是一条 `umctl` 命令——务必带 `-o json`（行在 `data.data`，列名在 `data.header`）。同样的 SPL 也可走 MCP 的 `query_spl_execute` 工具。[`umodel-query`](../../skills/umodel-query) skill 会自主执行这些；这里手动走一遍。
+
+### 1. 发现模型
+
+```bash
+umctl query run demo ".umodel with(kind='entity_set') | project domain, name" -o json
+```
+
+→ `devops`、`k8s`、`automaker`、`game`、`supplier` 五个域共 35 种对象类型。`.umodel` 是地图；这里看到的 `domain` + `name` 就是后面每个读取要传的参数。
+
+### 2. 读对象
+
+```bash
+umctl query run demo ".entity with(domain='devops', name='devops.service')" -o json   # 全字段
+umctl query run demo ".entity with(domain='devops', name='devops.service') | project __entity_id__, display_name, status, owner" -o json
+```
+
+→ `checkout-service`（degraded）、`catalog-api`（active）、`delivery-service`（warning）、`telemetry-collector`（active）。`__entity_id__`（checkout-service = `10000000000000000000000000000101`）是后续复用的句柄。`| project` 等 pipe 是可选的——裸读返回全部字段。
+
+### 3. 检索
+
+普通全文——填任意文本即可跨所有字段匹配：
+
+```bash
+umctl query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__, display_name, status" -o json
+# → checkout-service | degraded
+```
+
+需要按语义排序时加 `mode='vector'`（或 `mode='hyper'` 混合）和 `topk=N`——`query='payment checkout'` 的首位命中是 `checkout-service`（"Converts carts into paid orders"）。语义检索结果以**完整行**按相似度返回（`| project` 简写适用于普通读取）。
+
+### 4. 遍历拓扑（含跨域）
+
+```bash
+umctl query run demo ".topo | graph-call getNeighborNodes('full', 1, [(:\"devops@devops.service\" {__entity_id__:'10000000000000000000000000000101'})]) | where __relation_type__ = 'runs'" -o json
+```
+
+→ `checkout-service --runs--> ` 一个 **k8s** 工作负载：一条跨域边（devops → k8s）。该节点还有 `deploys`、`measured_by`、`runs_in`、`impacts`、`contains` 等关系。按关系过滤用 `where __relation_type__='…'`（`with(...)` 子句**不会**过滤 graph-call 输出）。行里是实体 **ID**——用 `.entity … with(ids=[…])` 还原名字。
+
+### 5. 发现对象的方法与数据集
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call __list_method__()" -o json
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call list_data_set(['metric_set','log_set','event_set'], true)" -o json
+```
+
+→ 方法：`__list_method__`、`list_data_set`、`get_metrics`、`get_logs`。服务上的数据集：`devops.metric.service`（**Prometheus**）、`devops.log.service`（**Elasticsearch**）、`devops.event.deployment`（**MySQL**，表 `deployment_events`）。一个对象、三种存储后端，都在同一套模型之下。
+
+### 6. 读指标 → plan → 执行
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops','devops.metric.service','request_count', step='30s')" -o json
+```
+
+→ 一个 `prometheus_promql` plan，携带
+`sum(rate(devops_service_request_total{service_id="10000000000000000000000000000101"}[1m]))`，
+打到 `http://prometheus.devops.example:9090`——service id 已替换好，无需手写 PromQL。把 endpoint 改成你的 Prometheus 再执行（见 skill 的 [metrics-logs 指南](../../skills/umodel-query/references/metrics-logs.md)）。
+
+### 7. 读日志 → plan → 执行
+
+```bash
+umctl query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops','devops.log.service', query='level = \"ERROR\"')" -o json
+```
+
+→ 一个 `elasticsearch_dsl` plan：对索引 `devops-service-logs-*`、`https://elasticsearch.devops.example:9200` 的 bool/filter 查询。同样改成你的 ES 再执行。
+
+> `devops.event.deployment` event_set 建模在 **MySQL** 上（第 5 步 / `.umodel` 可发现），展示一套模型覆盖三种后端。目前可执行的 plan 方法是 `get_metrics`（Prometheus）和 `get_logs`（Elasticsearch）。
+
+## 给 Agent
+
+[`umodel-query`](../../skills/umodel-query) skill 教 Agent 自主完成以上全部——发现模型、跨域读取、检索、把 `get_metrics` / `get_logs` 的 plan 变成真实数值。加载它（再加 [`umodel-rca`](../../skills/umodel-rca) 做根因分析），通过 MCP 或 CLI 接入，用自然语言提问即可。
 
 ## 内容
 
@@ -14,7 +96,7 @@ Kubernetes 域刻意保持粗粒度：只建模能解释服务拓扑的运行时
 |---|---|---:|---|
 | DevOps EntitySet | `devops/entity_set/` | 10 | 团队、服务、仓库、流水线、环境、部署、发布、变更、故障、SLO。 |
 | Kubernetes EntitySet | `k8s/entity_set/` | 7 | 粗粒度集群、命名空间、工作负载、Pod、节点、Service、Ingress。 |
-| 企业 demo EntitySet | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | 直接复用 `Demo/umodel-demo-2/umodel` 的实体拓扑定义。 |
+| 企业 demo EntitySet | `automaker/entity_set/`, `game/entity_set/`, `supplier/entity_set/` | 18 | 复用的企业实体拓扑定义。 |
 | EntitySetLink | `*/link/entity_set_link/`, `cross-domain/link/entity_set_link/` | 42 | 域内和跨域拓扑语义。 |
 | DevOps DataSet | `devops/metric_set/`, `devops/log_set/`, `devops/event_set/` | 3 | 用于 EntitySet DataSet 发现的最小服务指标、日志和部署事件。 |
 | DataLink 和 StorageLink | `devops/link/data_link/`, `devops/link/storage_link/` | 6 | 连接 `devops.service` 到 DataSet，并连接 DataSet 到 Storage。 |
@@ -22,15 +104,9 @@ Kubernetes 域刻意保持粗粒度：只建模能解释服务拓扑的运行时
 | Runtime entities | `sample-data/entities.json` | 93 | CMS 2.0 兼容实体 payload。 |
 | Runtime relations | `sample-data/relations.json` | 125 | CMS 2.0 兼容拓扑 payload。 |
 
-## 导入
+## 手动导入
 
-启动 quickstart：
-
-```bash
-make quickstart
-```
-
-手动导入到其他 workspace：
+导入到其他 workspace（quickstart 服务会自动导入）：
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/samples/demo/multi-domain-quickstart:import \
@@ -38,26 +114,10 @@ curl -X POST http://localhost:8080/api/v1/samples/demo/multi-domain-quickstart:i
   -d '{}'
 ```
 
-## 查询示例
-
-```bash
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".umodel with(kind='entity_set') | project domain,name,kind | sort domain,name | limit 20"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity with(domain='devops', name='devops.service', query='checkout') | project __entity_id__,display_name,status,owner | limit 10"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service') | entity-call list_data_set(['metric_set', 'log_set', 'event_set'], true)"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_logs('devops', 'devops.log.service', query='level = \"ERROR\"')"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".entity_set with(domain='devops', name='devops.service', ids=['10000000000000000000000000000101']) | entity-call get_metrics('devops', 'devops.metric.service', 'request_count', step='30s')"
-
-go run ./cmd/umctl --addr http://localhost:8080 query run demo ".topo | graph-call getNeighborNodes('full', 2, [(:\"devops@devops.service\" {__entity_id__: '10000000000000000000000000000101'})]) | limit 20"
-```
-
 ## 维护规则
 
 - 保持模型 YAML、entity payload、relation payload 和文档一致。
 - 保持 DevOps 可观测链路足够小：一个服务 `metric_set`、一个服务 `log_set`、一个服务 `event_set`，以及对应的 `data_link` / `storage_link`。
-- quickstart 里的 k8s 保持粗粒度，避免变成完整 Kubernetes 规范。
-- 只从 `Demo/umodel-demo-2/umodel` 复用 `entity_set` 和 `entity_set_link`；DataSet/Storage 定义保持为 quickstart discovery 专用的最小版本。
+- quickstart 里的 k8s 保持粗粒度。
+- DataSet/Storage 定义保持为 quickstart discovery 专用的最小版本。
 - 修改后运行 `make example-validate` 和 `go test ./internal/sampledata ./internal/bootstrap ./internal/query`。


### PR DESCRIPTION
## What

Turns the default `make quickstart` pack's README (en + zh) from a terse reference into a guided
**smart data-retrieval (智能读数)** walkthrough — the read-side companion to the
incident-investigation RCA demo. It pairs with the `umodel-query` skill.

## The walkthrough (7 steps, all verified against live `make quickstart` data)

1. **Discover the model** — `.umodel` → 5 domains / 35 object types.
2. **Read objects** — `.entity` → checkout-service (degraded), catalog-api, delivery-service, telemetry-collector.
3. **Search** — full-text `query='checkout'`; `mode='vector'` / `'hyper'` for semantic ranking.
4. **Traverse topology** — `.topo getNeighborNodes … | where __relation_type__='runs'` → the cross-domain devops→**k8s** edge (uses `where`; a `with(...)` clause does not filter graph-call output).
5. **Discover capabilities** — `__list_method__` (4 methods) + `list_data_set` → 3 datasets across **Prometheus / Elasticsearch / MySQL**.
6. **Read metrics → plan → run** — `prometheus_promql`, `sum(rate(devops_service_request_total{service_id="…"}[1m]))`.
7. **Read logs → plan → run** — `elasticsearch_dsl`, index `devops-service-logs-*`.

Real ids/values/plans throughout; links to the `umodel-query` / `umodel-rca` skills. The MySQL
`event_set` is noted as modeled/discoverable (the plan-returning fetch methods today are
`get_metrics` / `get_logs`).

## Scope

README only (en + zh). Pack model/sample-data unchanged — counts (35 entity sets, 93 entities,
125 relations) and structure were already correct, so `make example-validate` is unaffected.