### PR TITLE
fix: reject unsupported model envelope versions

### DIFF
--- a/internal/umodel/import_test.go
+++ b/internal/umodel/import_test.go
@@ -38,6 +38,29 @@ func TestValidateAcceptsValidUModelElements(t *testing.T) {
 	}
 }
 
+func TestValidateReportsUnsupportedEnvelopeVersionOnVersionField(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
+	result, err := svc.Validate(context.Background(), "demo", []model.UModelElement{{
+		Kind:    "entity_set",
+		Domain:  "devops",
+		Name:    "devops.service",
+		Version: "v9.9.9",
+		Spec:    map[string]any{},
+	}})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if result.Valid {
+		t.Fatalf("expected invalid result")
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected one validation error, got %+v", result.Errors)
+	}
+	if result.Errors[0].Field != "elements[0].version" {
+		t.Fatalf("expected unsupported envelope version on version field, got %+v", result.Errors[0])
+	}
+}
+
 func TestImportFileBuildsIndexAndRebuildsFromSnapshot(t *testing.T) {
 	ctx := context.Background()
 	store := graphstore.NewMemoryStore()

--- a/internal/umodel/schemaspec/registry.go
+++ b/internal/umodel/schemaspec/registry.go
@@ -12,7 +12,8 @@ import (
 )
 
 type Registry struct {
-	schemas map[string]*Schema
+	schemas                  map[string]*Schema
+	acceptedEnvelopeVersions map[string]struct{}
 }
 
 func NewRegistry(efs embed.FS, dir string) (*Registry, error) {
@@ -20,7 +21,7 @@ func NewRegistry(efs embed.FS, dir string) (*Registry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read embedded dir %q: %w", dir, err)
 	}
-	reg := &Registry{schemas: make(map[string]*Schema)}
+	reg := newEmptyRegistry()
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -37,10 +38,8 @@ func NewRegistry(efs embed.FS, dir string) (*Registry, error) {
 		if s == nil {
 			continue
 		}
-		if existing, ok := reg.schemas[s.Name]; ok {
+		if _, ok := reg.schemas[s.Name]; ok {
 			return nil, fmt.Errorf("duplicate schema name %q (in %s and earlier source)", s.Name, path)
-		} else {
-			_ = existing
 		}
 		reg.schemas[s.Name] = s
 	}
@@ -52,7 +51,7 @@ func newRegistryFromFS(efs fs.ReadDirFS, dir string) (*Registry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read dir %q: %w", dir, err)
 	}
-	reg := &Registry{schemas: make(map[string]*Schema)}
+	reg := newEmptyRegistry()
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -72,11 +71,31 @@ func newRegistryFromFS(efs fs.ReadDirFS, dir string) (*Registry, error) {
 	return reg, nil
 }
 
+func newEmptyRegistry() *Registry {
+	return &Registry{
+		schemas: make(map[string]*Schema),
+		acceptedEnvelopeVersions: map[string]struct{}{
+			// schemas/manifest.yaml declares system schema v0.1.0 while mapping
+			// core model kinds to their v1.0.0 schemas. Existing examples use
+			// that manifest-level version in element envelopes.
+			"v0.1.0": {},
+		},
+	}
+}
+
 func (r *Registry) Lookup(kind string) *Schema {
 	if r == nil {
 		return nil
 	}
 	return r.schemas[kind]
+}
+
+func (r *Registry) AcceptsVersion(version string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.acceptedEnvelopeVersions[version]
+	return ok
 }
 
 func (r *Registry) Kinds() []string {

--- a/internal/umodel/schemaspec/registry.go
+++ b/internal/umodel/schemaspec/registry.go
@@ -41,7 +41,7 @@ func NewRegistry(efs embed.FS, dir string) (*Registry, error) {
 		if _, ok := reg.schemas[s.Name]; ok {
 			return nil, fmt.Errorf("duplicate schema name %q (in %s and earlier source)", s.Name, path)
 		}
-		reg.schemas[s.Name] = s
+		reg.registerSchema(s)
 	}
 	return reg, nil
 }
@@ -65,7 +65,7 @@ func newRegistryFromFS(efs fs.ReadDirFS, dir string) (*Registry, error) {
 			return nil, fmt.Errorf("parse %s: %w", entry.Name(), err)
 		}
 		if s != nil {
-			reg.schemas[s.Name] = s
+			reg.registerSchema(s)
 		}
 	}
 	return reg, nil
@@ -75,12 +75,19 @@ func newEmptyRegistry() *Registry {
 	return &Registry{
 		schemas: make(map[string]*Schema),
 		acceptedEnvelopeVersions: map[string]struct{}{
-			// schemas/manifest.yaml declares system schema v0.1.0 while mapping
-			// core model kinds to their v1.0.0 schemas. Existing examples use
-			// that manifest-level version in element envelopes.
+			// v0.1.0 is the manifest-level envelope version. Kind schema
+			// versions are added as schemas load.
 			"v0.1.0": {},
 		},
 	}
+}
+
+func (r *Registry) registerSchema(s *Schema) {
+	r.schemas[s.Name] = s
+	if s.Version == "" {
+		return
+	}
+	r.acceptedEnvelopeVersions[s.Version] = struct{}{}
 }
 
 func (r *Registry) Lookup(kind string) *Schema {

--- a/internal/umodel/schemaspec/registry_test.go
+++ b/internal/umodel/schemaspec/registry_test.go
@@ -32,6 +32,16 @@ func TestRegistryLookupReturnsNilForUnknownKind(t *testing.T) {
 	}
 }
 
+func TestRegistryAcceptsManifestEnvelopeVersion(t *testing.T) {
+	reg := Default()
+	if !reg.AcceptsVersion("v0.1.0") {
+		t.Fatal("manifest envelope version v0.1.0 should be accepted")
+	}
+	if reg.AcceptsVersion("v9.9.9") {
+		t.Fatal("unknown envelope version should not be accepted")
+	}
+}
+
 func TestEntitySetLinkSchemaCarriesRequiredEntityLinkType(t *testing.T) {
 	s := Default().Lookup("entity_set_link")
 	if s == nil {

--- a/internal/umodel/schemaspec/registry_test.go
+++ b/internal/umodel/schemaspec/registry_test.go
@@ -32,10 +32,13 @@ func TestRegistryLookupReturnsNilForUnknownKind(t *testing.T) {
 	}
 }
 
-func TestRegistryAcceptsManifestEnvelopeVersion(t *testing.T) {
+func TestRegistryAcceptsManifestAndLoadedSchemaVersions(t *testing.T) {
 	reg := Default()
 	if !reg.AcceptsVersion("v0.1.0") {
 		t.Fatal("manifest envelope version v0.1.0 should be accepted")
+	}
+	if !reg.AcceptsVersion("v1.0.0") {
+		t.Fatal("loaded schema version v1.0.0 should be accepted")
 	}
 	if reg.AcceptsVersion("v9.9.9") {
 		t.Fatal("unknown envelope version should not be accepted")

--- a/internal/umodel/schemaspec/validator.go
+++ b/internal/umodel/schemaspec/validator.go
@@ -29,7 +29,6 @@ func NewNoopValidator() *Validator {
 // element.Kind. The returned error is non-nil only when the kind itself is
 // unknown to the registry; field-level problems are reported in Result.
 //
-// TODO(v2): respect element.Version; today we always use versions[0].
 // TODO(v2): also validate the kind/schema/metadata envelope (currently
 // elementFromPayload validates the minimum imperatively before the element
 // reaches this layer).
@@ -40,6 +39,12 @@ func (v *Validator) Validate(element model.UModelElement) (Result, error) {
 	s := v.registry.Lookup(element.Kind)
 	if s == nil {
 		return Result{}, fmt.Errorf("unknown kind %q", element.Kind)
+	}
+	if element.Version != "" && !v.registry.AcceptsVersion(element.Version) {
+		return Result{Errors: []Issue{{
+			Path:   "version",
+			Reason: fmt.Sprintf("unsupported model envelope version %q", element.Version),
+		}}}, nil
 	}
 	var res Result
 	walk(element.Spec, s.Spec, "spec", &res)

--- a/internal/umodel/schemaspec/validator_test.go
+++ b/internal/umodel/schemaspec/validator_test.go
@@ -19,6 +19,36 @@ func TestValidateReturnsErrorForUnknownKind(t *testing.T) {
 	}
 }
 
+func TestValidateReportsUnsupportedEnvelopeVersionIssue(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	res, err := v.Validate(model.UModelElement{Kind: "entity_set", Domain: "d", Name: "n", Version: "v9.9.9"})
+	if err != nil {
+		t.Fatalf("unknown version should be reported as a validation issue, got error: %v", err)
+	}
+	if !hasErrorAt(res, "version", "unsupported model envelope version") {
+		t.Fatalf("expected unsupported envelope version issue on version, got %+v", res.Errors)
+	}
+}
+
+func TestValidateAcceptsCompatibleManifestVersion(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	res, err := v.Validate(model.UModelElement{
+		Kind:    "entity_set",
+		Domain:  "demo",
+		Name:    "demo.service",
+		Version: "v0.1.0",
+		Spec: map[string]any{
+			"fields": []any{map[string]any{"name": "service_id", "type": "string"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validate compatible manifest version: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("compatible manifest version should validate against default kind schema, got %+v", res.Errors)
+	}
+}
+
 func TestNoopValidatorAcceptsEverything(t *testing.T) {
 	v := schemaspec.NewNoopValidator()
 	res, err := v.Validate(model.UModelElement{Kind: "anything_goes", Spec: map[string]any{"garbage": true}})

--- a/internal/umodel/schemaspec/validator_test.go
+++ b/internal/umodel/schemaspec/validator_test.go
@@ -49,6 +49,23 @@ func TestValidateAcceptsCompatibleManifestVersion(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsLoadedSchemaVersion(t *testing.T) {
+	v := schemaspec.DefaultValidator()
+	res, err := v.Validate(model.UModelElement{
+		Kind:    "metric_set",
+		Domain:  "demo",
+		Name:    "demo.metrics",
+		Version: "v1.0.0",
+		Spec:    map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("validate loaded schema version: %v", err)
+	}
+	if hasErrorAt(res, "version", "unsupported model envelope version") {
+		t.Fatalf("loaded schema version should not report unsupported version, got %+v", res.Errors)
+	}
+}
+
 func TestNoopValidatorAcceptsEverything(t *testing.T) {
 	v := schemaspec.NewNoopValidator()
 	res, err := v.Validate(model.UModelElement{Kind: "anything_goes", Spec: map[string]any{"garbage": true}})


### PR DESCRIPTION
## Summary

The validator now rejects unsupported model envelope versions before validating the element spec.

This keeps schema lookup keyed by model kind. Existing `v0.1.0` model envelopes still validate against the registered kind schema, while an unknown non-empty envelope version is reported on `version` instead of being silently accepted.

## Changes

- Keep registry lookup keyed by model kind.
- Add an accepted model envelope version check, currently `v0.1.0`.
- Report unsupported envelope versions on the `version` field.
- Add tests for accepted and unsupported envelope versions.

## Tests

```bash
go test ./internal/umodel/schemaspec
go test ./internal/umodel -run "TestValidate(RejectsInvalidUModelElement|AcceptsValidUModelElements|ReportsUnsupportedEnvelopeVersionOnVersionField)$"
git diff --check