### PR TITLE
fix(query): quote-aware where-operator scan + validate agent query limit

### DIFF
--- a/internal/agentgateway/service.go
+++ b/internal/agentgateway/service.go
@@ -268,6 +268,12 @@ func (s *Service) queryRequest(args map[string]any) (model.QueryRequest, error) 
 	if req.Query == "" {
 		return model.QueryRequest{}, apperrors.New(apperrors.CodeInvalidArgument, "query argument is required")
 	}
+	if req.Limit < 0 {
+		return model.QueryRequest{}, apperrors.New(apperrors.CodeInvalidArgument, "limit must be >= 0")
+	}
+	if req.TimeoutMS < 0 {
+		return model.QueryRequest{}, apperrors.New(apperrors.CodeInvalidArgument, "timeout_ms must be >= 0")
+	}
 	if params, ok := args["parameters"].(map[string]any); ok {
 		req.Params = params
 	}

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -362,18 +362,17 @@ func parsePredicate(expression string) (model.QueryPredicate, error) {
 		return model.QueryPredicate{Field: strings.TrimSpace(args[0]), Op: "contains", Value: parseValue(args[1])}, nil
 	}
 
-	for _, op := range []string{"==", "!=", ">=", "<=", "=", "~", ">", "<"} {
-		if idx := strings.Index(expression, op); idx >= 0 {
-			field := strings.TrimSpace(expression[:idx])
-			value := strings.TrimSpace(expression[idx+len(op):])
-			if field == "" || value == "" {
-				return model.QueryPredicate{}, apperrors.New(apperrors.CodeQueryParseError, "where requires field, operator, and value")
-			}
-			if op == "==" {
-				op = "="
-			}
-			return model.QueryPredicate{Field: field, Op: op, Value: parseValue(value)}, nil
+	ops := []string{"==", "!=", ">=", "<=", "=", "~", ">", "<"}
+	if idx, op := topLevelOperatorIndex(expression, ops); idx >= 0 {
+		field := strings.TrimSpace(expression[:idx])
+		value := strings.TrimSpace(expression[idx+len(op):])
+		if field == "" || value == "" {
+			return model.QueryPredicate{}, apperrors.New(apperrors.CodeQueryParseError, "where requires field, operator, and value")
 		}
+		if op == "==" {
+			op = "="
+		}
+		return model.QueryPredicate{Field: field, Op: op, Value: parseValue(value)}, nil
 	}
 	return model.QueryPredicate{}, apperrors.New(apperrors.CodeQueryParseError, "unsupported where predicate")
 }
@@ -818,6 +817,50 @@ func cutTopLevel(text string, sep rune) (string, string, bool) {
 		return "", "", false
 	}
 	return text[:idx], text[idx+len(string(sep)):], true
+}
+
+// topLevelOperatorIndex returns the byte offset and matched operator of the
+// first operator in ops that sits outside any quoted string or bracket group,
+// so a quoted value containing operator characters (e.g. "a<=b") is not
+// mistaken for the predicate's operator. List multi-character operators before
+// their single-character prefixes (== before =, >= before >) so the longest
+// match wins at a given position.
+func topLevelOperatorIndex(text string, ops []string) (int, string) {
+	depth := 0
+	quote := rune(0)
+	for i, r := range text {
+		if quote != 0 {
+			if quote == '`' && r == '`' && isDoubledBacktick(text, i) {
+				continue
+			}
+			if r == quote && !isEscaped(text, i) {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"', '`':
+			quote = r
+			continue
+		case '(', '[', '{':
+			depth++
+			continue
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		for _, op := range ops {
+			if strings.HasPrefix(text[i:], op) {
+				return i, op
+			}
+		}
+	}
+	return -1, ""
 }
 
 func parseValue(value string) any {

--- a/internal/query/parser_predicate_test.go
+++ b/internal/query/parser_predicate_test.go
@@ -1,0 +1,38 @@
+package query
+
+import "testing"
+
+// TestParsePredicateQuoteAware guards the `where` operator scan against quoted
+// values that contain operator characters — previously `strings.Index` matched
+// the operator inside the quotes and produced a wrong predicate.
+func TestParsePredicateQuoteAware(t *testing.T) {
+	p, err := parsePredicate(`path = "a<=b>=c"`)
+	if err != nil {
+		t.Fatalf("parsePredicate: %v", err)
+	}
+	if p.Field != "path" || p.Op != "=" {
+		t.Fatalf("quoted value: got field=%q op=%q, want path / =", p.Field, p.Op)
+	}
+	if s, ok := p.Value.(string); !ok || s != "a<=b>=c" {
+		t.Fatalf("quoted value: got value=%#v, want \"a<=b>=c\"", p.Value)
+	}
+
+	// Normal predicates still resolve to the correct (longest-match) operator.
+	cases := []struct{ expr, field, op string }{
+		{`status = active`, "status", "="},
+		{`status != active`, "status", "!="},
+		{`count >= 5`, "count", ">="},
+		{`count <= 5`, "count", "<="},
+		{`a == b`, "a", "="}, // == normalizes to =
+		{`x ~ y`, "x", "~"},
+	}
+	for _, c := range cases {
+		got, err := parsePredicate(c.expr)
+		if err != nil {
+			t.Fatalf("parsePredicate(%q): %v", c.expr, err)
+		}
+		if got.Field != c.field || got.Op != c.op {
+			t.Fatalf("parsePredicate(%q): got field=%q op=%q, want %q / %q", c.expr, got.Field, got.Op, c.field, c.op)
+		}
+	}
+}


### PR DESCRIPTION
Two correctness fixes from a deep review of the read path and the agent surface.

## 1. `where` operator scan was not quote-aware
`parsePredicate` ([internal/query/parser.go](internal/query/parser.go)) located the comparison operator with `strings.Index`, which matches inside quoted strings. So `where path = "a<=b>=c"` was split on the `<=` *inside the value*, producing a silently wrong predicate (`field="path = \"a"`, `op="<="`, …).

Fix: a quote- and bracket-aware scan (`topLevelOperatorIndex`, modeled on the existing `topLevelIndex`) that finds the first operator outside any quote/bracket, longest-match first. Adds `TestParsePredicateQuoteAware`.

## 2. Agent `limit` / `timeout_ms` not validated
`agentgateway.queryRequest` ([internal/agentgateway/service.go](internal/agentgateway/service.go)) copied `limit`/`timeout_ms` straight into the `QueryRequest`; a negative value reached the Query Service. Fix: reject `< 0` with `INVALID_ARGUMENT`.

## Verification
`go build ./...`, `go vet`, `internal/query` + `internal/agentgateway` tests pass (incl. the new test).

> Deferred (flagged): the cross-workspace schema-resolver leak (`findIndexedElement` scans all workspaces) needs a `Workspace` field threaded through the public `UModelSchemaResolver` contract — a design change, not bundled here.
