### PR TITLE
fix(query): enforce provider query timeout + run the test gate with -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ serve-ui: build-ui
 	go run $(GO_RUN_TAGS) ./cmd/umodel-server --addr "$(API_ADDR)" --data "$(DATA_ROOT)" --graphstore "$(GRAPHSTORE)" --ui-dir web/dist $(if $(filter 1 true TRUE yes YES on ON,$(QUICKSTART)),--quickstart --quickstart-workspace "$(QUICKSTART_WORKSPACE)" --quickstart-sample "$(QUICKSTART_SAMPLE)")
 
 test-service:
-	go test ./...
+	go test -race ./...
 
 test-ui:
 	@PNPM="$(PNPM)" bash ./scripts/env.sh web-build

--- a/internal/graphstore/memory.go
+++ b/internal/graphstore/memory.go
@@ -182,6 +182,9 @@ func (s *MemoryStore) WriteRelations(ctx context.Context, batch model.RelationWr
 }
 
 func (s *MemoryStore) QueryEntities(ctx context.Context, plan model.EntityQueryPlan) (model.QueryResult, error) {
+	if err := ctx.Err(); err != nil {
+		return model.QueryResult{}, err
+	}
 	limit := normalizeLimit(plan.Limit, 100)
 
 	s.mu.RLock()
@@ -195,6 +198,9 @@ func (s *MemoryStore) QueryEntities(ctx context.Context, plan model.EntityQueryP
 	sort.Strings(keys)
 
 	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return model.QueryResult{}, err
+		}
 		payload := s.entities[plan.Workspace][key]
 		if !entityMatches(payload, plan) {
 			continue
@@ -213,6 +219,9 @@ func (s *MemoryStore) QueryEntities(ctx context.Context, plan model.EntityQueryP
 }
 
 func (s *MemoryStore) QueryTopo(ctx context.Context, plan model.TopoQueryPlan) (model.QueryResult, error) {
+	if err := ctx.Err(); err != nil {
+		return model.QueryResult{}, err
+	}
 	limit := normalizeLimit(plan.Limit, 100)
 
 	s.mu.RLock()
@@ -230,6 +239,9 @@ func (s *MemoryStore) QueryTopo(ctx context.Context, plan model.TopoQueryPlan) (
 	sort.Strings(keys)
 
 	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return model.QueryResult{}, err
+		}
 		payload := s.relations[plan.Workspace][key]
 		if !relationMatches(payload, plan) {
 			continue

--- a/internal/graphstore/memory_test.go
+++ b/internal/graphstore/memory_test.go
@@ -249,3 +249,18 @@ func TestMemoryStoreMaxLimitNotBelowDefaultProvider(t *testing.T) {
 		t.Fatalf("memory MaxLimit = %d, want >= 1000 so production-valid limits stay portable", caps.MaxLimit)
 	}
 }
+
+// TestQueryRespectsContextCancellation verifies the memory store honors a
+// cancelled context and aborts instead of scanning — the store-side half of the
+// query-timeout contract (the Service sets the deadline; the store respects it).
+func TestQueryRespectsContextCancellation(t *testing.T) {
+	store := NewMemoryStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := store.QueryEntities(ctx, model.EntityQueryPlan{Workspace: "demo"}); err != context.Canceled {
+		t.Fatalf("QueryEntities with cancelled ctx: got %v, want context.Canceled", err)
+	}
+	if _, err := store.QueryTopo(ctx, model.TopoQueryPlan{Workspace: "demo"}); err != context.Canceled {
+		t.Fatalf("QueryTopo with cancelled ctx: got %v, want context.Canceled", err)
+	}
+}

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -149,14 +149,17 @@ func parseQueryTimeout(s string) time.Duration {
 	return d
 }
 
-// asQueryTimeout maps a context deadline/cancellation into a CodeTimeout error so
-// callers get a stable, machine-actionable timeout signal; other errors pass
-// through unchanged.
+// asQueryTimeout maps a query that exceeded the provider's deadline to a stable,
+// machine-actionable CodeTimeout. Only deadline expiry counts: a cancelled
+// context (client disconnect, parent cancellation) is not a provider timeout and
+// must not be reported as one — that would be misleading and, since CodeTimeout
+// is retryable, would wrongly mark a cancelled request as retryable. Cancellation
+// and all other errors pass through unchanged.
 func asQueryTimeout(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) || ctx.Err() != nil {
+	if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 		return apperrors.New(apperrors.CodeTimeout, "query exceeded the provider time limit")
 	}
 	return err

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -2,6 +2,8 @@ package query
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
 	"github.com/alibaba/UnifiedModel/pkg/model"
@@ -104,10 +106,19 @@ func (s *Service) Execute(ctx context.Context, workspace string, req model.Query
 		return model.QueryResult{}, err
 	}
 
+	// Bound execution by the active provider's declared timeout. The deadline is
+	// set here; the stores honor ctx and abort in-flight scans, and ctx errors
+	// are mapped to CodeTimeout below.
+	if d := parseQueryTimeout(caps.Timeout); d > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d)
+		defer cancel()
+	}
+
 	if shouldRouteToSearch(plan) {
 		searchRes, mode, err := dispatchSearch(ctx, s.search, workspace, plan)
 		if err != nil {
-			return model.QueryResult{}, err
+			return model.QueryResult{}, asQueryTimeout(ctx, err)
 		}
 		result := searchResultToQueryResult(searchRes, plan.Source, plan.Limit)
 		explain := buildExplain(plan, caps, health)
@@ -118,11 +129,37 @@ func (s *Service) Execute(ctx context.Context, workspace string, req model.Query
 
 	result, err := s.executor.Execute(ctx, workspace, plan)
 	if err != nil {
-		return model.QueryResult{}, err
+		return model.QueryResult{}, asQueryTimeout(ctx, err)
 	}
 	explain := buildExplain(plan, caps, health)
 	result.Explain = &explain
 	return result, nil
+}
+
+// parseQueryTimeout parses a provider's declared timeout (e.g. "10s"). Empty or
+// non-positive values disable the deadline.
+func parseQueryTimeout(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// asQueryTimeout maps a context deadline/cancellation into a CodeTimeout error so
+// callers get a stable, machine-actionable timeout signal; other errors pass
+// through unchanged.
+func asQueryTimeout(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) || ctx.Err() != nil {
+		return apperrors.New(apperrors.CodeTimeout, "query exceeded the provider time limit")
+	}
+	return err
 }
 
 func (s *Service) Explain(ctx context.Context, workspace string, req model.QueryRequest) (model.QueryExplain, error) {

--- a/internal/query/timeout_test.go
+++ b/internal/query/timeout_test.go
@@ -38,22 +38,43 @@ func TestAsQueryTimeout(t *testing.T) {
 	if got := asQueryTimeout(bg, other); got != other {
 		t.Fatalf("non-ctx error should pass through unchanged, got %v", got)
 	}
-	for _, e := range []error{context.DeadlineExceeded, context.Canceled} {
-		if got := asQueryTimeout(bg, e); !apperrors.IsCode(got, apperrors.CodeTimeout) {
-			t.Fatalf("asQueryTimeout(%v) should be CodeTimeout, got %v", e, got)
-		}
+	// Deadline expiry is a provider timeout.
+	if got := asQueryTimeout(bg, context.DeadlineExceeded); !apperrors.IsCode(got, apperrors.CodeTimeout) {
+		t.Fatalf("DeadlineExceeded should map to CodeTimeout, got %v", got)
+	}
+	// Cancellation is NOT a timeout: it must pass through unchanged so a
+	// client disconnect / parent cancellation is not reported as a (retryable)
+	// provider timeout.
+	if got := asQueryTimeout(bg, context.Canceled); got != context.Canceled {
+		t.Fatalf("context.Canceled should pass through unchanged, got %v", got)
 	}
 }
 
-// TestExecuteCancelledContextReturnsTimeout proves the end-to-end wiring: a
-// cancelled context flows through Execute -> executor -> memory store, the store
+// TestExecuteDeadlineExceededReturnsTimeout proves the end-to-end wiring: an
+// expired deadline flows through Execute -> executor -> memory store, the store
 // aborts, and the ctx error is mapped to CodeTimeout.
-func TestExecuteCancelledContextReturnsTimeout(t *testing.T) {
+func TestExecuteDeadlineExceededReturnsTimeout(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity with(domain='devops', name='devops.service')"})
+	if !apperrors.IsCode(err, apperrors.CodeTimeout) {
+		t.Fatalf("Execute with expired deadline: got %v, want CodeTimeout", err)
+	}
+}
+
+// TestExecuteCancelledContextIsNotTimeout guards against misreporting: a cancelled
+// request must surface an error, but NOT CodeTimeout — it is not a provider
+// timeout and must not look retryable.
+func TestExecuteCancelledContextIsNotTimeout(t *testing.T) {
 	svc := NewService(graphstore.NewMemoryStore())
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity with(domain='devops', name='devops.service')"})
-	if !apperrors.IsCode(err, apperrors.CodeTimeout) {
-		t.Fatalf("Execute with cancelled ctx: got %v, want CodeTimeout", err)
+	if err == nil {
+		t.Fatal("Execute with cancelled ctx should return an error")
+	}
+	if apperrors.IsCode(err, apperrors.CodeTimeout) {
+		t.Fatalf("cancelled ctx must not map to CodeTimeout, got %v", err)
 	}
 }

--- a/internal/query/timeout_test.go
+++ b/internal/query/timeout_test.go
@@ -1,0 +1,59 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+	apperrors "github.com/alibaba/UnifiedModel/pkg/errors"
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+func TestParseQueryTimeout(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"bogus", 0},
+		{"0s", 0},
+		{"-5s", 0},
+		{"10s", 10 * time.Second},
+		{"1m", time.Minute},
+	}
+	for _, c := range cases {
+		if got := parseQueryTimeout(c.in); got != c.want {
+			t.Errorf("parseQueryTimeout(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAsQueryTimeout(t *testing.T) {
+	bg := context.Background()
+	if asQueryTimeout(bg, nil) != nil {
+		t.Fatal("nil error should pass through as nil")
+	}
+	other := apperrors.New(apperrors.CodeInvalidArgument, "bad")
+	if got := asQueryTimeout(bg, other); got != other {
+		t.Fatalf("non-ctx error should pass through unchanged, got %v", got)
+	}
+	for _, e := range []error{context.DeadlineExceeded, context.Canceled} {
+		if got := asQueryTimeout(bg, e); !apperrors.IsCode(got, apperrors.CodeTimeout) {
+			t.Fatalf("asQueryTimeout(%v) should be CodeTimeout, got %v", e, got)
+		}
+	}
+}
+
+// TestExecuteCancelledContextReturnsTimeout proves the end-to-end wiring: a
+// cancelled context flows through Execute -> executor -> memory store, the store
+// aborts, and the ctx error is mapped to CodeTimeout.
+func TestExecuteCancelledContextReturnsTimeout(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := svc.Execute(ctx, "demo", model.QueryRequest{Query: ".entity with(domain='devops', name='devops.service')"})
+	if !apperrors.IsCode(err, apperrors.CodeTimeout) {
+		t.Fatalf("Execute with cancelled ctx: got %v, want CodeTimeout", err)
+	}
+}


### PR DESCRIPTION
The query path declared a per-provider `Timeout` capability but never applied it, so a slow or hung provider call could block the request indefinitely.

- `Service.Execute` wraps `ctx` with the provider's declared timeout and maps `DeadlineExceeded` / `Canceled` to `CodeTimeout`.
- The memory store checks `ctx` on entry and inside its scan loops, so the deadline is actually observed rather than ignored.
- `make test-service` now runs with `-race`.

Cancellation is cooperative — it interrupts providers that observe `ctx` (the memory store now does); a provider that blocks ignoring `ctx` would still need its own handling.

**Verification:** full `go test -race ./...` green, 0 data races; new tests cover the timeout mapping and the ctx-cancellation path.
