### PR TITLE
feat(demo): add stop.sh to tear down the quickstart demo stack

### DIFF
--- a/examples/quickstart-multidomain/deploy/README.md
+++ b/examples/quickstart-multidomain/deploy/README.md
@@ -52,7 +52,8 @@ plan's `_search` against `:9200`.
 ## Teardown
 
 ```bash
-docker compose -f examples/quickstart-multidomain/deploy/docker-compose.yml down -v   # or: podman compose …
+sh examples/quickstart-multidomain/deploy/stop.sh          # stop + remove containers, network, volumes
+sh examples/quickstart-multidomain/deploy/stop.sh --all    # also remove the built image
 ```
 
 ## Notes

--- a/examples/quickstart-multidomain/deploy/README.zh-CN.md
+++ b/examples/quickstart-multidomain/deploy/README.zh-CN.md
@@ -42,7 +42,8 @@ sh examples/quickstart-multidomain/deploy/verify.sh
 ## 关停
 
 ```bash
-docker compose -f examples/quickstart-multidomain/deploy/docker-compose.yml down -v   # 或:podman compose …
+sh examples/quickstart-multidomain/deploy/stop.sh          # 停止并删除容器、网络、卷
+sh examples/quickstart-multidomain/deploy/stop.sh --all    # 连构建的镜像也删
 ```
 
 ## 说明

--- a/examples/quickstart-multidomain/deploy/start.sh
+++ b/examples/quickstart-multidomain/deploy/start.sh
@@ -56,5 +56,5 @@ cat <<EOF
        error rate, and p95 latency, and show its recent ERROR logs. Why is it degraded?"
 
     Smoke-test without an agent:  sh "$DIR/verify.sh"
-    Tear down:                    $COMPOSE -f "$COMPOSE_FILE" down -v
+    Stop & clean up:              sh "$DIR/stop.sh"   (add --all to also remove the image)
 EOF

--- a/examples/quickstart-multidomain/deploy/stop.sh
+++ b/examples/quickstart-multidomain/deploy/stop.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+# Stop the quickstart demo stack and clean up its containers, network, and volumes.
+# Pass --all to also remove the built image. Bring it back with start.sh.
+set -eu
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="$DIR/docker-compose.yml"
+
+RMI=""
+case "${1:-}" in
+  --all|--images) RMI="--rmi local" ;;
+  "") ;;
+  *) echo "usage: stop.sh [--all]   (--all also removes the built demo image)" >&2; exit 2 ;;
+esac
+
+# Pick a compose engine: docker compose / podman compose / docker-compose.
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE="docker compose"
+elif podman compose version >/dev/null 2>&1; then
+  COMPOSE="podman compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE="docker-compose"
+else
+  echo "error: need 'docker compose' or 'podman compose' (or docker-compose) on PATH" >&2
+  exit 1
+fi
+
+echo "==> Stopping the demo stack with: $COMPOSE"
+# shellcheck disable=SC2086
+$COMPOSE -f "$COMPOSE_FILE" down -v --remove-orphans $RMI
+
+echo "==> Stopped. Removed containers, network, and volumes${RMI:+ and the built image}."
+[ -z "$RMI" ] && echo "    (run 'stop.sh --all' to also remove the built image)"
+echo "    Bring it back: sh \"$DIR/start.sh\""


### PR DESCRIPTION
Adds `deploy/stop.sh` — the teardown counterpart to `start.sh`. Runs `compose down -v --remove-orphans` (docker or podman); `--all` also removes the built image. Wired into `start.sh`'s output and the deploy READMEs (en+zh) in place of the raw `compose down` command.