### PR TITLE
fix(graphstore): default to file.memory for OSS entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The project follows a simple changelog structure until stable releases are publi
 - **`umodel-query` skill rebuilt around plan→execute** with progressive-disclosure `references/` (#51); the multi-domain quickstart walkthrough was rewritten (#52).
 - Quickstart sample pack reorganized into `umodel/` (schema) and `deploy/` (demo stack); the pack's storage endpoints point at `localhost` so the demo's plans run as returned.
 - Removed CMS 2.0 references from the front-page READMEs.
+- **OSS default GraphStore provider changed to `file.memory`** (was `local.ladybug`) when `umodel-server`, `umodel-mcp`, or `bootstrap.NewApp` are used without an explicit provider. `make dev` and deployment assets were already on `file.memory`; `local.ladybug` remains available as an explicit `--graphstore local.ladybug` option when built with `-tags ladybug`. `make quickstart` still defaults to `memory`.
 
 ### Fixed
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -25,6 +25,7 @@ English version: [CHANGELOG.md](CHANGELOG.md)
 - **`umodel-query` skill 按 plan→execute 重写**，配渐进式披露 `references/`（#51）；多 domain quickstart 走查重写（#52）。
 - quickstart 样例包重构为 `umodel/`（schema）与 `deploy/`（demo 栈）；pack 的 storage endpoint 指向 `localhost`，demo 的 plan 按返回内容直接执行。
 - 首页 README 移除 CMS 2.0 引用。
+- **OSS 默认 GraphStore provider 改为 `file.memory`**（原 `local.ladybug`）。当 `umodel-server`、`umodel-mcp` 或 `bootstrap.NewApp` 未显式指定 provider 时，默认使用 `file.memory`；`make dev` 和部署资产此前已使用 `file.memory`。`local.ladybug` 仍可通过 `--graphstore local.ladybug` 显式指定（需 `-tags ladybug`）。`make quickstart` 仍默认使用 `memory`。
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ Generated Go and Python model SDKs live under `sdk/`. The Java SDK currently rem
 
 ## GraphStore Providers
 
-Runtime GraphStore providers are selected with `--graphstore`.
+Runtime GraphStore providers are selected with `--graphstore`. When omitted, Go entry binaries default to `file.memory`.
 
 | Provider | Typical use |
 |---|---|
 | `memory` | Ephemeral local tests and quickstart demos. Data is lost after process exit. |
-| `file.memory` | JSON persistence under `--data`. Default for `make dev`, Docker, and Compose. |
+| `file.memory` | JSON persistence under `--data`. Default for Go entry binaries, `make dev`, Docker, and Compose. |
 | `local.ladybug` | Ladybug-backed environments. Requires `-tags ladybug` and a local Ladybug runtime. |
 
 Provider details: [GraphStore Providers](docs/en/graphstore-providers.md).

--- a/README_CN.md
+++ b/README_CN.md
@@ -157,12 +157,12 @@ make ci
 
 ## GraphStore Providers
 
-运行时 GraphStore provider 通过 `--graphstore` 选择。
+运行时 GraphStore provider 通过 `--graphstore` 选择。省略时，Go 入口二进制文件默认使用 `file.memory`。
 
 | Provider | 典型用途 |
 |---|---|
 | `memory` | 临时本地测试和 quickstart demo。进程退出后数据丢失。 |
-| `file.memory` | `--data` 下的 JSON 持久化。这是 `make dev`、Docker 和 Compose 的默认值。 |
+| `file.memory` | `--data` 下的 JSON 持久化。这是 Go 入口二进制文件、`make dev`、Docker 和 Compose 的默认值。 |
 | `local.ladybug` | Ladybug-backed 环境。需要 `-tags ladybug` 和本地 Ladybug runtime。 |
 
 Provider 细节：[GraphStore Providers](docs/zh/graphstore-providers.md)。

--- a/cmd/README.en.md
+++ b/cmd/README.en.md
@@ -12,12 +12,12 @@ Entry Layer: process entry points.
 
 ## GraphStore Provider Flag
 
-`umodel-server` and `umodel-mcp` both support `--graphstore`:
+`umodel-server` and `umodel-mcp` both support `--graphstore`. The default is `file.memory`.
 
 | Provider | Description |
 |---|---|
+| `file.memory` | Default provider with in-memory querying plus JSON file persistence under `<--data>/graphstore/file-memory/`. |
 | `memory` | In-memory provider for fast local verification; data is lost on process exit. |
-| `file.memory` | In-memory querying plus JSON file persistence under `<--data>/graphstore/file-memory/`. |
 | `local.ladybug` | Ladybug-backed provider; requires `-tags ladybug` and a local Ladybug runtime. |
 
 Examples:

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -10,19 +10,19 @@ Entry Layer — 二进制入口点。
 
 ## GraphStore Provider 参数
 
-`umodel-server` 和 `umodel-mcp` 都支持 `--graphstore`：
+`umodel-server` 和 `umodel-mcp` 都支持 `--graphstore`。省略时默认使用 `file.memory`。
 
 | Provider | 说明 |
 |---|---|
+| `file.memory` | 默认 provider，内存查询 + JSON 文件持久化，按 workspace 和数据类型保存到 `<--data>/graphstore/file-memory/`；通过纯 Go 引擎支持 Ladybug 兼容只读 Cypher。 |
 | `memory` | 纯内存，适合本地快速验证，进程退出后数据丢失；通过纯 Go 引擎支持 Ladybug 兼容只读 Cypher。 |
-| `file.memory` | 内存查询 + JSON 文件持久化，默认按 workspace 和数据类型保存到 `<--data>/graphstore/file-memory/`；通过纯 Go 引擎支持 Ladybug 兼容只读 Cypher。 |
-| `local.ladybug` | Ladybug-backed provider；开启 graph-match 和 Cypher 透传，真实实现需要 `-tags ladybug` 和本地 Ladybug 运行时。 |
+| `local.ladybug` | Ladybug-backed provider；开启 graph-match 和 Cypher 透传，需要 `-tags ladybug` 和本地 Ladybug 运行时。 |
 
 示例：
 
 ```bash
-go run -tags ladybug ./cmd/umodel-server --addr :8080 --data data --graphstore local.ladybug
-go run -tags ladybug ./cmd/umodel-mcp --data data --graphstore local.ladybug
+go run ./cmd/umodel-server --addr :8080 --data data --graphstore file.memory
+go run ./cmd/umodel-mcp --data data --graphstore file.memory
 ```
 
 更多语义见 [GraphStore Providers](../docs/zh/graphstore-providers.md)。

--- a/cmd/umodel-mcp/main.go
+++ b/cmd/umodel-mcp/main.go
@@ -26,7 +26,7 @@ func run(args []string, in io.Reader, out, errOut io.Writer) error {
 	flags.SetOutput(errOut)
 	workspace := flags.String("workspace", "demo", "default workspace for MCP requests")
 	dataRoot := flags.String("data", ".umodel-data", "local UModel data root")
-	provider := flags.String("graphstore", graphstore.DefaultProviderType, "GraphStore provider: local.ladybug, memory, or file.memory")
+	provider := flags.String("graphstore", graphstore.DefaultProviderType, "GraphStore provider: file.memory, memory, or local.ladybug")
 	quickStart := flags.Bool("quickstart", false, "Create a demo workspace and import bundled quickstart data before serving MCP")
 	quickStartWorkspace := flags.String("quickstart-workspace", bootstrap.DefaultQuickStartWorkspaceID, "Workspace id used by --quickstart")
 	quickStartSample := flags.String("quickstart-sample", bootstrap.DefaultQuickStartSample, "Sample package imported by --quickstart")

--- a/cmd/umodel-server/main.go
+++ b/cmd/umodel-server/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	addr := flag.String("addr", ":8080", "HTTP listen address")
 	dataRoot := flag.String("data", "data", "UModel data root")
-	provider := flag.String("graphstore", graphstore.DefaultProviderType, "GraphStore provider: local.ladybug, memory, or file.memory")
+	provider := flag.String("graphstore", graphstore.DefaultProviderType, "GraphStore provider: file.memory, memory, or local.ladybug")
 	uiDir := flag.String("ui-dir", "", "Optional directory containing built UModel web UI assets")
 	quickStart := flag.Bool("quickstart", false, "Create a demo workspace and import bundled quickstart data before serving")
 	quickStartWorkspace := flag.String("quickstart-workspace", bootstrap.DefaultQuickStartWorkspaceID, "Workspace id used by --quickstart")

--- a/docs/en/concepts/storage-and-graphstore.md
+++ b/docs/en/concepts/storage-and-graphstore.md
@@ -39,7 +39,7 @@ GraphStore providers are runtime implementations behind the local UModel service
 | Provider | Role |
 |---|---|
 | `memory` | Fast in-memory provider for tests and disposable local work. |
-| `file.memory` | JSON-backed local provider; default for `make dev`, Docker, and Compose. |
+| `file.memory` | JSON-backed local provider; default for Go entry binaries, `make dev`, Docker, and Compose. |
 | `local.ladybug` | Ladybug-backed provider when built with `-tags ladybug`. |
 
 Start the service with a specific provider:

--- a/docs/en/graphstore-providers.md
+++ b/docs/en/graphstore-providers.md
@@ -2,7 +2,7 @@
 
 中文：[GraphStore Providers](../zh/graphstore-providers.md)
 
-UModel stores UModel elements, CMS 2.0 entities, and topology relations behind the `GraphStore` interface. Go entry binaries default to `local.ladybug` when `--graphstore` is omitted; select another provider with `--graphstore` on `umodel-server` or `umodel-mcp`.
+UModel stores UModel elements, CMS 2.0 entities, and topology relations behind the `GraphStore` interface. Go entry binaries default to `file.memory` when `--graphstore` is omitted; `memory` (process-only) and `local.ladybug` (Ladybug-backed) are also available via `--graphstore` on `umodel-server` or `umodel-mcp`.
 
 ```bash
 go run ./cmd/umodel-server --addr :8080 --data data --graphstore file.memory

--- a/docs/zh/concepts/storage-and-graphstore.md
+++ b/docs/zh/concepts/storage-and-graphstore.md
@@ -37,7 +37,7 @@ GraphStore provider 是本地 UModel 服务背后的运行时实现。
 | Provider | 角色 |
 |---|---|
 | `memory` | 面向测试和一次性本地工作的内存 provider。 |
-| `file.memory` | JSON-backed 本地 provider，是 `make dev`、Docker、Compose 的默认选择。 |
+| `file.memory` | JSON-backed 本地 provider，是 Go 入口二进制文件、`make dev`、Docker、Compose 的默认选择。 |
 | `local.ladybug` | 使用 `-tags ladybug` 构建时的 Ladybug-backed provider。 |
 
 启动示例：

--- a/docs/zh/graphstore-providers.md
+++ b/docs/zh/graphstore-providers.md
@@ -2,7 +2,7 @@
 
 English: [GraphStore Providers](../en/graphstore-providers.md)
 
-UModel 通过 `GraphStore` 接口保存和查询 UModel elements、CMS 2.0 实体以及拓扑关系。运行时通过 `--graphstore` 选择 provider。
+UModel 通过 `GraphStore` 接口保存和查询 UModel elements、CMS 2.0 实体以及拓扑关系。Go 入口二进制文件省略 `--graphstore` 时默认使用 `file.memory`；也可通过 `--graphstore` 在 `umodel-server` 或 `umodel-mcp` 上选择 `memory`（纯进程内存）或 `local.ladybug`（Ladybug-backed）。
 
 
 ## Providers

--- a/internal/graphstore/memory.go
+++ b/internal/graphstore/memory.go
@@ -295,7 +295,7 @@ func (s *MemoryStore) Capabilities(ctx context.Context) (model.GraphStoreCapabil
 		ServerSideFilter:   false,
 		MaxDepth:           2,
 		// Memory backs --quickstart / MCP / demos and has no storage backend, so
-		// it serves a generous row ceiling. Kept >= the default local.ladybug
+		// it serves a generous row ceiling. Kept >= the default file.memory
 		// provider's 1000 so any production-valid `limit` is also valid here.
 		MaxLimit: 10000,
 		Timeout:  "10s",

--- a/internal/graphstore/memory_test.go
+++ b/internal/graphstore/memory_test.go
@@ -237,7 +237,7 @@ func relationPayload(src, dest, method string, first, last int64, fields map[str
 
 // TestMemoryStoreMaxLimitNotBelowDefaultProvider guards query portability: the
 // memory store backs --quickstart / MCP / the demos, so a `limit` valid on the
-// default local.ladybug provider (MaxLimit 1000) must not be rejected here.
+// default file.memory provider (MaxLimit 1000) must not be rejected here.
 // Memory itself caps higher (10000, in-memory headroom). Regression for
 // "query limit exceeds provider capability" when memory advertised MaxLimit 100.
 func TestMemoryStoreMaxLimitNotBelowDefaultProvider(t *testing.T) {

--- a/internal/graphstore/provider.go
+++ b/internal/graphstore/provider.go
@@ -11,7 +11,7 @@ const (
 	ProviderTypeMemory     = "memory"
 	ProviderTypeFileMemory = "file.memory"
 	ProviderTypeLadybug    = "local.ladybug"
-	DefaultProviderType    = ProviderTypeLadybug
+	DefaultProviderType    = ProviderTypeFileMemory
 )
 
 type ProviderConfig struct {

--- a/tests/contract/graphstore_contract_test.go
+++ b/tests/contract/graphstore_contract_test.go
@@ -27,14 +27,14 @@ func TestFileMemoryGraphStoreConformance(t *testing.T) {
 	exerciseGraphStore(t, store)
 }
 
-func TestDefaultAppUsesLadybugProvider(t *testing.T) {
+func TestDefaultAppUsesFileMemoryProvider(t *testing.T) {
 	app := bootstrap.NewApp(t.TempDir())
 	health, err := app.GraphStore.Health(context.Background())
 	if err != nil {
 		t.Fatalf("default provider health: %v", err)
 	}
-	if health.Provider != graphstore.ProviderTypeLadybug {
-		t.Fatalf("default provider should be local.ladybug, got %+v", health)
+	if health.Provider != graphstore.ProviderTypeFileMemory {
+		t.Fatalf("default provider should be file.memory, got %+v", health)
 	}
 }
 

--- a/tests/e2e/ladybug_optional_test.go
+++ b/tests/e2e/ladybug_optional_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/alibaba/UnifiedModel/internal/bootstrap"
+	"github.com/alibaba/UnifiedModel/internal/graphstore"
 )
 
 func TestLadybugOptionalBusinessFlowPersistsAcrossRestart(t *testing.T) {
@@ -16,7 +17,10 @@ func TestLadybugOptionalBusinessFlowPersistsAcrossRestart(t *testing.T) {
 	}
 
 	dataRoot := t.TempDir()
-	app := bootstrap.NewApp(dataRoot)
+	app, err := bootstrap.NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeLadybug, DataRoot: dataRoot})
+	if err != nil {
+		t.Fatalf("new ladybug app: %v", err)
+	}
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -43,7 +47,10 @@ func TestLadybugOptionalBusinessFlowPersistsAcrossRestart(t *testing.T) {
 	}
 	server.Close()
 
-	reopened := bootstrap.NewApp(dataRoot)
+	reopened, err := bootstrap.NewAppWithGraphStore(dataRoot, graphstore.ProviderConfig{Type: graphstore.ProviderTypeLadybug, DataRoot: dataRoot})
+	if err != nil {
+		t.Fatalf("reopen ladybug app: %v", err)
+	}
 	reopenedServer := httptest.NewServer(reopened.Handler())
 	defer reopenedServer.Close()
 	defer func() {


### PR DESCRIPTION
## Summary

This changes the default GraphStore provider for OSS entrypoints from `local.ladybug` to `file.memory`.

When `umodel-server`, `umodel-mcp`, or `bootstrap.NewApp` are used without an explicit provider, they now use the JSON-backed local provider. This keeps the default path runnable without Ladybug build tags or a local Ladybug runtime.

`local.ladybug` is still available when explicitly selected with `--graphstore local.ladybug`.

## Notes

- `make quickstart` still defaults to `memory`.
- `make dev` and deployment assets were already using `file.memory`.
- Ladybug optional tests now request `local.ladybug` explicitly.

## Validation

- `git diff --check`
- `GOPROXY=https://goproxy.cn,direct go test ./tests/contract ./cmd/umodel-server ./cmd/umodel-mcp ./internal/bootstrap`