### PR TITLE
fix(guard): exclude gitignored .claude/ from the architecture guard

### DIFF
--- a/tools/guards/architecture_guard.py
+++ b/tools/guards/architecture_guard.py
@@ -34,7 +34,10 @@ ALLOWED_PROVIDER_IMPORTS = {
 
 
 def iter_files() -> list[pathlib.Path]:
-    ignored_parts = {".git", ".venv", "__pycache__", "node_modules"}
+    # .claude holds gitignored local agent artifacts — nested git worktrees of
+    # other branches and copies of tooling — which are not the source tree under
+    # review and would otherwise trip the path-exact self-exclusion / allowlist.
+    ignored_parts = {".git", ".venv", "__pycache__", "node_modules", ".claude"}
     files: list[pathlib.Path] = []
     for path in ROOT.rglob("*"):
         if not path.is_file() or path.suffix not in TEXT_SUFFIXES:


### PR DESCRIPTION
## Symptom

`make ci` fails on the **`guard`** step (the first step of the gate) with violations that are all under `.claude/worktrees/`:

```
Architecture guard failed:
  - .claude/worktrees/github-pages/tools/guards/architecture_guard.py: UModelAssistant is not part of the current open-source runtime
  - .claude/worktrees/github-pages/tools/guards/architecture_guard.py: business modules must not import provider implementation packages
  - .claude/worktrees/github-pages/internal/bootstrap/app.go: business modules must not import provider implementation packages
```

## Cause

`iter_files()` walks the whole working tree via `rglob("*")`, skipping only `.git / .venv / __pycache__ / node_modules`. It does **not** skip `.claude/`, which is gitignored and holds nested git worktrees of *other* branches plus a copy of the guard script. The guard self-excludes and allowlists provider imports by **exact relative path** (`tools/guards/architecture_guard.py`, `internal/bootstrap/app.go`, …); the `.claude/worktrees/.../` copies have different relative paths, dodge those exclusions, and get flagged.

CI runs on `ubuntu-latest` from a clean checkout with no `.claude/`, so this only breaks **local** `make ci`.

## Fix

Add `.claude` to the guard's `ignored_parts`.

## Verification

- `make guard` → `Architecture guard passed.`
- The rest of the gate already passes on current `main`: `build-service`, `test-service`, `test-capability`, `test-quickstart-health`, `check-manifest`, `example-validate`, `docs-schema-check`, `verify-go` all green.
