### PR TITLE
fix(graphstore): raise memory provider MaxLimit 100 → 10000

### DIFF
--- a/internal/graphstore/memory.go
+++ b/internal/graphstore/memory.go
@@ -256,8 +256,11 @@ func (s *MemoryStore) Capabilities(ctx context.Context) (model.GraphStoreCapabil
 		TimeVisibility:     true,
 		ServerSideFilter:   false,
 		MaxDepth:           2,
-		MaxLimit:           100,
-		Timeout:            "10s",
+		// Memory backs --quickstart / MCP / demos and has no storage backend, so
+		// it serves a generous row ceiling. Kept >= the default local.ladybug
+		// provider's 1000 so any production-valid `limit` is also valid here.
+		MaxLimit: 10000,
+		Timeout:  "10s",
 	}, nil
 }
 

--- a/internal/graphstore/memory_test.go
+++ b/internal/graphstore/memory_test.go
@@ -234,3 +234,18 @@ func relationPayload(src, dest, method string, first, last int64, fields map[str
 	}
 	return payload
 }
+
+// TestMemoryStoreMaxLimitNotBelowDefaultProvider guards query portability: the
+// memory store backs --quickstart / MCP / the demos, so a `limit` valid on the
+// default local.ladybug provider (MaxLimit 1000) must not be rejected here.
+// Memory itself caps higher (10000, in-memory headroom). Regression for
+// "query limit exceeds provider capability" when memory advertised MaxLimit 100.
+func TestMemoryStoreMaxLimitNotBelowDefaultProvider(t *testing.T) {
+	caps, err := NewMemoryStore().Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("capabilities: %v", err)
+	}
+	if caps.MaxLimit < 1000 {
+		t.Fatalf("memory MaxLimit = %d, want >= 1000 so production-valid limits stay portable", caps.MaxLimit)
+	}
+}


### PR DESCRIPTION
## Problem

A `limit 1000` query is rejected with `VALIDATION_FAILED — query limit exceeds provider capability` whenever the **memory** GraphStore backs the server (`--quickstart`, MCP, the demos):

```json
"error": {
  "code": "VALIDATION_FAILED",
  "message": "query limit exceeds provider capability",
  "details": { "limit": "1000", "max_limit": "100" }
}
```

The memory provider advertised `MaxLimit: 100` while the default `local.ladybug` provider advertises `1000`, so a query that is valid in production fails on the in-memory backend. The query default is `100`, so the `1000` here was an explicit `| limit 1000`.

## Fix

Memory has no storage backend, so give it a generous **`MaxLimit: 10000`**. It stays `>=` the default `local.ladybug` provider's `1000`, so any production-valid `limit` is also valid here. Row prealloc is already bounded at `1024`, so large limits just grow the slice. `MaxDepth` is left at `2` — memory's traversal genuinely doesn't expand deep, so that cap stays honest.

> Note: this puts memory (10000) above ladybug (1000), so a `limit` of 1001–10000 works on the memory-backed quickstart/demo but is rejected on the ladybug default. That's intentional headroom for in-memory demos; raise ladybug too if you want them symmetric.

Adds `TestMemoryStoreMaxLimitNotBelowDefaultProvider` to guard the floor.

## Verification

- `go build` + `internal/graphstore`, `internal/query`, `internal/bootstrap`, `tests/contract` green (including the new test).
- Live, against a freshly-built memory-backed server: `.entity … | limit 1000` returns `Success` (previously the error); `limit 100` → OK; `limit > 10000` → still correctly rejected.
