### PR TITLE
fix(cypher): cap variable-length path depth to bound recursion

### DIFF
--- a/internal/cypher/engine.go
+++ b/internal/cypher/engine.go
@@ -531,28 +531,52 @@ func readRelTypes(text string) ([]string, string) {
 	}
 }
 
+// maxCypherPathDepth bounds variable-length relationship patterns (`*min..max`)
+// so a single query cannot drive unbounded path expansion / recursion. An
+// open-ended range (`*1..`) is clamped to this ceiling; an explicit bound that
+// exceeds it (or overflows int) is rejected.
+const maxCypherPathDepth = 16
+
 func readDepth(text string) (int, int, string, error) {
 	text = strings.TrimSpace(text)
-	readNumber := func(s string) (int, string) {
+	// readNumber returns the leading run of digits, whether any were present,
+	// and whether they overflowed int (strconv.Atoi clamps to MaxInt on a range
+	// error, so the discarded error previously hid an unbounded upper bound).
+	readNumber := func(s string) (n int, rest string, present, overflow bool) {
 		i := 0
 		for i < len(s) && s[i] >= '0' && s[i] <= '9' {
 			i++
 		}
 		if i == 0 {
-			return 0, s
+			return 0, s, false, false
 		}
-		n, _ := strconv.Atoi(s[:i])
-		return n, s[i:]
+		v, err := strconv.Atoi(s[:i])
+		if err != nil {
+			return 0, s[i:], true, true
+		}
+		return v, s[i:], true, false
 	}
-	min, rest := readNumber(text)
+	depthExceeded := func() error {
+		return apperrors.WithDetails(apperrors.CodeQueryParseError,
+			"cypher relationship depth exceeds the maximum",
+			map[string]string{"max_depth": strconv.Itoa(maxCypherPathDepth)})
+	}
+
+	min, rest, _, minOverflow := readNumber(text)
+	if minOverflow {
+		return 0, 0, "", depthExceeded()
+	}
 	max := min
 	if strings.HasPrefix(rest, "..") {
 		rest = rest[2:]
-		if parsed, next := readNumber(rest); parsed > 0 {
+		if parsed, next, present, overflow := readNumber(rest); overflow {
+			return 0, 0, "", depthExceeded()
+		} else if present && parsed > 0 {
 			max = parsed
 			rest = next
 		} else {
-			max = 10
+			// Open-ended range (`*1..`): bound to the maximum.
+			max = maxCypherPathDepth
 		}
 	}
 	if min == 0 {
@@ -563,6 +587,9 @@ func readDepth(text string) (int, int, string, error) {
 	}
 	if max < min {
 		return 0, 0, "", apperrors.New(apperrors.CodeQueryParseError, "cypher relationship depth is invalid")
+	}
+	if min > maxCypherPathDepth || max > maxCypherPathDepth {
+		return 0, 0, "", depthExceeded()
 	}
 	return min, max, rest, nil
 }

--- a/internal/cypher/engine.go
+++ b/internal/cypher/engine.go
@@ -567,11 +567,16 @@ func readDepth(text string) (int, int, string, error) {
 		return 0, 0, "", depthExceeded()
 	}
 	max := min
+	hasRange := false
 	if strings.HasPrefix(rest, "..") {
+		hasRange = true
 		rest = rest[2:]
 		if parsed, next, present, overflow := readNumber(rest); overflow {
 			return 0, 0, "", depthExceeded()
-		} else if present && parsed > 0 {
+		} else if present {
+			// Explicit upper bound, including 0. A zero (`*1..0`) is kept as-is so
+			// the max < min check below rejects it instead of silently widening it
+			// to the ceiling.
 			max = parsed
 			rest = next
 		} else {
@@ -582,7 +587,10 @@ func readDepth(text string) (int, int, string, error) {
 	if min == 0 {
 		min = 1
 	}
-	if max == 0 {
+	// Only default a missing upper bound from min. When a range was given, max is
+	// already determined (an explicit value, or the open-ended ceiling), so an
+	// explicit `..0` must not be normalized away here.
+	if max == 0 && !hasRange {
 		max = min
 	}
 	if max < min {

--- a/internal/cypher/engine_depth_test.go
+++ b/internal/cypher/engine_depth_test.go
@@ -1,0 +1,26 @@
+package cypher
+
+import "testing"
+
+// TestReadDepthCaps guards the variable-length path depth (`*min..max`) against
+// unbounded / overflowing bounds that previously bypassed the depth limit.
+func TestReadDepthCaps(t *testing.T) {
+	// Explicit in-range bounds pass unchanged.
+	if mn, mx, _, err := readDepth("1..3"); err != nil || mn != 1 || mx != 3 {
+		t.Fatalf(`readDepth("1..3") = %d..%d, err=%v; want 1..3`, mn, mx, err)
+	}
+	// An open-ended range is clamped to the ceiling, not rejected.
+	if mn, mx, _, err := readDepth("1.."); err != nil || mn != 1 || mx != maxCypherPathDepth {
+		t.Fatalf(`readDepth("1..") = %d..%d, err=%v; want 1..%d`, mn, mx, err, maxCypherPathDepth)
+	}
+	// A single bound at the ceiling passes; just above it is rejected.
+	if _, _, _, err := readDepth("16"); err != nil {
+		t.Fatalf(`readDepth("16") err=%v; want nil`, err)
+	}
+	// Explicit over-cap bounds and integer overflow are rejected.
+	for _, in := range []string{"17", "20..30", "1..100", "1..99999999999999999999999", "99999999999999999999999"} {
+		if _, _, _, err := readDepth(in); err == nil {
+			t.Fatalf("readDepth(%q) should reject an over-cap depth, got nil error", in)
+		}
+	}
+}

--- a/internal/cypher/engine_depth_test.go
+++ b/internal/cypher/engine_depth_test.go
@@ -24,3 +24,19 @@ func TestReadDepthCaps(t *testing.T) {
 		}
 	}
 }
+
+// TestReadDepthRejectsExplicitZeroUpperBound distinguishes an absent upper bound
+// (`*1..`, open-ended → clamp to the ceiling) from an explicit zero upper bound
+// (`*1..0`). An explicit zero is an empty/invalid range and must be rejected, not
+// silently widened to the ceiling.
+func TestReadDepthRejectsExplicitZeroUpperBound(t *testing.T) {
+	for _, in := range []string{"1..0", "2..0", "..0"} {
+		if mn, mx, _, err := readDepth(in); err == nil {
+			t.Errorf("readDepth(%q) should reject an explicit zero upper bound, got %d..%d nil", in, mn, mx)
+		}
+	}
+	// A bare "0" (single bound, no range) keeps its existing 1..1 normalization.
+	if mn, mx, _, err := readDepth("0"); err != nil || mn != 1 || mx != 1 {
+		t.Fatalf(`readDepth("0") = %d..%d, err=%v; want 1..1`, mn, mx, err)
+	}
+}


### PR DESCRIPTION
Caps the cypher variable-length path depth so a single query cannot drive unbounded recursion.

## Problem
`readDepth` ([internal/cypher/engine.go](internal/cypher/engine.go)) parsed `*min..max` with `strconv.Atoi` and **discarded the error**. `Atoi` clamps to `MaxInt` on a range error, so `*1..99999999999999999999999` yielded an effectively unbounded upper bound. The cypher path depth is also **not** covered by the planner's `MaxDepth` check, so nothing bounded the expansion — a confirmed runaway (12.5M paths on a 7-node graph at depth 6 in the review).

## Fix
Bound variable-length depth at `maxCypherPathDepth` (16):
- open-ended range (`*1..`) → clamped to the ceiling;
- explicit bound over the ceiling, or integer overflow → rejected with a clear `"depth exceeds the maximum"` error.

Adds `TestReadDepthCaps`. Existing usage (depth-1 `-[r]->` patterns in the samples/templates) is unaffected.

## Verification
`go build ./...`, `go vet`, and `internal/cypher` + `internal/graphstore` + `internal/query` tests pass (incl. the new test).

> Deferred (flagged): the related perf issue — var-length path products are materialized *before* `limit` is applied — needs the limit threaded into path expansion; it's a separate change, not bundled here.
