### PR TITLE
docs(readme): make the demo video render (user-attachments <video>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ With UModel, you can:
 
 ## Demo
 
-<video src="https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4" controls width="800"></video>
+<video src="https://github.com/user-attachments/assets/3cdc72de-2f78-495c-baf9-7066c1d9792f" controls></video>
 
-An AI agent reads across the object graph in the `quickstart-multidomain` workspace (90 seconds): it discovers services, walks cross-domain topology, and pulls metrics and logs through model-scoped query plans, without hand-writing a single query. If the player does not load, [watch the clip directly](https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4).
+An AI agent reads across the object graph in the `quickstart-multidomain` workspace (90 seconds): it discovers services, walks cross-domain topology, and pulls metrics and logs through model-scoped query plans, without hand-writing a single query.
 
 ## Why UModel
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,9 +19,9 @@ UModel 支持：
 
 ## 演示
 
-<video src="https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4" controls width="800"></video>
+<video src="https://github.com/user-attachments/assets/3cdc72de-2f78-495c-baf9-7066c1d9792f" controls></video>
 
-AI Agent 在 `quickstart-multidomain` workspace 上读取对象图（90 秒）：发现服务、沿跨域拓扑遍历、并通过模型自动生成的查询计划拉取指标和日志，全程不手写一条查询。播放器若未加载，[直接观看视频](https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4)。
+AI Agent 在 `quickstart-multidomain` workspace 上读取对象图（90 秒）：发现服务、沿跨域拓扑遍历、并通过模型自动生成的查询计划拉取指标和日志，全程不手写一条查询。
 
 ## 为什么需要 UModel
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -19,9 +19,9 @@ UModel 支持：
 
 ## 演示
 
-<video src="https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4" controls width="800"></video>
+<video src="https://github.com/user-attachments/assets/3cdc72de-2f78-495c-baf9-7066c1d9792f" controls></video>
 
-AI Agent 在 `quickstart-multidomain` workspace 上读取对象图（90 秒）：发现服务、沿跨域拓扑遍历、并通过模型自动生成的查询计划拉取指标和日志，全程不手写一条查询。播放器若未加载，[直接观看视频](https://unifiedmodel-assets.oss-accelerate.aliyuncs.com/QuickStart.mp4)。
+AI Agent 在 `quickstart-multidomain` workspace 上读取对象图（90 秒）：发现服务、沿跨域拓扑遍历、并通过模型自动生成的查询计划拉取指标和日志，全程不手写一条查询。
 
 ## 为什么需要 UModel
 


### PR DESCRIPTION
Follow-up to #59. The merge landed the **OSS** `<video>`, which GitHub's CSP blocks — so the Demo player doesn't show on the front page. This swaps it for the **GitHub user-attachments** `<video>` (the only source that renders an inline player in a README file) and drops the now-unneeded fallback link. EN + both CN; no other changes.