### PR TITLE
fix(docker): copy go.sum so the server image builds

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.22 AS build
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
+RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 COPY pkg ./pkg


### PR DESCRIPTION
## Problem

`deployments/docker/Dockerfile` copies only `go.mod` into the build stage:

```dockerfile
COPY go.mod ./
```

`go.sum` is therefore absent from the build context, and `go build` fails:

```
internal/umodel/schemaspec/registry.go:11:2: missing go.sum entry for module providing package gopkg.in/yaml.v3 (imported by github.com/alibaba/UnifiedModel/internal/umodel); to add:
	go get github.com/alibaba/UnifiedModel/internal/umodel
```

## Fix

Copy `go.sum` alongside `go.mod` and pre-download modules before building — the standard multi-stage Go pattern:

```dockerfile
COPY go.mod go.sum ./
RUN go mod download
```

`go.sum` already exists at the repo root, so it just needs to be added to the `COPY`.

## Verification

Built with the build context = repo root (`docker build -f deployments/docker/Dockerfile .`):

- **Before** (original Dockerfile): fails at `go build` with the `missing go.sum entry` error above.
- **After** (this change): image builds successfully through both stages.
