### PR TITLE
fix(security): harden import confinement, request bodies, server timeouts

### DIFF
--- a/cmd/umodel-server/main.go
+++ b/cmd/umodel-server/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/alibaba/UnifiedModel/internal/bootstrap"
 	"github.com/alibaba/UnifiedModel/internal/graphstore"
@@ -60,7 +61,16 @@ func main() {
 	if *uiDir != "" {
 		log.Printf("serving web UI from %s", *uiDir)
 	}
-	if err := http.ListenAndServe(*addr, app.HandlerWithUI(*uiDir)); err != nil {
+	server := &http.Server{
+		Addr:              *addr,
+		Handler:           app.HandlerWithUI(*uiDir),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -628,8 +628,13 @@ func workspaceAction(path, prefix string) (string, string, bool) {
 	return parts[0], parts[1], true
 }
 
+// maxRequestBodyBytes caps a decoded JSON request body so a single request
+// cannot exhaust server memory.
+const maxRequestBodyBytes = 32 << 20 // 32 MiB
+
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) bool {
 	defer r.Body.Close()
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {

--- a/internal/umodel/import.go
+++ b/internal/umodel/import.go
@@ -18,24 +18,33 @@ import (
 // confined to the configured import root (WithImportRoot; the current working
 // directory by default) so an API caller cannot read arbitrary server files.
 func (s *Service) Import(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
+	confineRoot := ""
 	if req.Path != "" {
 		confined, err := s.confineImportPath(req.Path)
 		if err != nil {
 			return model.UModelImportResult{Workspace: workspace, Source: req.Path}, err
 		}
 		req.Path = confined
+		// collectImportFiles discovers files by extension without resolving
+		// symlinks, so a nested symlink could point outside the import root.
+		// Carry the resolved root so importInternal re-checks every file.
+		root, err := s.resolvedImportRoot()
+		if err != nil {
+			return model.UModelImportResult{Workspace: workspace, Source: req.Path}, err
+		}
+		confineRoot = root
 	}
-	return s.importInternal(ctx, workspace, req)
+	return s.importInternal(ctx, workspace, req, confineRoot)
 }
 
 // ImportTrusted loads UModel elements from a path the caller has already
 // vouched for (e.g. a bundled sample pack resolved from the repository).
 // It skips import-root confinement and must never be reached by user input.
 func (s *Service) ImportTrusted(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
-	return s.importInternal(ctx, workspace, req)
+	return s.importInternal(ctx, workspace, req, "")
 }
 
-func (s *Service) importInternal(ctx context.Context, workspace string, req model.UModelImportRequest) (model.UModelImportResult, error) {
+func (s *Service) importInternal(ctx context.Context, workspace string, req model.UModelImportRequest, confineRoot string) (model.UModelImportResult, error) {
 	if workspace == "" {
 		return model.UModelImportResult{}, apperrors.New(apperrors.CodeInvalidArgument, "workspace is required")
 	}
@@ -56,6 +65,19 @@ func (s *Service) importInternal(ctx context.Context, workspace string, req mode
 	result.Skipped = skipped
 
 	for _, path := range paths {
+		// Re-confine each discovered file to the import root. collectImportFiles
+		// matches by extension and does not resolve symlinks, so a nested symlink
+		// could otherwise read a file outside the root. ImportTrusted passes an
+		// empty confineRoot to keep bundled sample loads unconfined.
+		if confineRoot != "" {
+			resolved, ok := withinResolvedRoot(confineRoot, path)
+			if !ok {
+				return result, apperrors.WithDetails(apperrors.CodeInvalidArgument,
+					"import file is outside the allowed import root",
+					map[string]string{"path": path, "import_root": confineRoot})
+			}
+			path = resolved
+		}
 		element, err := parseUModelElementFile(path)
 		if err != nil {
 			return result, apperrors.WithDetails(apperrors.CodeValidationFailed, "umodel import failed", map[string]string{
@@ -85,7 +107,10 @@ func (s *Service) importInternal(ctx context.Context, workspace string, req mode
 // returning the cleaned absolute path. The root defaults to the current
 // working directory; "/" effectively disables confinement. This is the
 // barrier that stops an API-provided path from escaping to arbitrary files.
-func (s *Service) confineImportPath(p string) (string, error) {
+// resolvedImportRoot returns the absolute, symlink-resolved import root. The root
+// defaults to the current working directory; "/" effectively disables
+// confinement.
+func (s *Service) resolvedImportRoot() (string, error) {
 	root := s.importRoot
 	if root == "" {
 		wd, err := os.Getwd()
@@ -103,6 +128,14 @@ func (s *Service) confineImportPath(p string) (string, error) {
 	if resolvedRoot, rerr := filepath.EvalSymlinks(rootAbs); rerr == nil {
 		rootAbs = resolvedRoot
 	}
+	return rootAbs, nil
+}
+
+func (s *Service) confineImportPath(p string) (string, error) {
+	rootAbs, err := s.resolvedImportRoot()
+	if err != nil {
+		return "", err
+	}
 
 	abs, err := filepath.Abs(p)
 	if err != nil {
@@ -118,13 +151,28 @@ func (s *Service) confineImportPath(p string) (string, error) {
 	}
 	abs = resolvedAbs
 
-	rel, err := filepath.Rel(rootAbs, abs)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if _, ok := withinResolvedRoot(rootAbs, abs); !ok {
 		return "", apperrors.WithDetails(apperrors.CodeInvalidArgument,
 			"import path is outside the allowed import root",
 			map[string]string{"import_root": rootAbs})
 	}
 	return abs, nil
+}
+
+// withinResolvedRoot resolves candidate's symlinks and reports whether it stays
+// inside rootResolved, which must be absolute and already symlink-resolved. It
+// returns the resolved candidate path when contained. This is the per-file
+// counterpart to confineImportPath's top-level check.
+func withinResolvedRoot(rootResolved, candidate string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return resolved, true
 }
 
 func (s *Service) loadCommonSchemaPacks(ctx context.Context, workspace string, packs []string) ([]model.UModelElement, error) {

--- a/internal/umodel/import.go
+++ b/internal/umodel/import.go
@@ -99,12 +99,24 @@ func (s *Service) confineImportPath(p string) (string, error) {
 		return "", apperrors.WithDetails(apperrors.CodeInternal, "invalid import root", map[string]string{"reason": err.Error()})
 	}
 	rootAbs = filepath.Clean(rootAbs)
+	// Resolve symlinks in the root so containment is checked against the real path.
+	if resolvedRoot, rerr := filepath.EvalSymlinks(rootAbs); rerr == nil {
+		rootAbs = resolvedRoot
+	}
 
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		return "", apperrors.WithDetails(apperrors.CodeInvalidArgument, "invalid import path", map[string]string{"path": p})
 	}
 	abs = filepath.Clean(abs)
+	// Resolve symlinks before the containment check so an in-root symlink cannot
+	// point outside the import root. EvalSymlinks also fails closed for a path
+	// that does not exist.
+	resolvedAbs, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", apperrors.WithDetails(apperrors.CodeInvalidArgument, "import path is not accessible", map[string]string{"path": p})
+	}
+	abs = resolvedAbs
 
 	rel, err := filepath.Rel(rootAbs, abs)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {

--- a/internal/umodel/import_confine_test.go
+++ b/internal/umodel/import_confine_test.go
@@ -82,3 +82,37 @@ func TestImportRejectsSymlinkEscape(t *testing.T) {
 		t.Fatalf("import via in-root symlink to outside should be INVALID_ARGUMENT, got: %v", err)
 	}
 }
+
+// TestImportRejectsNestedSymlinkFileEscape covers a symlinked import file nested
+// inside an allowed directory that points outside the import root. The top-level
+// path (the directory) is legitimately inside the root, so confineImportPath
+// passes it; the escape only happens for a file discovered by the directory
+// walk, which must therefore re-check every collected file.
+func TestImportRejectsNestedSymlinkFileEscape(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	const es = "kind: entity_set\nschema:\n  url: u\n  version: v0.1.0\nmetadata:\n  name: devops.service\n  domain: devops\nspec:\n  fields:\n    - name: id\n      type: string\n  primary_key_fields: [id]\n  id_generator: id\n"
+
+	// A valid pack file outside the root — valid so that, absent the fix, it
+	// would import cleanly rather than failing on a parse error.
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.yaml")
+	if err := os.WriteFile(secret, []byte(es), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	// An allowed directory inside the root, containing a symlinked yaml that
+	// points at the outside file.
+	pack := filepath.Join(root, "pack")
+	if err := os.MkdirAll(pack, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(secret, filepath.Join(pack, "outside.yaml")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot(root))
+	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: pack}); !apperrors.IsCode(err, apperrors.CodeInvalidArgument) {
+		t.Fatalf("nested symlink file escaping the root should be INVALID_ARGUMENT, got: %v", err)
+	}
+}

--- a/internal/umodel/import_confine_test.go
+++ b/internal/umodel/import_confine_test.go
@@ -57,3 +57,28 @@ func TestImportConfinesToRoot(t *testing.T) {
 		t.Fatalf("ImportTrusted should bypass confinement, got: %v", err)
 	}
 }
+
+// TestImportRejectsSymlinkEscape verifies that a symlink placed inside the
+// import root but pointing outside it is rejected: symlinks are resolved before
+// the containment check, so the import root cannot be escaped via a symlink.
+func TestImportRejectsSymlinkEscape(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	const es = "kind: entity_set\nschema:\n  url: u\n  version: v0.1.0\nmetadata:\n  name: devops.service\n  domain: devops\nspec:\n  fields:\n    - name: id\n      type: string\n  primary_key_fields: [id]\n  id_generator: id\n"
+
+	// A pack directory outside the root.
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "svc.yaml"), []byte(es), 0o644); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	// A symlink inside the root that points at the outside directory.
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot(root))
+	if _, err := svc.Import(ctx, "demo", model.UModelImportRequest{Path: link}); !apperrors.IsCode(err, apperrors.CodeInvalidArgument) {
+		t.Fatalf("import via in-root symlink to outside should be INVALID_ARGUMENT, got: %v", err)
+	}
+}


### PR DESCRIPTION
Three robustness fixes surfaced by a deep functionality/performance/stability review of the backend.

## 1. Import root can be escaped via a symlink (security)
`confineImportPath` ([internal/umodel/import.go](internal/umodel/import.go)) checked containment with `filepath.Abs`+`Clean`, which does **not** resolve symlinks. A symlink placed inside the import root but pointing outside it passed the check and was then read — defeating the "an API caller cannot read arbitrary server files" barrier from #44.

Fix: `filepath.EvalSymlinks` on both the root and the candidate path before the `filepath.Rel` containment check (also fails closed for non-existent paths). Adds `TestImportRejectsSymlinkEscape`; the existing `TestImportConfinesToRoot` still passes.

## 2. Unbounded JSON request bodies
`decodeJSON` ([internal/bootstrap/app.go](internal/bootstrap/app.go)) decoded `r.Body` with no size cap → a single large body could exhaust memory. Fix: wrap with `http.MaxBytesReader` (32 MiB).

## 3. No server timeouts
`umodel-server` used bare `http.ListenAndServe` ([cmd/umodel-server/main.go](cmd/umodel-server/main.go)) → slow/hung clients hold connections indefinitely (Slowloris). Fix: an `http.Server` with `ReadHeaderTimeout` / `ReadTimeout` / `WriteTimeout` / `IdleTimeout` and `MaxHeaderBytes`.

## Verification
`go build ./...`, `go vet`, and `internal/umodel` + `internal/bootstrap` tests pass (incl. the new symlink test).
