### PR TITLE
fix(umodel): surface authoring warnings during validation

### DIFF
--- a/internal/umodel/import_test.go
+++ b/internal/umodel/import_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/UnifiedModel/internal/graphstore"
@@ -35,6 +36,72 @@ func TestValidateAcceptsValidUModelElements(t *testing.T) {
 	}
 	if !result.Valid || len(result.Errors) != 0 {
 		t.Fatalf("expected valid result, got %+v", result)
+	}
+}
+
+func TestValidateReportsAuthoringWarnings(t *testing.T) {
+	svc := NewService(graphstore.NewMemoryStore(), WithImportRoot("/"))
+	result, err := svc.Validate(context.Background(), "demo", []model.UModelElement{
+		{
+			Kind:   "entity_set",
+			Domain: "devops",
+			Name:   "devops.service",
+			Spec:   map[string]any{},
+		},
+		{
+			Kind:   "metric_set",
+			Domain: "devops",
+			Name:   "devops.metric.service",
+			Spec: map[string]any{"metrics": []any{
+				map[string]any{"name": "request_count", "type": "counter", "generator": "sum(rate(http_requests_total[1m]))"},
+				map[string]any{"name": "latency_p99", "type": "gauge", "data_format": "ms", "generator": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[1m]))"},
+			}},
+		},
+		{
+			Kind:   "entity_set_link",
+			Domain: "devops",
+			Name:   "devops.service_candidate_related_to_devops.deployment",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service"},
+				"dest":             map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.deployment"},
+				"entity_link_type": "candidate_related_to",
+			},
+		},
+		{
+			Kind:   "entity_set_link",
+			Domain: "devops",
+			Name:   "devops.service_related_to_devops.deployment",
+			Spec: map[string]any{
+				"src":              map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.service"},
+				"dest":             map[string]any{"domain": "devops", "kind": "entity_set", "name": "devops.deployment"},
+				"entity_link_type": "related_to",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !result.Valid || len(result.Errors) != 0 {
+		t.Fatalf("authoring warnings must not reject valid elements, got %+v", result)
+	}
+
+	want := map[string][]string{
+		"elements[0].spec.fields":           {"entity_set", "may limit"},
+		"elements[1].spec.metrics[0].unit":  {"metric", "unit", "data_format"},
+		"elements[2].spec.entity_link_type": {"provisional", "explicit"},
+	}
+	for field, parts := range want {
+		if !hasWarningContaining(result.Warnings, field, parts...) {
+			t.Fatalf("expected warning %s containing %v, got %+v", field, parts, result.Warnings)
+		}
+	}
+	for _, field := range []string{
+		"elements[1].spec.metrics[1].unit",
+		"elements[3].spec.entity_link_type",
+	} {
+		if hasWarningField(result.Warnings, field) {
+			t.Fatalf("unexpected warning for %s: %+v", field, result.Warnings)
+		}
 	}
 }
 
@@ -231,4 +298,28 @@ func writeFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func hasWarningContaining(warnings []model.ErrorDetail, field string, parts ...string) bool {
+	for _, warning := range warnings {
+		if warning.Field != field {
+			continue
+		}
+		for _, part := range parts {
+			if !strings.Contains(warning.Reason, part) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func hasWarningField(warnings []model.ErrorDetail, field string) bool {
+	for _, warning := range warnings {
+		if warning.Field == field {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/umodel/service.go
+++ b/internal/umodel/service.go
@@ -106,6 +106,7 @@ func (s *Service) Validate(ctx context.Context, workspace string, elements []mod
 			})
 			continue
 		}
+		hasSchemaErrors := len(res.Errors) > 0
 		for _, e := range res.Errors {
 			errors = append(errors, model.ErrorDetail{
 				Field:  fmt.Sprintf("elements[%d].%s", i, e.Path),
@@ -118,12 +119,62 @@ func (s *Service) Validate(ctx context.Context, workspace string, elements []mod
 				Reason: w.Reason,
 			})
 		}
+		if !hasSchemaErrors {
+			warnings = appendAuthoringWarnings(warnings, i, element)
+		}
 	}
 	return model.ValidationResult{
 		Valid:    len(errors) == 0,
 		Errors:   errors,
 		Warnings: warnings,
 	}, nil
+}
+
+func appendAuthoringWarnings(warnings []model.ErrorDetail, index int, element model.UModelElement) []model.ErrorDetail {
+	switch element.Kind {
+	case "entity_set":
+		fields, ok := element.Spec["fields"].([]any)
+		if !ok || len(fields) == 0 {
+			warnings = append(warnings, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].spec.fields", index),
+				Reason: "entity_set has no fields; this may limit schema guidance for entity writes and filters",
+			})
+		}
+	case "metric_set":
+		metrics, ok := element.Spec["metrics"].([]any)
+		if !ok {
+			return warnings
+		}
+		for i, metric := range metrics {
+			spec, ok := metric.(map[string]any)
+			if !ok {
+				continue
+			}
+			unit, ok := spec["unit"].(string)
+			dataFormat, hasDataFormat := spec["data_format"].(string)
+			if (!ok || strings.TrimSpace(unit) == "") && (!hasDataFormat || strings.TrimSpace(dataFormat) == "") {
+				warnings = append(warnings, model.ErrorDetail{
+					Field:  fmt.Sprintf("elements[%d].spec.metrics[%d].unit", index, i),
+					Reason: "metric has no unit or data_format; define display formatting so query results are interpretable",
+				})
+			}
+		}
+	case "entity_set_link":
+		linkType, ok := element.Spec["entity_link_type"].(string)
+		if ok && weakEntityLinkType(linkType) {
+			warnings = append(warnings, model.ErrorDetail{
+				Field:  fmt.Sprintf("elements[%d].spec.entity_link_type", index),
+				Reason: "entity_link_type is weak or provisional; use explicit topology semantics for hard entity links",
+			})
+		}
+	}
+	return warnings
+}
+
+func weakEntityLinkType(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return strings.HasPrefix(normalized, "candidate_") ||
+		strings.HasPrefix(normalized, "maybe_")
 }
 
 func (s *Service) PutElements(ctx context.Context, batch model.UModelElementBatch) (model.WriteResult, error) {


### PR DESCRIPTION
## Summary

`Service.Validate` now surfaces warning-only authoring hints for UModel elements that are schema-valid but may be less useful for downstream writes, filters, query display, or topology traversal.

The hints are intentionally narrow:

- `entity_set` without `spec.fields` gets a schema-guidance warning.
- `metric_set` metrics without both `unit` and `data_format` get a display-formatting warning.
- `entity_set_link` types prefixed with `candidate_` or `maybe_` get a provisional-link warning.

These warnings reuse the existing `ValidationResult.Warnings` field and do not reject model elements.

## What stays unchanged

- Valid model elements remain valid.
- No REST, CLI, MCP schema, SDK, model schema, import, or graphstore behavior changes.
- Existing schema validation errors still come from the schema validator.
- Normal relation types such as `related_to` are not warned.
- Metrics with `data_format` but no `unit` are not warned.

## Verification details

- **Affected version:** `main`; no released tag was used for this reproduction.
- **Steps to reproduce before this change:** Call `Service.Validate` with a schema-valid `entity_set` that has no `spec.fields`, a `metric_set` metric that has neither `unit` nor `data_format`, or an `entity_set_link` whose type starts with `candidate_` or `maybe_`.
- **Expected behavior:** Validation remains successful and `ValidationResult.Warnings` identifies the relevant authoring field and explains why the missing or provisional metadata may reduce downstream usefulness.
- **Actual behavior before this change:** Validation succeeds, but no authoring warning is returned for those cases, so callers cannot distinguish a minimally schema-valid element from one that lacks useful authoring guidance.
- **Logs/stack trace:** No runtime error or stack trace occurs; this is a missing warning in a successful validation result. `TestValidateReportsAuthoringWarnings` reproduces the previous behavior and verifies the warning fields and non-blocking semantics added here.

## Test plan

```bash
go test ./internal/umodel -run TestValidate -count=1
go test ./internal/agentgateway -count=1
git diff --check
```
