### PR TITLE
ci: supply-chain hardening — Dependabot, govulncheck, fuzz targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependency update automation. Grouped + weekly to keep PR volume low.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      go-modules:
+        patterns: ["*"]
+  - package-ecosystem: gomod
+    directory: "/sdk/go"
+    schedule:
+      interval: weekly
+    groups:
+      go-sdk:
+        patterns: ["*"]
+  - package-ecosystem: pip
+    directory: "/tools"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+    groups:
+      web:
+        patterns: ["*"]
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: weekly
+    groups:
+      docs:
+        patterns: ["*"]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,13 @@ jobs:
       - name: Run CI
         run: make ci
 
+      # Vulnerability scan. Non-blocking for now: most findings are Go std-lib
+      # CVEs that track the toolchain version (cleared by bumping Go), not the
+      # repo's own deps. Drop continue-on-error once findings are triaged.
+      - name: Vulnerability scan (govulncheck)
+        run: make vulncheck
+        continue-on-error: true
+
       - name: Run Playwright UI tests
         run: |
           make quickstart &

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help check-env install-env setup setup-ui expand doc docs-schema docs-schema-check example-validate check-manifest
-.PHONY: build build-service build-cli install-cli build-ui build-sdk-go dev quickstart dev-api dev-web deploy serve-ui status stop-all stop-dev stop-deploy test test-service test-ui test-ui-e2e test-capability test-quickstart-health test-ladybug verify verify-go verify-python verify-java guard ci clean
+.PHONY: build build-service build-cli install-cli build-ui build-sdk-go dev quickstart dev-api dev-web deploy serve-ui status stop-all stop-dev stop-deploy test test-service test-ui test-ui-e2e test-capability test-quickstart-health test-ladybug vulncheck verify verify-go verify-python verify-java guard ci clean
 
 VENV_PYTHON := .venv/bin/python
 CONDA_PYTHON := $(if $(CONDA_PREFIX),$(CONDA_PREFIX)/bin/python)
@@ -134,6 +134,11 @@ serve-ui: build-ui
 
 test-service:
 	go test ./...
+
+# Scan for known vulnerabilities (the repo's modules + reachable stdlib). Std-lib
+# findings track the Go toolchain version; keep it current to clear them.
+vulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
 test-ui:
 	@PNPM="$(PNPM)" bash ./scripts/env.sh web-build

--- a/internal/query/fuzz_test.go
+++ b/internal/query/fuzz_test.go
@@ -1,0 +1,36 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/pkg/model"
+)
+
+// FuzzParse hardens the SPL parser, an untrusted-input surface. The invariant is
+// simple but important: Parse must never panic on arbitrary input — it may
+// return an error, but it must not crash the server. The seed corpus runs on
+// every `go test`; `go test -fuzz=FuzzParse` explores further.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		"",
+		".entity with(domain='devops', name='devops.service')",
+		".entity with(domain='a', name='b', query='x', topk=5, mode='vector')",
+		".umodel with(kind='entity_set') | project domain,name | sort domain | limit 10",
+		".entity_set with(domain='d', name='n', ids=['1']) | entity-call get_metrics('d','m','x', step='30s')",
+		".topo | graph-call getNeighborNodes('full', 2, [(:\"d@n\" {__entity_id__: '1'})]) | limit 5",
+		".topo | graph-call cypher(`MATCH (n) RETURN n LIMIT 1`)",
+		"not a query",
+		".entity with(",
+		".entity with(domain='x'",
+		".topo | graph-call getNeighborNodes(",
+		"| | |",
+		".entity with(domain='a', name='b') | project | sort | limit",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, query string) {
+		// Must not panic. An error return is acceptable.
+		_, _ = Parse(model.QueryRequest{Query: query})
+	})
+}

--- a/internal/umodel/fuzz_test.go
+++ b/internal/umodel/fuzz_test.go
@@ -1,0 +1,54 @@
+package umodel
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
+)
+
+// FuzzConfineImportPath hardens the import-path confinement, the boundary that
+// stops an API caller from reading arbitrary server files. The security
+// invariant: if confineImportPath accepts a path (no error), the returned path
+// must stay inside the import root. The fuzzer hunts for adversarial inputs
+// (traversal, odd separators, NUL bytes) that get accepted yet escape.
+func FuzzConfineImportPath(f *testing.F) {
+	const root = "/srv/umodel/import-root"
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot(root))
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		f.Fatalf("abs root: %v", err)
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	seeds := []string{
+		root + "/pack",
+		root + "/a/b/c",
+		"pack",
+		"a/b",
+		"../etc/passwd",
+		"/etc/passwd",
+		"",
+		".",
+		"..",
+		root + "/../escape",
+		root + "/a/../../escape",
+		"\x00",
+		root + "/\x00pack",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, p string) {
+		out, err := svc.confineImportPath(p)
+		if err != nil {
+			return // rejected — safe
+		}
+		rel, relErr := filepath.Rel(rootAbs, out)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("confineImportPath(%q) was accepted but escapes the root: out=%q rel=%q", p, out, rel)
+		}
+	})
+}


### PR DESCRIPTION
Three input/dependency-robustness layers, without changing the CI gate's pass/fail contract.

- **Dependabot:** weekly, grouped updates for gomod (root + `sdk/go`), pip (`tools`), npm (`web` + `docs`), and github-actions. Grouped to keep PR volume low; security alerts are independent of this config, so grouping version updates does not delay security fixes.
- **govulncheck:** a `make vulncheck` target plus a **non-blocking** CI step. Most current findings are Go std-lib CVEs that track the toolchain version (cleared by bumping Go), not the repo's own deps; the step comment notes to drop `continue-on-error` once findings are triaged.
- **Fuzz targets** on two untrusted-input surfaces: the SPL parser (`FuzzParse`) and the import-path confinement (`FuzzConfineImportPath`). Seed corpora run on every `go test`, doubling as fast regression tests.

**Verification:** 2M+ fuzz executions per target with no panic or path escape; full suite green.
