### PR TITLE
docs: correct incident-investigation sample counts (+ tidy import comment)

### DIFF
--- a/examples/incident-investigation/README.md
+++ b/examples/incident-investigation/README.md
@@ -293,8 +293,8 @@ See the [MCP Reference](../../docs/en/reference/mcp.md) for transports (stdio, S
 | Storage | `platform/storage/` | 2 | Prometheus (metrics) and Elasticsearch (logs) endpoints |
 | Data links | `platform/link/data_link/` | 2 | Connect platform.service to its metric/log sets |
 | Storage links | `platform/link/storage_link/` | 2 | Connect metric/log sets to their storage |
-| Sample entities | `sample-data/entities.json` | 65 | Runtime entity payloads |
-| Sample relations | `sample-data/relations.json` | 83 | Runtime topology payloads |
+| Sample entities | `sample-data/entities.json` | 95 | All entity instances (platform/runtime/business) |
+| Sample relations | `sample-data/relations.json` | 126 | All topology relations (platform/runtime/business) |
 | Manifest | `sample-data/manifest.json` | — | Sample metadata, seed entities, scenario description |
 
 ## Extending This Demo

--- a/examples/incident-investigation/README.zh-CN.md
+++ b/examples/incident-investigation/README.zh-CN.md
@@ -293,8 +293,8 @@ go run ./cmd/umodel-mcp --quickstart \
 | 存储 | `platform/storage/` | 2 | Prometheus（指标）和 Elasticsearch（日志）端点 |
 | 数据链接 | `platform/link/data_link/` | 2 | 将 platform.service 连接到其指标/日志集 |
 | 存储链接 | `platform/link/storage_link/` | 2 | 将指标/日志集连接到对应存储 |
-| 运行时实体 | `sample-data/entities.json` | 65 | 实体数据 |
-| 运行时关系 | `sample-data/relations.json` | 83 | 拓扑数据 |
+| 样例实体 | `sample-data/entities.json` | 95 | 三个域的全部实体实例（platform/runtime/business） |
+| 样例关系 | `sample-data/relations.json` | 126 | 三个域的全部拓扑关系（platform/runtime/business） |
 | 清单 | `sample-data/manifest.json` | — | 样例元数据、种子实体、场景描述 |
 
 ## 扩展此 Demo

--- a/internal/umodel/import.go
+++ b/internal/umodel/import.go
@@ -103,10 +103,6 @@ func (s *Service) importInternal(ctx context.Context, workspace string, req mode
 	return result, nil
 }
 
-// confineImportPath resolves p and verifies it stays within the import root,
-// returning the cleaned absolute path. The root defaults to the current
-// working directory; "/" effectively disables confinement. This is the
-// barrier that stops an API-provided path from escaping to arbitrary files.
 // resolvedImportRoot returns the absolute, symlink-resolved import root. The root
 // defaults to the current working directory; "/" effectively disables
 // confinement.
@@ -131,6 +127,9 @@ func (s *Service) resolvedImportRoot() (string, error) {
 	return rootAbs, nil
 }
 
+// confineImportPath resolves p and verifies it stays within the import root,
+// returning the cleaned absolute path. This is the barrier that stops an
+// API-provided path from escaping to arbitrary files.
 func (s *Service) confineImportPath(p string) (string, error) {
 	rootAbs, err := s.resolvedImportRoot()
 	if err != nil {


### PR DESCRIPTION
Two small post-merge cleanups, both verified against the data / build:

- **incident-investigation README counts:** the Contents table listed `sample-data/entities.json` as 65 and `sample-data/relations.json` as 83, but the files — and `manifest.json` and the Quick Start summary on the same page — hold **95** and **126**. Corrected in both `README.md` and `README.zh-CN.md`, and relabeled those rows (the files span all three domains, not just runtime).
- **import.go doc comment:** extracting `resolvedImportRoot` (in #62) left `confineImportPath`'s doc comment stranded above it; moved it back to `confineImportPath`. Comment-only, no behavior change.

Verification: `go vet ./internal/umodel` clean; the corrected counts match `sample-data/manifest.json` (`entities=95, relations=126`).
