### PR TITLE
fix(web): raise UModel Explorer limit to 2000

### DIFF
--- a/docs/en/ui-api.md
+++ b/docs/en/ui-api.md
@@ -12,7 +12,7 @@ The web UI maps each screen to the public REST contract below.
 | Workspace shell | Load selected workspace | `GET /api/v1/workspaces/{workspace}` | none |
 | Settings | Update workspace | `PUT /api/v1/workspaces/{workspace}` | `UpdateWorkspaceRequest` |
 | Settings | Delete workspace | `DELETE /api/v1/workspaces/{workspace}` | none |
-| Explorer | Load model graph/table | `POST /api/v1/query/{workspace}/execute` | `{"query": ".umodel | sort id | limit 100", "limit": 100}` |
+| Explorer | Load model graph/table | `POST /api/v1/query/{workspace}/execute` | `{"query": ".umodel | sort name | limit 2000"}` |
 | Explorer detail | Validate element JSON | `POST /api/v1/umodel/{workspace}/validate` | `{"elements": [UModelElement]}` |
 | Explorer detail | Save element JSON | `POST /api/v1/umodel/{workspace}/elements` | `{"elements": [UModelElement]}` |
 | Explorer detail | Delete element | `DELETE /api/v1/umodel/{workspace}/elements` | `{"ids": ["element-id"]}` |

--- a/docs/zh/ui-api.md
+++ b/docs/zh/ui-api.md
@@ -12,7 +12,7 @@ Web UI 的每个界面只对应公开 REST 契约。
 | Workspace 工作台 | 加载当前 Workspace | `GET /api/v1/workspaces/{workspace}` | 无 |
 | Settings | 更新 Workspace | `PUT /api/v1/workspaces/{workspace}` | `UpdateWorkspaceRequest` |
 | Settings | 删除 Workspace | `DELETE /api/v1/workspaces/{workspace}` | 无 |
-| Explorer | 加载模型图/表 | `POST /api/v1/query/{workspace}/execute` | `{"query": ".umodel | sort id | limit 100", "limit": 100}` |
+| Explorer | 加载模型图/表 | `POST /api/v1/query/{workspace}/execute` | `{"query": ".umodel | sort name | limit 2000"}` |
 | Explorer 详情 | 校验元素 JSON | `POST /api/v1/umodel/{workspace}/validate` | `{"elements": [UModelElement]}` |
 | Explorer 详情 | 保存元素 JSON | `POST /api/v1/umodel/{workspace}/elements` | `{"elements": [UModelElement]}` |
 | Explorer 详情 | 删除元素 | `DELETE /api/v1/umodel/{workspace}/elements` | `{"ids": ["element-id"]}` |

--- a/web/e2e/umodel-explorer.spec.ts
+++ b/web/e2e/umodel-explorer.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+test('UModel Explorer requests up to 2000 model elements without exceeding the request limit contract', async ({ page }) => {
+  const queryRequests: Array<{ query?: string; limit?: number }> = []
+
+  await page.route('**/healthz', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'ok',
+        graphstore: { provider: 'memory', status: 'ok' },
+      }),
+    })
+  })
+  await page.route('**/api/v1/workspaces/demo', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'demo',
+        name: 'Demo',
+        paths: { root: '/tmp/demo' },
+        status: 'active',
+        resource_version: 1,
+        created_at: '2026-08-10T00:00:00Z',
+        updated_at: '2026-08-10T00:00:00Z',
+      }),
+    })
+  })
+  await page.route('**/api/v1/query/demo/execute', async (route) => {
+    queryRequests.push(route.request().postDataJSON() as { query?: string; limit?: number })
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        columns: [],
+        rows: [],
+        page: { limit: queryRequests.at(-1)?.limit },
+      }),
+    })
+  })
+
+  await page.goto('/workspaces/demo/umodel')
+
+  await expect.poll(() => queryRequests.length).toBeGreaterThan(0)
+  expect(queryRequests[0]).toEqual({
+    query: '.umodel | sort name | limit 2000',
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -101,7 +101,7 @@ export class UModelApi {
   }
 
   listUModel(workspace: string, limit = 1000): Promise<QueryResult> {
-    return this.query(workspace, { query: `.umodel | sort name | limit ${limit}`, limit })
+    return this.query(workspace, { query: `.umodel | sort name | limit ${limit}` })
   }
 
   importUModel(workspace: string, payload: UModelImportRequest): Promise<UModelImportResult> {

--- a/web/src/features/umodel/UModelPage.tsx
+++ b/web/src/features/umodel/UModelPage.tsx
@@ -160,7 +160,7 @@ export function UModelPage({
     setLoading(true)
     setError('')
     try {
-      const result = await api.listUModel(workspaceId, 100)
+      const result = await api.listUModel(workspaceId, 2000)
       const elements = result.rows.map(rowToElement).filter((element) => elementKey(element))
       setQueryResult(result)
       setServerElements(elements)


### PR DESCRIPTION
## Summary

Raise the UModel Explorer query ceiling from 100 to 2000 elements so the graph, table, and sidebar statistics are no longer truncated for workspaces such as the reported 183-element model.

## Motivation

The Explorer explicitly requested only 100 `.umodel` rows. Its type counts therefore represented the first 100 sorted elements rather than the complete workspace model, making 10 `RunbookSet` definitions appear as 4 in the UI.

## Changes

- Web: request `.umodel | sort name | limit 2000` from UModel Explorer.
- Web API client: rely on the SPL limit instead of sending a request-body `limit` above the OpenAPI maximum of 1000.
- Tests: add a Playwright regression test that captures the real Explorer request payload.
- Docs: align the English and Chinese Web UI API maps with the new request.

## Test plan

- [ ] `make build`
- [ ] `make test-service`
- [x] `make guard`
- [ ] `make ci`
- [x] If user-facing: ran an end-to-end probe (all 18 Playwright tests passed; local Explorer graph/table rendered with no browser console warnings or errors)
- [x] `npx pnpm@9.15.9 --dir web run build`
- [x] `git diff --check`

## Compatibility

No REST, SPL, MCP, or SDK schema changes. The Explorer keeps the 2000-row bound in the SPL query and omits the redundant request-body `limit`, preserving the existing OpenAPI maximum of 1000 for that optional field.

## Out of scope

- Server-side pagination or loading workspaces with more than 2000 UModel elements.
- Changes to Apply/Upsert partial-success reporting.
